### PR TITLE
CA-14/Fix crash in EventHolderFragment due to task leak

### DIFF
--- a/app/src/main/java/com/connfa/ui/fragment/EventHolderFragment.java
+++ b/app/src/main/java/com/connfa/ui/fragment/EventHolderFragment.java
@@ -100,25 +100,6 @@ public class EventHolderFragment extends Fragment {
         return true;
     }
 
-//    @Override
-//    public void onActivityCreated(Bundle savedInstanceState) {
-//        super.onActivityCreated(savedInstanceState);
-//        Model.createInstance().getUpdatesManager().registerUpdateListener(updateReceiver);
-//        favoriteReceiver.register(getActivity());
-//
-//        initData();
-//        initView();
-//        new LoadData().execute();
-//    }
-//
-//
-//    @Override
-//    public void onDestroy() {
-//        super.onDestroy();
-//        Model.createInstance().getUpdatesManager().unregisterUpdateListener(updateReceiver);
-//        favoriteReceiver.unregister(getActivity());
-//    }
-
     @Override
     public void onViewCreated(View view, Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
@@ -177,72 +158,6 @@ public class EventHolderFragment extends Fragment {
             setHasOptionsMenu(true);
         } else {
             setHasOptionsMenu(false);
-        }
-    }
-
-    private void updateViews(List<Long> dayList) {
-
-//        if(!isResumed()){
-//            return;
-//        }
-
-        if (dayList.isEmpty()) {
-            tabStrip.setVisibility(View.GONE);
-            layoutPlaceholder.setVisibility(View.VISIBLE);
-
-            if (isFilterUsed) {
-                emptyImageView.setVisibility(View.GONE);
-                emptyLabel.setText(getString(R.string.placeholder_no_matching_events));
-            } else {
-                emptyImageView.setVisibility(View.VISIBLE);
-
-                int imageResId = 0, textResId = 0;
-
-                switch (eventMode) {
-                    case PROGRAM:
-                        imageResId = R.drawable.ic_no_session;
-                        textResId = R.string.placeholder_sessions;
-                        break;
-                    case BOFS:
-                        imageResId = R.drawable.ic_no_bofs;
-                        textResId = R.string.placeholder_bofs;
-                        break;
-                    case SOCIAL:
-                        imageResId = R.drawable.ic_no_social_events;
-                        textResId = R.string.placeholder_social_events;
-                        break;
-                    case FAVORITES:
-                        imageResId = R.drawable.ic_no_my_schedule;
-                        textResId = R.string.placeholder_schedule;
-                        break;
-                }
-
-                emptyImageView.setImageResource(imageResId);
-                emptyLabel.setText(getString(textResId));
-            }
-        } else {
-            layoutPlaceholder.setVisibility(View.GONE);
-            tabStrip.setVisibility(View.VISIBLE);
-        }
-
-        adapter.setData(dayList, eventMode);
-        switchToCurrentDay(dayList);
-    }
-
-    private void switchToCurrentDay(List<Long> days) {
-        FragmentActivity activity = getActivity();
-        if (activity == null) {
-            Timber.e("Trying to switch day while not attached to an activity");
-            return;
-        }
-
-        int item = 0;
-        for (Long millis : days) {
-            if (DateUtils.isToday(activity, millis) || DateUtils.isAfterCurrentDate(millis)) {
-                viewPager.setCurrentItem(item);
-                return;
-            }
-            item++;
         }
     }
 
@@ -308,8 +223,71 @@ public class EventHolderFragment extends Fragment {
     private final LoadDataTask.LoadDataTaskCallback loadDataCallback = new LoadDataTask.LoadDataTaskCallback() {
         @Override
         public void onDataLoaded(List<Long> result) {
-            updateViews(result);
+            if (isResumed()) {
+                updateViews(result);
+            }
         }
     };
+
+    private void updateViews(List<Long> dayList) {
+        if (dayList.isEmpty()) {
+            tabStrip.setVisibility(View.GONE);
+            layoutPlaceholder.setVisibility(View.VISIBLE);
+
+            if (isFilterUsed) {
+                emptyImageView.setVisibility(View.GONE);
+                emptyLabel.setText(getString(R.string.placeholder_no_matching_events));
+            } else {
+                emptyImageView.setVisibility(View.VISIBLE);
+
+                int imageResId = 0, textResId = 0;
+
+                switch (eventMode) {
+                    case PROGRAM:
+                        imageResId = R.drawable.ic_no_session;
+                        textResId = R.string.placeholder_sessions;
+                        break;
+                    case BOFS:
+                        imageResId = R.drawable.ic_no_bofs;
+                        textResId = R.string.placeholder_bofs;
+                        break;
+                    case SOCIAL:
+                        imageResId = R.drawable.ic_no_social_events;
+                        textResId = R.string.placeholder_social_events;
+                        break;
+                    case FAVORITES:
+                        imageResId = R.drawable.ic_no_my_schedule;
+                        textResId = R.string.placeholder_schedule;
+                        break;
+                }
+
+                emptyImageView.setImageResource(imageResId);
+                emptyLabel.setText(getString(textResId));
+            }
+        } else {
+            layoutPlaceholder.setVisibility(View.GONE);
+            tabStrip.setVisibility(View.VISIBLE);
+        }
+
+        adapter.setData(dayList, eventMode);
+        switchToCurrentDay(dayList);
+    }
+
+    private void switchToCurrentDay(List<Long> days) {
+        FragmentActivity activity = getActivity();
+        if (activity == null) {
+            Timber.e("Trying to switch day while not attached to an activity");
+            return;
+        }
+
+        int item = 0;
+        for (Long millis : days) {
+            if (DateUtils.isToday(activity, millis) || DateUtils.isAfterCurrentDate(millis)) {
+                viewPager.setCurrentItem(item);
+                return;
+            }
+            item++;
+        }
+    }
 
 }

