### PR TITLE
CA-26/Populate schedule UI in ScheduleActivity

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -33,7 +33,7 @@
 
     <activity
       android:name="com.connfa.schedule.ScheduleActivity"
-      android:theme="@style/Theme.Connfa.Home"
+      android:theme="@style/Theme.Connfa.Schedule"
       android:label="@string/app_name">
 
       <intent-filter>

--- a/app/src/main/java/com/connfa/PageView.java
+++ b/app/src/main/java/com/connfa/PageView.java
@@ -1,0 +1,6 @@
+package com.connfa;
+
+public interface PageView<T> {
+
+    void updateWith(T data);
+}

--- a/app/src/main/java/com/connfa/PageView.java
+++ b/app/src/main/java/com/connfa/PageView.java
@@ -2,5 +2,5 @@ package com.connfa;
 
 public interface PageView<T> {
 
-    void updateWith(T data);
+    void updateWith(T newData);
 }

--- a/app/src/main/java/com/connfa/schedule/ScheduleActivity.java
+++ b/app/src/main/java/com/connfa/schedule/ScheduleActivity.java
@@ -1,6 +1,9 @@
 package com.connfa.schedule;
 
 import android.os.Bundle;
+import android.support.design.widget.TabLayout;
+import android.support.v4.view.ViewPager;
+import android.support.v7.widget.Toolbar;
 import android.view.LayoutInflater;
 import android.view.ViewGroup;
 
@@ -18,7 +21,17 @@ public class ScheduleActivity extends NavigationDrawerActivity {
 
     @Override
     protected void initializeActivity(Bundle savedInstanceState) {
-        // TODO
+        Toolbar toolbar = (Toolbar) findViewById(R.id.toolbar);
+        setupToolbar(toolbar);
+
+        ViewPager viewPager = (ViewPager) findViewById(R.id.viewpager);
+        TabLayout tabLayout = (TabLayout) findViewById(R.id.tabstrip);
+        tabLayout.setupWithViewPager(viewPager);
+    }
+
+    private void setupToolbar(Toolbar toolbar) {
+        setSupportActionBar(toolbar);
+        toolbar.setTitle(R.string.activity_schedule);
     }
 
     @Override

--- a/app/src/main/java/com/connfa/schedule/ScheduleActivity.java
+++ b/app/src/main/java/com/connfa/schedule/ScheduleActivity.java
@@ -10,8 +10,15 @@ import android.view.ViewGroup;
 import com.connfa.R;
 import com.connfa.navigation.NavigationDrawerActivity;
 import com.connfa.navigation.Navigator;
+import com.connfa.schedule.domain.SchedulePage;
+import com.connfa.schedule.view.ScheduleViewPagerAdapter;
+
+import java.util.Collections;
+import java.util.Date;
 
 public class ScheduleActivity extends NavigationDrawerActivity {
+
+    private ScheduleViewPagerAdapter viewPagerAdapter;
 
     @Override
     protected void inflateActivityContent(ViewGroup parent) {
@@ -27,11 +34,29 @@ public class ScheduleActivity extends NavigationDrawerActivity {
         ViewPager viewPager = (ViewPager) findViewById(R.id.viewpager);
         TabLayout tabLayout = (TabLayout) findViewById(R.id.tabstrip);
         tabLayout.setupWithViewPager(viewPager);
+
+        viewPagerAdapter = new ScheduleViewPagerAdapter(this);
+        viewPager.setAdapter(viewPagerAdapter);
     }
 
     private void setupToolbar(Toolbar toolbar) {
         setSupportActionBar(toolbar);
         toolbar.setTitle(R.string.activity_schedule);
+    }
+
+    @Override
+    protected void onStart() {
+        super.onStart();
+
+        // TODO start fetching data
+        viewPagerAdapter.updateWith(Collections.singletonList(new SchedulePage(new Date())));
+    }
+
+    @Override
+    protected void onStop() {
+        super.onStop();
+
+        // TODO stop data flow
     }
 
     @Override
@@ -44,4 +69,5 @@ public class ScheduleActivity extends NavigationDrawerActivity {
             }
         };
     }
+
 }

