### PR TITLE
Add place and speakers to notification text

### DIFF
--- a/app/src/main/java/com/connfa/receiver/NotifyReceiver.java
+++ b/app/src/main/java/com/connfa/receiver/NotifyReceiver.java
@@ -64,13 +64,12 @@ public class NotifyReceiver extends BroadcastReceiver {
     }
 
     private CharSequence createContentText(Context context, EventDetailsEvent event) {
-        return context.getString(R.string.start_in_5_minutes_in) + event.getPlace();
+        return context.getString(R.string.start_in_5_minutes_in_place, event.getPlace());
     }
 
     private CharSequence createBigText(Context context, EventDetailsEvent event, List<Speaker> speakerList) {
         String speakersNames = createSpeakersNames(speakerList);
-        return context.getString(R.string.start_in_5_minutes_in) + event.getPlace()
-                + "\n" + speakersNames;
+        return context.getString(R.string.start_in_5_minutes_in_place_speakers,  event.getPlace(), speakersNames);
     }
 
     private String createSpeakersNames(List<Speaker> speakerList) {

--- a/app/src/main/java/com/connfa/receiver/NotifyReceiver.java
+++ b/app/src/main/java/com/connfa/receiver/NotifyReceiver.java
@@ -77,16 +77,23 @@ public class NotifyReceiver extends BroadcastReceiver {
             return "";
         }
         StringBuilder sb = new StringBuilder("by ");
-        for (int i = 0; i < speakerList.size() - 1; i++) {
+        for (int i = 0; i < speakerList.size(); i++) {
             sb.append(createSpeakerFullName(speakerList.get(i)));
-            if (i < speakerList.size() - 2) {
+            if (isBeforeSecondToLast(speakerList, i)) {
                 sb.append(", ");
-            } else if (i == speakerList.size() - 2) {
+            } else if (isSecondToLast(speakerList, i)) {
                 sb.append(" and ");
             }
         }
-        sb.append(createSpeakerFullName(speakerList.get(speakerList.size() - 1)));
         return sb.toString();
+    }
+
+    private boolean isBeforeSecondToLast(List<Speaker> speakerList, int i) {
+        return i < speakerList.size() - 2;
+    }
+
+    private boolean isSecondToLast(List<Speaker> speakerList, int i) {
+        return i == speakerList.size() - 2;
     }
 
     private String createSpeakerFullName(Speaker speaker) {

--- a/app/src/main/java/com/connfa/receiver/NotifyReceiver.java
+++ b/app/src/main/java/com/connfa/receiver/NotifyReceiver.java
@@ -9,22 +9,39 @@ import android.content.Intent;
 import android.support.v4.app.NotificationCompat;
 
 import com.connfa.R;
+import com.connfa.model.Model;
+import com.connfa.model.data.EventDetailsEvent;
+import com.connfa.model.data.Speaker;
+import com.connfa.model.managers.EventManager;
+import com.connfa.model.managers.SpeakerManager;
 import com.connfa.ui.activity.EventDetailsActivity;
 import com.connfa.ui.activity.HomeActivity;
 import com.connfa.utils.AlarmTask;
 
+import java.util.List;
+
+import static android.R.attr.id;
+
 public class NotifyReceiver extends BroadcastReceiver {
 
     @Override
-    public void onReceive(Context context, Intent intent) {
-        long eventId = intent.getLongExtra(AlarmTask.EXTRA_ID, -1);
-        long day = intent.getLongExtra(AlarmTask.EXTRA_DAY, -1);
-        String text = intent.getStringExtra(AlarmTask.EXTRA_TEXT);
-        showNotification(context, eventId, day, text);
+    public void onReceive(final Context context, Intent intent) {
+         long eventId = intent.getLongExtra(AlarmTask.EXTRA_ID, -1);
+         long day = intent.getLongExtra(AlarmTask.EXTRA_DAY, -1);
+
+        SpeakerManager speakerManager = Model.getInstance().getSpeakerManager();
+        List<Speaker> speakerList = speakerManager.getSpeakersByEventId(eventId);
+
+        EventManager eventManager = Model.getInstance().getEventManager();
+        EventDetailsEvent event = eventManager.getEventById(eventId);
+        if (event != null) {
+            showNotification(context, event, speakerList, day);
+        }
+
     }
 
-    private void showNotification(Context context, long id, long day, String text) {
-        String title = context.getString(R.string.dont_miss_it);
+    private void showNotification(Context context, EventDetailsEvent event, List<Speaker> speakerList, long day) {
+        String title = event.getEventName();
         int icon = android.R.drawable.ic_dialog_info;
 
         Intent intent = new Intent(context, HomeActivity.class);
@@ -32,15 +49,48 @@ public class NotifyReceiver extends BroadcastReceiver {
         intent.putExtra(EventDetailsActivity.EXTRA_DAY, day);
         PendingIntent contentIntent = PendingIntent.getActivity(context, 0, intent, PendingIntent.FLAG_UPDATE_CURRENT);
 
-        NotificationCompat.Builder builder = new NotificationCompat.Builder(context);
-        builder.setSmallIcon(icon);
-        builder.setContentTitle(title);
-        builder.setContentText(text);
-        builder.setAutoCancel(true);
-        builder.setContentIntent(contentIntent);
-        builder.setDefaults(Notification.DEFAULT_ALL);
+        NotificationCompat.Builder builder = new NotificationCompat.Builder(context)
+                .setSmallIcon(icon)
+                .setContentTitle(title)
+                .setContentText(createContentText(context, event))
+                .setAutoCancel(true)
+                .setContentIntent(contentIntent)
+                .setStyle(new NotificationCompat.BigTextStyle()
+                                  .bigText(createBigText(context, event, speakerList)))
+                .setDefaults(Notification.DEFAULT_ALL);
 
         NotificationManager manager = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
         manager.notify(0, builder.build());
+    }
+
+    private CharSequence createContentText(Context context, EventDetailsEvent event) {
+        return context.getString(R.string.start_in_5_minutes_in) + event.getPlace();
+    }
+
+    private CharSequence createBigText(Context context, EventDetailsEvent event, List<Speaker> speakerList) {
+        String speakersNames = createSpeakersNames(speakerList);
+        return context.getString(R.string.start_in_5_minutes_in) + event.getPlace()
+                + "\n" + speakersNames;
+    }
+
+    private String createSpeakersNames(List<Speaker> speakerList) {
+        if (speakerList.isEmpty()) {
+            return "";
+        }
+        StringBuilder sb = new StringBuilder("by ");
+        for (int i = 0; i < speakerList.size() - 1; i++) {
+            sb.append(createSpeakerFullName(speakerList.get(i)));
+            if (i < speakerList.size() - 2) {
+                sb.append(", ");
+            } else if (i == speakerList.size() - 2) {
+                sb.append(" and ");
+            }
+        }
+        sb.append(createSpeakerFullName(speakerList.get(speakerList.size() - 1)));
+        return sb.toString();
+    }
+
+    private String createSpeakerFullName(Speaker speaker) {
+        return speaker.getFirstName() + " " + speaker.getLastName();
     }
 }

--- a/app/src/main/java/com/connfa/utils/AlarmTask.java
+++ b/app/src/main/java/com/connfa/utils/AlarmTask.java
@@ -5,7 +5,6 @@ import android.app.PendingIntent;
 import android.content.Context;
 import android.content.Intent;
 
-import com.connfa.R;
 import com.connfa.model.data.EventDetailsEvent;
 import com.connfa.receiver.NotifyReceiver;
 
@@ -13,7 +12,6 @@ public class AlarmTask implements Runnable {
 
     public static final String EXTRA_ID = "EXTRA_ID";
     public static final String EXTRA_DAY = "EXTRA_DAY";
-    public static final String EXTRA_TEXT = "EXTRA_TEXT";
     private static final int FIVE_MINUTES = 5 * 60 * 1000;
 
     private final AlarmManager am;
@@ -36,8 +34,6 @@ public class AlarmTask implements Runnable {
         intent.putExtra(EXTRA_ID, event.getEventId());
         intent.putExtra(EXTRA_DAY, day);
 
-        String notifyText = event.getEventName() + context.getString(R.string.start_in_5_minutes);
-        intent.putExtra(EXTRA_TEXT, notifyText);
         PendingIntent pendingIntent = PendingIntent.getBroadcast(context, (int) event.getEventId(), intent, PendingIntent.FLAG_UPDATE_CURRENT);
 
         am.set(AlarmManager.RTC_WAKEUP, startMillis - FIVE_MINUTES, pendingIntent);

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -44,7 +44,8 @@
   <string name="dont_miss_it">Don\'t miss it!</string>
   <string name="twenty_four_hours">24 HOURS</string>
   <string name="Attention">Attention</string>
-  <string name="start_in_5_minutes_in">"In 5 minutes, in "</string>
+  <string name="start_in_5_minutes_in_place">"In 5 minutes, in %s"</string>
+  <string name="start_in_5_minutes_in_place_speakers">"In 5 minutes, in %1$s\n%2$s"</string>
   <string name="to">to %s</string>
   <string name="speaker_separator">", "</string>
   <string name="css"><![CDATA[<link rel=\'stylesheet\' href=\'css/style.css\' type=\'text/css\'>]]></string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -44,7 +44,7 @@
   <string name="dont_miss_it">Don\'t miss it!</string>
   <string name="twenty_four_hours">24 HOURS</string>
   <string name="Attention">Attention</string>
-  <string name="start_in_5_minutes">" starts in 5 minutes"</string>
+  <string name="start_in_5_minutes_in">"In 5 minutes, in "</string>
   <string name="to">to %s</string>
   <string name="speaker_separator">", "</string>
   <string name="css"><![CDATA[<link rel=\'stylesheet\' href=\'css/style.css\' type=\'text/css\'>]]></string>


### PR DESCRIPTION
This PR increases the usefulness of about-to-start notifications, by adding the place and speakers to the notification text.

| Before | After |
| --- | --- |
| ![device-2017-01-11-095607](https://cloud.githubusercontent.com/assets/3942812/21841873/8a138146-d7e4-11e6-97f4-a91d7a0b7dbb.png) | ![device-2017-01-11-094939](https://cloud.githubusercontent.com/assets/3942812/21841877/8d4e7ad2-d7e4-11e6-9789-a101f3d283f2.png) |

**TODO in future PRs:**
- in case of conflicting events, only one notification is shown: we need to stack them to see some detail for every upcoming event
- change the notification icon
- Check how the notifications are displayed on Wear