--- a/app/src/main/java/com/connfa/ui/fragment/LoadDataTask.java
+++ b/app/src/main/java/com/connfa/ui/fragment/LoadDataTask.java
@@ -10,18 +10,17 @@ import com.connfa.model.managers.ProgramManager;
 import com.connfa.model.managers.SocialManager;
 import com.connfa.ui.drawer.DrawerManager;
 
-import java.lang.ref.WeakReference;
 import java.util.ArrayList;
 import java.util.List;
 
 class LoadDataTask extends AsyncTask<Void, Void, List<Long>> {
 
     private final DrawerManager.EventMode eventMode;
-    private final WeakReference<LoadDataTaskCallback> callbackRef;
+    private final LoadDataTaskCallback callback;
 
     LoadDataTask(DrawerManager.EventMode eventMode, LoadDataTaskCallback callback) {
         this.eventMode = eventMode;
-        this.callbackRef = new WeakReference<>(callback);
+        this.callback = callback;
     }
 
     @Override
@@ -60,7 +59,6 @@ class LoadDataTask extends AsyncTask<Void, Void, List<Long>> {
 
     @Override
     protected void onPostExecute(@Nullable List<Long> result) {
-        LoadDataTaskCallback callback = callbackRef.get();
         if (result != null && callback != null) {
             callback.onDataLoaded(result);
         }

--- a/app/src/main/java/com/connfa/ui/fragment/LoadDataTask.java
+++ b/app/src/main/java/com/connfa/ui/fragment/LoadDataTask.java
@@ -1,0 +1,73 @@
+package com.connfa.ui.fragment;
+
+import android.os.AsyncTask;
+import android.support.annotation.Nullable;
+
+import com.connfa.model.Model;
+import com.connfa.model.managers.BofsManager;
+import com.connfa.model.managers.FavoriteManager;
+import com.connfa.model.managers.ProgramManager;
+import com.connfa.model.managers.SocialManager;
+import com.connfa.ui.drawer.DrawerManager;
+
+import java.lang.ref.WeakReference;
+import java.util.ArrayList;
+import java.util.List;
+
+class LoadDataTask extends AsyncTask<Void, Void, List<Long>> {
+
+    private final DrawerManager.EventMode eventMode;
+    private final WeakReference<LoadDataTaskCallback> callbackRef;
+
+    LoadDataTask(DrawerManager.EventMode eventMode, LoadDataTaskCallback callback) {
+        this.eventMode = eventMode;
+        this.callbackRef = new WeakReference<>(callback);
+    }
+
+    @Override
+    @Nullable
+    protected List<Long> doInBackground(Void... params) {
+        if (isCancelled()) {
+            return null;
+        }
+
+        List<Long> dayList = new ArrayList<>();
+        switch (eventMode) {
+            case BOFS:
+                BofsManager bofsManager = Model.getInstance().getBofsManager();
+                dayList.addAll(bofsManager.getBofsDays());
+                break;
+            case SOCIAL:
+                SocialManager socialManager = Model.getInstance().getSocialManager();
+                dayList.addAll(socialManager.getSocialsDays());
+                break;
+            case FAVORITES:
+                FavoriteManager favoriteManager = Model.getInstance().getFavoriteManager();
+                dayList.addAll(favoriteManager.getFavoriteEventDays());
+                break;
+            default:
+                ProgramManager programManager = Model.getInstance().getProgramManager();
+                dayList.addAll(programManager.getProgramDays());
+                break;
+        }
+
+        if (isCancelled()) {
+            return null;
+        }
+
+        return dayList;
+    }
+
+    @Override
+    protected void onPostExecute(@Nullable List<Long> result) {
+        LoadDataTaskCallback callback = callbackRef.get();
+        if (result != null && callback != null) {
+            callback.onDataLoaded(result);
+        }
+    }
+
+    interface LoadDataTaskCallback {
+
+        void onDataLoaded(List<Long> result);
+    }
+}

--- a/app/src/main/java/com/connfa/utils/DateUtils.java
+++ b/app/src/main/java/com/connfa/utils/DateUtils.java
@@ -55,7 +55,7 @@ public class DateUtils {
         return (todayYear == year && todayMonth == month && todayDay == day);
     }
 
-    public static boolean isAfterCurrentFate(long millis) {
+    public static boolean isAfterCurrentDate(long millis) {
         return millis > System.currentTimeMillis();
     }
 


### PR DESCRIPTION
This fixes one of the issues reported by Lemberg's QA in lemberg/connfa-android#14, "Android. Events. App crashes if restore it from background".

This is caused because the app still uses `AsyncTasks` and fire-and-forgets them. If the activity is killed (see the "kill background activity" option in the repro steps), the fragment is still held in memory by the AsyncTask. When the task completes, it ends up calling `getActivity()` which returns null, and then tries to use that as a context which causes the NPE and hence the bug.

This PR refactors the task extracting it, and makes sure there's always only one running. Added in some cleanup too.