--- a/app/src/main/java/com/connfa/schedule/domain/SchedulePage.java
+++ b/app/src/main/java/com/connfa/schedule/domain/SchedulePage.java
@@ -1,0 +1,20 @@
+package com.connfa.schedule.domain;
+
+import android.content.Context;
+
+import com.connfa.utils.DateUtils;
+
+import java.util.Date;
+
+public class SchedulePage {
+
+    private final Date date;           // TODO use JodaTime
+
+    public SchedulePage(Date date) {
+        this.date = date;
+    }
+
+    public String formattedTitle(Context context) {
+        return DateUtils.getWeekNameAndDate(context, date.getTime());
+    }
+}

--- a/app/src/main/java/com/connfa/schedule/domain/SchedulePage.java
+++ b/app/src/main/java/com/connfa/schedule/domain/SchedulePage.java
@@ -2,9 +2,14 @@ package com.connfa.schedule.domain;
 
 import android.content.Context;
 
+import com.connfa.model.data.Event;
+import com.connfa.model.data.Level;
 import com.connfa.utils.DateUtils;
 
+import java.util.Collections;
 import java.util.Date;
+import java.util.List;
+import java.util.TimeZone;
 
 public class SchedulePage {
 
@@ -16,5 +21,19 @@ public class SchedulePage {
 
     public String formattedTitle(Context context) {
         return DateUtils.getWeekNameAndDate(context, date.getTime());
+    }
+
+    public List<Event> events() {
+        Event event = new Event(TimeZone.getDefault());
+        event.setId(123456);
+        event.setDate(new Date());
+        event.setName("Test event \uD83C\uDF4C");
+        event.setTrack(0);
+        event.setSpeakers(Collections.<Long>emptyList());
+        event.setFromTime("2017-01-31T08:00:00Z");
+        event.setToTime("2017-01-31T08:00:00Z");
+        event.setType(0);
+        event.setExperienceLevel(Level.INTERMEDIATE);
+        return Collections.singletonList(event);
     }
 }

--- a/app/src/main/java/com/connfa/schedule/view/EventItemView.java
+++ b/app/src/main/java/com/connfa/schedule/view/EventItemView.java
@@ -1,0 +1,64 @@
+package com.connfa.schedule.view;
+
+import android.content.Context;
+import android.text.TextUtils;
+import android.util.AttributeSet;
+import android.view.View;
+import android.widget.FrameLayout;
+import android.widget.ImageView;
+import android.widget.TextView;
+
+import com.connfa.R;
+import com.connfa.model.data.Event;
+import com.connfa.model.data.Level;
+
+public class EventItemView extends FrameLayout {
+
+    private TextView titleView;
+    private TextView placeView;
+    private View placeContainer;
+    private View trackView;
+    private TextView speakersView;
+    private View speakersContainer;
+    private ImageView experienceIconView;
+
+    public EventItemView(Context context, AttributeSet attrs) {
+        super(context, attrs);
+    }
+
+    public EventItemView(Context context, AttributeSet attrs, int defStyleAttr) {
+        super(context, attrs, defStyleAttr);
+    }
+
+    @Override
+    protected void onFinishInflate() {
+        super.onFinishInflate();
+
+        titleView = (TextView) findViewById(R.id.txtTitle);
+        placeView = (TextView) findViewById(R.id.txtPlace);
+        placeContainer = findViewById(R.id.layout_place);
+        trackView = findViewById(R.id.txtTrack);
+        speakersView = (TextView) findViewById(R.id.txtSpeakers);
+        speakersContainer = findViewById(R.id.layout_speakers);
+        experienceIconView = (ImageView) findViewById(R.id.imgExperience);
+    }
+
+    public void updateWith(Event event) {
+        titleView.setText(event.getName());
+
+        if (TextUtils.isEmpty(event.getPlace())) {
+            placeContainer.setVisibility(View.GONE);
+        } else {
+            placeView.setText(event.getPlace());
+            placeContainer.setVisibility(View.VISIBLE);
+        }
+
+        trackView.setVisibility(View.GONE);
+
+        speakersView.setText("Carl Urbane, Lee Onwards");
+        speakersContainer.setVisibility(View.VISIBLE);
+
+        int icon = Level.getIcon(event.getExperienceLevel());
+        experienceIconView.setImageResource(icon);
+    }
+}

--- a/app/src/main/java/com/connfa/schedule/view/EventViewHolder.java
+++ b/app/src/main/java/com/connfa/schedule/view/EventViewHolder.java
@@ -1,0 +1,16 @@
+package com.connfa.schedule.view;
+
+import android.support.v7.widget.RecyclerView;
+
+import com.connfa.model.data.Event;
+
+class EventViewHolder extends RecyclerView.ViewHolder {
+
+    public EventViewHolder(EventItemView itemView) {
+        super(itemView);
+    }
+
+    public void updateWith(Event event) {
+        ((EventItemView) itemView).updateWith(event);
+    }
+}

--- a/app/src/main/java/com/connfa/schedule/view/EventsAdapter.java
+++ b/app/src/main/java/com/connfa/schedule/view/EventsAdapter.java
@@ -1,0 +1,54 @@
+package com.connfa.schedule.view;
+
+import android.content.Context;
+import android.support.v7.widget.RecyclerView;
+import android.view.LayoutInflater;
+import android.view.ViewGroup;
+
+import com.connfa.R;
+import com.connfa.model.data.Event;
+
+import java.util.Collections;
+import java.util.List;
+
+class EventsAdapter extends RecyclerView.Adapter<EventViewHolder> {
+
+    private final Context context;
+
+    private List<Event> events = Collections.emptyList();
+
+    EventsAdapter(Context context) {
+        this.context = context;
+        setHasStableIds(true);
+    }
+
+    @Override
+    public long getItemId(int position) {
+        return events.get(position).getId();
+    }
+
+    @Override
+    public EventViewHolder onCreateViewHolder(ViewGroup parent, int viewType) {
+        EventItemView itemView = (EventItemView) LayoutInflater.from(context)
+                .inflate(R.layout.item_schedule_event, parent, false);
+        return new EventViewHolder(itemView);
+    }
+
+    @Override
+    public void onBindViewHolder(EventViewHolder holder, int position) {
+        holder.updateWith(events.get(position));
+    }
+
+    @Override
+    public int getItemCount() {
+        return events.size();
+    }
+
+    public List<Event> events() {
+        return events;
+    }
+
+    public void updateWith(List<Event> events) {
+        this.events = events;
+    }
+}

--- a/app/src/main/java/com/connfa/schedule/view/SchedulePageView.java
+++ b/app/src/main/java/com/connfa/schedule/view/SchedulePageView.java
@@ -1,6 +1,7 @@
 package com.connfa.schedule.view;
 
 import android.content.Context;
+import android.support.v7.util.DiffUtil;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
 import android.util.AttributeSet;
@@ -17,6 +18,7 @@ public class SchedulePageView extends FrameLayout implements PageView<List<Event
 
     private RecyclerView recyclerView;
     private ProgressBar progressBar;
+    private EventsAdapter adapter;
 
     public SchedulePageView(Context context, AttributeSet attrs) {
         this(context, attrs, 0);
@@ -35,10 +37,50 @@ public class SchedulePageView extends FrameLayout implements PageView<List<Event
 
         LinearLayoutManager layoutManager = new LinearLayoutManager(getContext());
         recyclerView.setLayoutManager(layoutManager);
+        adapter = new EventsAdapter(getContext());
+        recyclerView.setAdapter(adapter);
     }
 
     @Override
-    public void updateWith(List<Event> data) {
-        // TODO bind to adapter
+    public void updateWith(List<Event> newData) {
+        DiffUtil.Callback callback = new EventsDiffCallback(adapter.events(), newData);
+        DiffUtil.DiffResult diffResult = DiffUtil.calculateDiff(callback, true);    // TODO move off the UI thread
+        adapter.updateWith(newData);
+        diffResult.dispatchUpdatesTo(adapter);
+    }
+
+    private static class EventsDiffCallback extends DiffUtil.Callback {
+
+        private final List<Event> oldEvents;
+        private final List<Event> newEvents;
+
+        private EventsDiffCallback(List<Event> oldEvents, List<Event> newEvents) {
+            this.oldEvents = oldEvents;
+            this.newEvents = newEvents;
+        }
+
+        @Override
+        public int getOldListSize() {
+            return oldEvents.size();
+        }
+
+        @Override
+        public int getNewListSize() {
+            return newEvents.size();
+        }
+
+        @Override
+        public boolean areItemsTheSame(int oldItemPosition, int newItemPosition) {
+            Event oldEvent = oldEvents.get(oldItemPosition);
+            Event newEvent = newEvents.get(newItemPosition);
+            return oldEvent.getId() == newEvent.getId();
+        }
+
+        @Override
+        public boolean areContentsTheSame(int oldItemPosition, int newItemPosition) {
+            Event oldEvent = oldEvents.get(oldItemPosition);
+            Event newEvent = newEvents.get(newItemPosition);
+            return oldEvent.equals(newEvent);
+        }
     }
 }

--- a/app/src/main/java/com/connfa/schedule/view/SchedulePageView.java
+++ b/app/src/main/java/com/connfa/schedule/view/SchedulePageView.java
@@ -1,0 +1,44 @@
+package com.connfa.schedule.view;
+
+import android.content.Context;
+import android.support.v7.widget.LinearLayoutManager;
+import android.support.v7.widget.RecyclerView;
+import android.util.AttributeSet;
+import android.widget.FrameLayout;
+import android.widget.ProgressBar;
+
+import com.connfa.PageView;
+import com.connfa.R;
+import com.connfa.model.data.Event;
+
+import java.util.List;
+
+public class SchedulePageView extends FrameLayout implements PageView<List<Event>> {
+
+    private RecyclerView recyclerView;
+    private ProgressBar progressBar;
+
+    public SchedulePageView(Context context, AttributeSet attrs) {
+        this(context, attrs, 0);
+    }
+
+    public SchedulePageView(Context context, AttributeSet attrs, int defStyleAttr) {
+        super(context, attrs, defStyleAttr);
+    }
+
+    @Override
+    protected void onFinishInflate() {
+        super.onFinishInflate();
+
+        progressBar = (ProgressBar) findViewById(R.id.progressbar);
+        recyclerView = (RecyclerView) findViewById(R.id.recyclerview);
+
+        LinearLayoutManager layoutManager = new LinearLayoutManager(getContext());
+        recyclerView.setLayoutManager(layoutManager);
+    }
+
+    @Override
+    public void updateWith(List<Event> data) {
+        // TODO bind to adapter
+    }
+}

--- a/app/src/main/java/com/connfa/schedule/view/ScheduleViewPagerAdapter.java
+++ b/app/src/main/java/com/connfa/schedule/view/ScheduleViewPagerAdapter.java
@@ -7,6 +7,7 @@ import android.view.View;
 import android.view.ViewGroup;
 
 import com.connfa.R;
+import com.connfa.model.data.Event;
 import com.connfa.schedule.domain.SchedulePage;
 
 import java.util.Collections;
@@ -34,9 +35,14 @@ public class ScheduleViewPagerAdapter extends PagerAdapter {
 
     @Override
     public Object instantiateItem(ViewGroup container, int position) {
-        SchedulePageView itemView = (SchedulePageView) LayoutInflater.from(context).inflate(R.layout.page_schedule, container, false);
-        container.addView(itemView);
-        return itemView;
+        SchedulePageView pageView = (SchedulePageView) LayoutInflater.from(context)
+                .inflate(R.layout.page_schedule, container, false);
+
+        List<Event> events = pages.get(position).events();
+        pageView.updateWith(events);
+        container.addView(pageView);
+
+        return pageView;
     }
 
     @Override

--- a/app/src/main/java/com/connfa/schedule/view/ScheduleViewPagerAdapter.java
+++ b/app/src/main/java/com/connfa/schedule/view/ScheduleViewPagerAdapter.java
@@ -1,0 +1,56 @@
+package com.connfa.schedule.view;
+
+import android.content.Context;
+import android.support.v4.view.PagerAdapter;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+
+import com.connfa.R;
+import com.connfa.schedule.domain.SchedulePage;
+
+import java.util.Collections;
+import java.util.List;
+
+public class ScheduleViewPagerAdapter extends PagerAdapter {
+
+    private final Context context;
+
+    private List<SchedulePage> pages = Collections.emptyList();
+
+    public ScheduleViewPagerAdapter(Context context) {
+        this.context = context;
+    }
+
+    public void updateWith(List<SchedulePage> pages) {
+        this.pages = pages;
+        notifyDataSetChanged();
+    }
+
+    @Override
+    public int getCount() {
+        return pages.size();
+    }
+
+    @Override
+    public Object instantiateItem(ViewGroup container, int position) {
+        SchedulePageView itemView = (SchedulePageView) LayoutInflater.from(context).inflate(R.layout.page_schedule, container, false);
+        container.addView(itemView);
+        return itemView;
+    }
+
+    @Override
+    public void destroyItem(ViewGroup container, int position, Object view) {
+        container.removeView((View) view);
+    }
+
+    @Override
+    public CharSequence getPageTitle(int position) {
+        return pages.get(position).formattedTitle(context);
+    }
+
+    @Override
+    public boolean isViewFromObject(View view, Object object) {
+        return view == object;
+    }
+}

--- a/app/src/main/res/layout/activity_schedule.xml
+++ b/app/src/main/res/layout/activity_schedule.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <android.support.design.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:app="http://schemas.android.com/apk/res-auto"
   xmlns:tools="http://schemas.android.com/tools"
   android:id="@+id/content_root"
   android:layout_width="match_parent"
@@ -7,16 +8,31 @@
   tools:context="com.connfa.schedule.ScheduleActivity">
 
   <android.support.design.widget.AppBarLayout
+    style="@style/Connfa.Appbar"
     android:layout_width="match_parent"
-    android:layout_height="?attr/actionBarSize">
+    android:layout_height="wrap_content">
 
     <android.support.v7.widget.Toolbar
       android:id="@+id/toolbar"
       style="@style/Connfa.Toolbar.Schedule"
       android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"
       android:layout_width="match_parent"
-      android:layout_height="@dimen/toolbar_height" />
+      android:layout_height="?attr/actionBarSize"
+      app:layout_collapseMode="none" />
+
+    <android.support.design.widget.TabLayout
+      android:id="@+id/tabstrip"
+      style="@style/Connfa.Tabs.Schedule"
+      android:layout_width="match_parent"
+      android:layout_height="?attr/actionBarSize"
+      app:layout_collapseMode="pin" />
 
   </android.support.design.widget.AppBarLayout>
+
+  <android.support.v4.view.ViewPager
+    android:id="@+id/viewpager"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    app:layout_behavior="@string/appbar_scrolling_view_behavior" />
 
 </android.support.design.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/fr_holder_event.xml
+++ b/app/src/main/res/layout/fr_holder_event.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
   xmlns:app="http://schemas.android.com/apk/res-auto"
+  xmlns:tools="http://schemas.android.com/tools"
   android:layout_width="match_parent"
   android:layout_height="match_parent"
-  xmlns:tools="http://schemas.android.com/tools"
   android:background="@android:color/white"
   android:orientation="vertical">
 
@@ -23,41 +23,42 @@
     app:pstsIndicatorHeight="3dp" />
 
   <android.support.v4.view.ViewPager
-    android:layout_below="@+id/pager_tab_strip"
-    tools:visibility="gone"
     android:id="@+id/viewPager"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content"></android.support.v4.view.ViewPager>
+    android:layout_height="wrap_content"
+    android:layout_below="@+id/pager_tab_strip"
+    tools:visibility="gone" />
 
   <LinearLayout
     android:id="@+id/layout_placeholder"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
     android:layout_centerInParent="true"
-    android:gravity="center_horizontal"
-    android:visibility="gone"
-    tools:visibility="visible"
     android:layout_marginLeft="@dimen/activity_horizontal_margin"
     android:layout_marginRight="@dimen/activity_horizontal_margin"
-    android:orientation="vertical">
+    android:gravity="center_horizontal"
+    android:visibility="gone"
+    android:orientation="vertical"
+    tools:visibility="visible">
 
     <ImageView
       android:id="@+id/image_view_placeholder"
       android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
       android:layout_gravity="center"
-      tools:src="@drawable/ic_no_my_schedule"
-      android:layout_height="wrap_content" />
+      tools:src="@drawable/ic_no_my_schedule" />
 
     <com.connfa.ui.view.FontTextView
       android:id="@+id/text_view_placeholder"
       android:layout_width="wrap_content"
-      android:gravity="center_horizontal"
-      android:layout_marginTop="@dimen/margin_top_placeholder_text"
       android:layout_height="wrap_content"
-      tools:text="@string/placeholder_schedule"
-      app:custom_font="@string/roboto_regular"
+      android:layout_marginTop="@dimen/margin_top_placeholder_text"
+      android:gravity="center_horizontal"
       android:textSize="@dimen/text_size_placeholder"
-      android:textColor="@color/placeholder_text" />
+      android:textColor="@color/placeholder_text"
+      app:custom_font="@string/roboto_regular"
+      tools:text="@string/placeholder_schedule" />
+
   </LinearLayout>
 
 </RelativeLayout>

--- a/app/src/main/res/layout/item_schedule_event.xml
+++ b/app/src/main/res/layout/item_schedule_event.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.connfa.schedule.view.EventItemView xmlns:android="http://schemas.android.com/apk/res/android"
+  android:layout_width="match_parent"
+  android:layout_height="wrap_content">
+
+  <!-- TODO replace with more efficient layout -->
+  <include layout="@layout/item_event" />
+
+</com.connfa.schedule.view.EventItemView>

--- a/app/src/main/res/layout/page_schedule.xml
+++ b/app/src/main/res/layout/page_schedule.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<com.connfa.schedule.view.SchedulePageView xmlns:android="http://schemas.android.com/apk/res/android"
+  android:layout_width="match_parent"
+  android:layout_height="match_parent">
+
+  <android.support.v7.widget.RecyclerView
+    android:id="@+id/recyclerview"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:clipToPadding="false" />
+
+  <ProgressBar
+    android:id="@+id/progressbar"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:layout_gravity="center" />
+
+</com.connfa.schedule.view.SchedulePageView>

--- a/app/src/main/res/values/attributes.xml
+++ b/app/src/main/res/values/attributes.xml
@@ -1,7 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?><!--
-  ~ This document and the source codes contained herein are the property of Schneider Enterprises, LLC. 
-  ~ Copyright (c) 2015, Schneider Enterprises, LLC.  All rights reserved.
--->
+<?xml version="1.0" encoding="utf-8"?>
 
 <resources>
   <declare-styleable name="FontTextView">

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -21,4 +21,6 @@
 
   <dimen name="navigation_drawer_width">288dp</dimen>
 
+  <dimen name="toolbar_elevation">6dp</dimen>
+
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -59,5 +59,6 @@
 
   <string name="no_tweets_for_query">No Tweets for %s… yet</string>
   <string name="activity_social_feed">Social Feed</string>
+  <string name="activity_schedule">Schedule</string>
 
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -4,13 +4,19 @@
 
   <style name="Connfa" />
 
-  <style name="Connfa.Toolbar" parent="Widget.AppCompat.Light.ActionBar">
-    <item name="android:background">@color/primary</item>
-    <item name="elevation">6dp</item>
+  <style name="Connfa.Appbar" parent="None">
+    <item name="android:background">?attr/colorPrimary</item>
+    <item name="android:elevation">@dimen/toolbar_elevation</item>
   </style>
 
-  <style name="Connfa.Toolbar.SocialFeed" parent="None" />
+  <style name="Connfa.Toolbar" parent="Widget.AppCompat.Light.ActionBar" />
 
-  <style name="Connfa.Toolbar.Schedule" parent="None" />
+  <style name="Connfa.Toolbar.SocialFeed" />
+
+  <style name="Connfa.Toolbar.Schedule" />
+
+  <style name="Connfa.Tabs" parent="Widget.Design.TabLayout" />
+
+  <style name="Connfa.Tabs.Schedule" parent="None" />
 
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -1,39 +1,6 @@
 <resources>
 
-  <style name="Theme.Connfa" parent="Theme.AppCompat.NoActionBar">
-    <item name="android:windowBackground">@color/white</item>
-    <item name="colorAccent">@color/grey_100</item>
-    <item name="colorControlNormal">@color/white_200</item>
-  </style>
-
-  <style name="Theme.Connfa.Home" parent="Theme.Connfa">
-    <item name="colorPrimaryDark">@color/primary_dark</item>
-    <item name="colorPrimary">@color/primary</item>
-  </style>
-
-  <style name="Theme.Connfa.SocialFeed" parent="Theme.AppCompat.Light.NoActionBar">
-    <item name="colorControlNormal">@color/white_200</item>
-    <item name="colorPrimaryDark">@color/primary_dark</item>
-    <item name="colorPrimary">@color/primary</item>
-  </style>
-
-  <style name="Theme.Connfa.Speaker" parent="Theme.Connfa">
-    <item name="colorPrimaryDark">@color/speaker_primary</item>
-    <item name="colorPrimary">@color/speaker_primary</item>
-    <item name="colorControlNormal">@color/white</item>
-  </style>
-
-  <style name="Theme.Connfa.Event" parent="Theme.Connfa">
-    <item name="colorPrimaryDark">@color/event_primary</item>
-    <item name="colorPrimary">@color/event_primary</item>
-    <item name="colorControlNormal">@color/white</item>
-  </style>
-
-  <style name="Theme.Connfa.About" parent="Theme.Connfa">
-    <item name="colorPrimaryDark">@color/primary_dark</item>
-    <item name="colorPrimary">@color/primary</item>
-    <item name="colorControlNormal">@color/white</item>
-  </style>
+  <style name="None" />
 
   <style name="Connfa" />
 
@@ -42,8 +9,8 @@
     <item name="elevation">6dp</item>
   </style>
 
-  <style name="Connfa.Toolbar.SocialFeed" />
+  <style name="Connfa.Toolbar.SocialFeed" parent="None" />
 
-  <style name="Connfa.Toolbar.Schedule" />
+  <style name="Connfa.Toolbar.Schedule" parent="None" />
 
 </resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -36,4 +36,13 @@
     <item name="colorControlNormal">@color/white</item>
   </style>
 
+  <style name="Theme.ConnfaNew" parent="Theme.AppCompat.NoActionBar">
+    <item name="android:windowBackground">@color/white</item>
+    <item name="colorPrimaryDark">@color/primary_dark</item>
+    <item name="colorPrimary">@color/primary</item>
+  </style>
+
+  <style name="Theme.Connfa.Schedule" parent="Theme.ConnfaNew">
+  </style>
+
 </resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+  <style name="Theme.Connfa" parent="Theme.AppCompat.NoActionBar">
+    <item name="android:windowBackground">@color/white</item>
+    <item name="colorAccent">@color/grey_100</item>
+    <item name="colorControlNormal">@color/white_200</item>
+  </style>
+
+  <style name="Theme.Connfa.Home" parent="Theme.Connfa">
+    <item name="colorPrimaryDark">@color/primary_dark</item>
+    <item name="colorPrimary">@color/primary</item>
+  </style>
+
+  <style name="Theme.Connfa.SocialFeed" parent="Theme.AppCompat.Light.NoActionBar">
+    <item name="colorControlNormal">@color/white_200</item>
+    <item name="colorPrimaryDark">@color/primary_dark</item>
+    <item name="colorPrimary">@color/primary</item>
+  </style>
+
+  <style name="Theme.Connfa.Speaker" parent="Theme.Connfa">
+    <item name="colorPrimaryDark">@color/speaker_primary</item>
+    <item name="colorPrimary">@color/speaker_primary</item>
+    <item name="colorControlNormal">@color/white</item>
+  </style>
+
+  <style name="Theme.Connfa.Event" parent="Theme.Connfa">
+    <item name="colorPrimaryDark">@color/event_primary</item>
+    <item name="colorPrimary">@color/event_primary</item>
+    <item name="colorControlNormal">@color/white</item>
+  </style>
+
+  <style name="Theme.Connfa.About" parent="Theme.Connfa">
+    <item name="colorPrimaryDark">@color/primary_dark</item>
+    <item name="colorPrimary">@color/primary</item>
+    <item name="colorControlNormal">@color/white</item>
+  </style>
+
+</resources>


### PR DESCRIPTION
This PR populates the UI in the ScheduleActivity. The approach was "it's easier to do it from scratch than to fix what's there already". The structure is very MVP, but we don't have enough complexity at the moment to justify more than that. A presenter may be added when wiring data.

Still TODO:
 * Implement/handle states (show/hide progress indicator; errors/empty state)
 * Wire up the data (this requires the networking layer to be done, and to have new models which depends on #31 because we want to do it properly)
 * General cleanup (including removing the old stuff, which will be literally the last task for this feature branch)


![default](https://cloud.githubusercontent.com/assets/153802/22390581/c5040a12-e4e3-11e6-804a-74e289091f83.png)
