### PR TITLE
CA-26/Autovalue/JodaTime all the things

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -113,19 +113,22 @@ dependencies {
     compile libraries.app.scaleImageView
     compile libraries.app.timber
 
-    compile libraries.app.supportAppCompat
-    compile libraries.app.supportDesign
+    compile libraries.app.jodaTimeAndroid
+
     compile libraries.app.playAnalytics
     compile libraries.app.playMaps
+    
     compile libraries.app.retrofit
     compile libraries.app.retrofitGson
     compile libraries.app.retrofitRx
+    
     compile libraries.app.rx
     compile libraries.app.rxAndroid
+    
+    compile libraries.app.supportAppCompat
+    compile libraries.app.supportDesign
 
-    compile(libraries.app.crashlytics) {
-        transitive = true
-    }
+    compile(libraries.app.crashlytics)
     compile libraries.app.tweetUi
 
     apt libraries.app.autoValue

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -40,8 +40,11 @@ android {
         applicationId buildProperties.application['applicationId']
                 .or(buildProperties.env['APPLICATION_ID'])
                 .string
+        
         minSdkVersion Integer.parseInt(project.MIN_SDK_VERSION)
         targetSdkVersion Integer.parseInt(project.TARGET_SDK_VERSION)
+
+        multiDexEnabled true
 
         versionCode Integer.parseInt(project.VERSION_CODE)
         versionName project.VERSION_NAME

--- a/app/src/main/java/com/connfa/ConnfaApplication.java
+++ b/app/src/main/java/com/connfa/ConnfaApplication.java
@@ -15,6 +15,8 @@ import com.twitter.sdk.android.core.TwitterAuthConfig;
 import com.twitter.sdk.android.core.TwitterCore;
 import com.twitter.sdk.android.tweetui.TweetUi;
 
+import net.danlew.android.joda.JodaTimeAndroid;
+
 import io.fabric.sdk.android.Fabric;
 import timber.log.Timber;
 
@@ -23,6 +25,8 @@ public class ConnfaApplication extends Application {
     @Override
     public void onCreate() {
         super.onCreate();
+
+        JodaTimeAndroid.init(this);
 
         setupTracking();
 

--- a/app/src/main/java/com/connfa/schedule/ScheduleActivity.java
+++ b/app/src/main/java/com/connfa/schedule/ScheduleActivity.java
@@ -49,7 +49,7 @@ public class ScheduleActivity extends NavigationDrawerActivity {
         super.onStart();
 
         // TODO start fetching data
-        viewPagerAdapter.updateWith(Collections.singletonList(new SchedulePage(new Date())));
+        viewPagerAdapter.updateWith(Collections.singletonList(SchedulePage.create(new Date())));
     }
 
     @Override

--- a/app/src/main/java/com/connfa/schedule/ScheduleActivity.java
+++ b/app/src/main/java/com/connfa/schedule/ScheduleActivity.java
@@ -14,7 +14,8 @@ import com.connfa.schedule.domain.SchedulePage;
 import com.connfa.schedule.view.ScheduleViewPagerAdapter;
 
 import java.util.Collections;
-import java.util.Date;
+
+import org.joda.time.DateTime;
 
 public class ScheduleActivity extends NavigationDrawerActivity {
 
@@ -49,7 +50,7 @@ public class ScheduleActivity extends NavigationDrawerActivity {
         super.onStart();
 
         // TODO start fetching data
-        viewPagerAdapter.updateWith(Collections.singletonList(SchedulePage.create(new Date())));
+        viewPagerAdapter.updateWith(Collections.singletonList(SchedulePage.create(DateTime.now())));
     }
 
     @Override

--- a/app/src/main/java/com/connfa/schedule/domain/SchedulePage.java
+++ b/app/src/main/java/com/connfa/schedule/domain/SchedulePage.java
@@ -5,25 +5,21 @@ import android.content.Context;
 import com.connfa.model.data.Event;
 import com.connfa.model.data.Level;
 import com.connfa.utils.DateUtils;
+import com.google.auto.value.AutoValue;
 
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.TimeZone;
 
-public class SchedulePage {
+@AutoValue
+public abstract class SchedulePage {
 
-    private final Date date;           // TODO use JodaTime
-
-    public SchedulePage(Date date) {
-        this.date = date;
+    public static SchedulePage create(Date date) {
+        return new AutoValue_SchedulePage(date, dummyEvents());
     }
 
-    public String formattedTitle(Context context) {
-        return DateUtils.getWeekNameAndDate(context, date.getTime());
-    }
-
-    public List<Event> events() {
+    private static List<Event> dummyEvents() {
         Event event = new Event(TimeZone.getDefault());
         event.setId(123456);
         event.setDate(new Date());
@@ -35,5 +31,13 @@ public class SchedulePage {
         event.setType(0);
         event.setExperienceLevel(Level.INTERMEDIATE);
         return Collections.singletonList(event);
+    }
+
+    public abstract Date date();
+
+    public abstract List<Event> events();
+
+    public String formattedTitle(Context context) {
+        return DateUtils.getWeekNameAndDate(context, date().getTime());
     }
 }

--- a/app/src/main/java/com/connfa/schedule/domain/SchedulePage.java
+++ b/app/src/main/java/com/connfa/schedule/domain/SchedulePage.java
@@ -8,21 +8,22 @@ import com.connfa.utils.DateUtils;
 import com.google.auto.value.AutoValue;
 
 import java.util.Collections;
-import java.util.Date;
 import java.util.List;
 import java.util.TimeZone;
+
+import org.joda.time.DateTime;
 
 @AutoValue
 public abstract class SchedulePage {
 
-    public static SchedulePage create(Date date) {
+    public static SchedulePage create(DateTime date) {
         return new AutoValue_SchedulePage(date, dummyEvents());
     }
 
     private static List<Event> dummyEvents() {
         Event event = new Event(TimeZone.getDefault());
         event.setId(123456);
-        event.setDate(new Date());
+        event.setDate(DateTime.now().toDate());
         event.setName("Test event \uD83C\uDF4C");
         event.setTrack(0);
         event.setSpeakers(Collections.<Long>emptyList());
@@ -33,11 +34,11 @@ public abstract class SchedulePage {
         return Collections.singletonList(event);
     }
 
-    public abstract Date date();
+    public abstract DateTime date();
 
     public abstract List<Event> events();
 
     public String formattedTitle(Context context) {
-        return DateUtils.getWeekNameAndDate(context, date().getTime());
+        return DateUtils.getWeekNameAndDate(context, date().getMillis());
     }
 }

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -8,6 +8,7 @@ ext {
                     autoValue       : 'com.google.auto.value:auto-value:1.3',
                     crashlytics     : 'com.crashlytics.sdk.android:crashlytics:2.6.5',
                     gson            : 'com.google.code.gson:gson:2.8.0',
+                    jodaTimeAndroid : 'net.danlew:android.joda:2.9.5.1',
                     materialTabStrip: 'com.jpardogo.materialtabstrip:library:1.0.8',
                     parallaxScroll  : 'com.github.nirhart:parallaxscroll:1.0',
                     playAnalytics   : "com.google.android.gms:play-services-analytics:${playServicesVersion}",

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.2.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip


### PR DESCRIPTION
This PR uses AutoValue and JodaTime for the new data models. For greater justice!

Unfortunately this got us over 65k methods, so we have to enable multidex; the hope is that once we manage to cut down the amount of legacy code and its dependencies, we can roll that back too.