### PR TITLE
CA-26/Basic event details screen UI impl

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -57,7 +57,7 @@ android {
         versionCode Integer.parseInt(project.VERSION_CODE)
         versionName project.VERSION_NAME
 
-        resValueString 'app_name', (buildProperties.application['applicationName'] | 'Connfa').string
+        resValueString 'app_name', (buildProperties.application['applicationName'] | "Connfa").string
 
         manifestPlaceholders += [
                 fabricApiKey: (buildProperties.secrets['fabricApiKey'] | buildProperties.env['FABRIC_API_KEY']).string
@@ -71,7 +71,7 @@ android {
 
         resValueString 'api_value_base_url', (buildProperties.secrets['baseUrl'] | buildProperties.env['BASE_URL']).string
 
-        resValueString 'social_query', (buildProperties.application['socialQuery'] | '#AndroidDev').string
+        resValueString 'social_query', (buildProperties.application['socialQuery'] | "#AndroidDev").string
     }
 
     if (System.getenv('CI') == null) {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -81,6 +81,7 @@
       android:name="io.fabric.ApiKey"
       android:value="${fabricApiKey}" />
 
+    <activity android:name="com.connfa.eventdetails.EventDetailsActivity" />
   </application>
 
 </manifest>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -81,7 +81,9 @@
       android:name="io.fabric.ApiKey"
       android:value="${fabricApiKey}" />
 
-    <activity android:name="com.connfa.eventdetails.EventDetailsActivity" />
+    <activity
+      android:name="com.connfa.eventdetails.EventDetailsActivity"
+      android:theme="@style/Theme.Connfa.EventDetails" />
   </application>
 
 </manifest>

--- a/app/src/main/java/com/connfa/PageView.java
+++ b/app/src/main/java/com/connfa/PageView.java
@@ -1,6 +1,0 @@
-package com.connfa;
-
-public interface PageView<T> {
-
-    void updateWith(T newData);
-}

--- a/app/src/main/java/com/connfa/eventdetails/EventDetailsActivity.java
+++ b/app/src/main/java/com/connfa/eventdetails/EventDetailsActivity.java
@@ -1,0 +1,16 @@
+package com.connfa.eventdetails;
+
+import android.support.v7.app.AppCompatActivity;
+import android.os.Bundle;
+
+import com.connfa.R;
+
+public class EventDetailsActivity extends AppCompatActivity {
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        setContentView(R.layout.activity_event_details);
+    }
+}

--- a/app/src/main/java/com/connfa/eventdetails/EventDetailsActivity.java
+++ b/app/src/main/java/com/connfa/eventdetails/EventDetailsActivity.java
@@ -1,7 +1,8 @@
 package com.connfa.eventdetails;
 
-import android.support.v7.app.AppCompatActivity;
 import android.os.Bundle;
+import android.support.v7.app.AppCompatActivity;
+import android.support.v7.widget.Toolbar;
 
 import com.connfa.R;
 
@@ -12,5 +13,8 @@ public class EventDetailsActivity extends AppCompatActivity {
         super.onCreate(savedInstanceState);
 
         setContentView(R.layout.activity_event_details);
+
+        Toolbar toolbar = (Toolbar) findViewById(R.id.toolbar);
+        setSupportActionBar(toolbar);
     }
 }

--- a/app/src/main/java/com/connfa/navigation/Navigator.java
+++ b/app/src/main/java/com/connfa/navigation/Navigator.java
@@ -4,6 +4,6 @@ public interface Navigator {
 
     void up();
 
-    // TODO
+    void toEventDetails(/* TODO create eventId and pass it here */);
 
 }

--- a/app/src/main/java/com/connfa/schedule/ScheduleActivity.java
+++ b/app/src/main/java/com/connfa/schedule/ScheduleActivity.java
@@ -8,14 +8,18 @@ import android.view.ViewGroup;
 import com.connfa.R;
 import com.connfa.navigation.NavigationDrawerActivity;
 import com.connfa.navigation.Navigator;
+import com.connfa.schedule.navigation.ScheduleActivityNavigator;
 import com.connfa.schedule.service.ScheduleActivityService;
 import com.connfa.schedule.view.ScheduleView;
+import com.connfa.schedule.view.ScheduleViewPagerAdapter;
 import com.connfa.service.firebase.FirebaseConnfaRepository;
 
 import io.reactivex.android.schedulers.AndroidSchedulers;
 import io.reactivex.disposables.Disposable;
 
-public class ScheduleActivity extends NavigationDrawerActivity {
+public class ScheduleActivity extends NavigationDrawerActivity implements ScheduleViewPagerAdapter.OnEventClickedListener {
+
+    private Navigator navigator;
 
     private ScheduleView scheduleView;
     private ScheduleActivityService service;
@@ -34,6 +38,8 @@ public class ScheduleActivity extends NavigationDrawerActivity {
 
         scheduleView = (ScheduleView) findViewById(R.id.content_root);
         service = new ScheduleActivityService(FirebaseConnfaRepository.newInstance());
+
+        navigator = new ScheduleActivityNavigator(this);
     }
 
     private void setupToolbar(Toolbar toolbar) {
@@ -47,7 +53,7 @@ public class ScheduleActivity extends NavigationDrawerActivity {
 
         subscription = service.schedule()
                 .observeOn(AndroidSchedulers.mainThread())
-                .subscribe(schedule -> scheduleView.updateWith(schedule));
+                .subscribe(schedule -> scheduleView.updateWith(schedule, this));
     }
 
     @Override
@@ -59,8 +65,11 @@ public class ScheduleActivity extends NavigationDrawerActivity {
 
     @Override
     protected Navigator navigate() {
-        return () -> {
-            // TODO
-        };
+        return navigator;
+    }
+
+    @Override
+    public void onEventClicked() {
+        navigate().toEventDetails();
     }
 }

--- a/app/src/main/java/com/connfa/schedule/domain/view/SchedulePage.java
+++ b/app/src/main/java/com/connfa/schedule/domain/view/SchedulePage.java
@@ -12,10 +12,11 @@ import org.joda.time.format.DateTimeFormatter;
 public abstract class SchedulePage {
 
     private static final DateTimeFormatter FORMATTER = DateTimeFormat.forPattern("d-MM-yyyy");
+    private static final String TITLE_FORMAT_TEMPLATE = "EEE d";
 
     public static SchedulePage create(String date, List<Event> events) {
         DateTime dateTime = DateTime.parse(date, FORMATTER);
-        String title = dateTime.toString("EEE d");
+        String title = dateTime.toString(TITLE_FORMAT_TEMPLATE);
         return new AutoValue_SchedulePage(title, events);
     }
 

--- a/app/src/main/java/com/connfa/schedule/navigation/ScheduleActivityNavigator.java
+++ b/app/src/main/java/com/connfa/schedule/navigation/ScheduleActivityNavigator.java
@@ -1,0 +1,26 @@
+package com.connfa.schedule.navigation;
+
+import android.content.Context;
+import android.content.Intent;
+
+import com.connfa.eventdetails.EventDetailsActivity;
+import com.connfa.navigation.Navigator;
+
+public class ScheduleActivityNavigator implements Navigator {
+
+    private final Context context;
+
+    public ScheduleActivityNavigator(Context context) {
+        this.context = context;
+    }
+
+    @Override
+    public void up() {
+        // No-op (top level yo)
+    }
+
+    @Override
+    public void toEventDetails() {
+        context.startActivity(new Intent(context, EventDetailsActivity.class));
+    }
+}

--- a/app/src/main/java/com/connfa/schedule/view/EventItemView.java
+++ b/app/src/main/java/com/connfa/schedule/view/EventItemView.java
@@ -41,7 +41,7 @@ public class EventItemView extends FrameLayout {
         experienceIconView = (ImageView) findViewById(R.id.imgExperience);
     }
 
-    public void updateWith(Event event) {
+    void updateWith(Event event) {
         titleView.setText(event.title());
 
         placeView.setText(event.place());

--- a/app/src/main/java/com/connfa/schedule/view/EventViewHolder.java
+++ b/app/src/main/java/com/connfa/schedule/view/EventViewHolder.java
@@ -1,16 +1,22 @@
 package com.connfa.schedule.view;
 
+import android.support.annotation.Nullable;
 import android.support.v7.widget.RecyclerView;
 
 import com.connfa.schedule.domain.view.Event;
 
 class EventViewHolder extends RecyclerView.ViewHolder {
 
-    public EventViewHolder(EventItemView itemView) {
+    EventViewHolder(EventItemView itemView) {
         super(itemView);
     }
 
-    public void updateWith(Event event) {
+    void updateWith(Event event, @Nullable ScheduleViewPagerAdapter.OnEventClickedListener listener) {
         ((EventItemView) itemView).updateWith(event);
+        itemView.setOnClickListener(v -> {
+            if (listener != null) {
+                listener.onEventClicked();  // TODO pass in eventId
+            }
+        });
     }
 }

--- a/app/src/main/java/com/connfa/schedule/view/EventsAdapter.java
+++ b/app/src/main/java/com/connfa/schedule/view/EventsAdapter.java
@@ -1,6 +1,7 @@
 package com.connfa.schedule.view;
 
 import android.content.Context;
+import android.support.annotation.Nullable;
 import android.support.v7.widget.RecyclerView;
 import android.view.LayoutInflater;
 import android.view.ViewGroup;
@@ -17,6 +18,9 @@ class EventsAdapter extends RecyclerView.Adapter<EventViewHolder> {
 
     private List<Event> events = Collections.emptyList();
 
+    @Nullable
+    private ScheduleViewPagerAdapter.OnEventClickedListener listener;
+
     EventsAdapter(Context context) {
         this.context = context;
         setHasStableIds(true);
@@ -25,6 +29,11 @@ class EventsAdapter extends RecyclerView.Adapter<EventViewHolder> {
     @Override
     public long getItemId(int position) {
         return events.get(position).id();
+    }
+
+    void updateWith(List<Event> events, ScheduleViewPagerAdapter.OnEventClickedListener listener) {
+        this.events = events;
+        this.listener = listener;
     }
 
     @Override
@@ -36,7 +45,7 @@ class EventsAdapter extends RecyclerView.Adapter<EventViewHolder> {
 
     @Override
     public void onBindViewHolder(EventViewHolder holder, int position) {
-        holder.updateWith(events.get(position));
+        holder.updateWith(events.get(position), listener);
     }
 
     @Override
@@ -46,9 +55,5 @@ class EventsAdapter extends RecyclerView.Adapter<EventViewHolder> {
 
     public List<Event> events() {
         return events;
-    }
-
-    public void updateWith(List<Event> events) {
-        this.events = events;
     }
 }

--- a/app/src/main/java/com/connfa/schedule/view/SchedulePageView.java
+++ b/app/src/main/java/com/connfa/schedule/view/SchedulePageView.java
@@ -6,12 +6,11 @@ import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
 import android.util.AttributeSet;
 
-import com.connfa.PageView;
 import com.connfa.schedule.domain.view.Event;
 
 import java.util.List;
 
-public class SchedulePageView extends RecyclerView implements PageView<List<Event>> {
+public class SchedulePageView extends RecyclerView {
 
     private EventsAdapter adapter;
 
@@ -33,11 +32,10 @@ public class SchedulePageView extends RecyclerView implements PageView<List<Even
         setAdapter(adapter);
     }
 
-    @Override
-    public void updateWith(List<Event> newData) {
+    void updateWith(List<Event> newData, ScheduleViewPagerAdapter.OnEventClickedListener listener) {
         DiffUtil.Callback callback = new EventsDiffCallback(adapter.events(), newData);
         DiffUtil.DiffResult diffResult = DiffUtil.calculateDiff(callback, true);    // TODO move off the UI thread
-        adapter.updateWith(newData);
+        adapter.updateWith(newData, listener);
         diffResult.dispatchUpdatesTo(adapter);
     }
 

--- a/app/src/main/java/com/connfa/schedule/view/ScheduleView.java
+++ b/app/src/main/java/com/connfa/schedule/view/ScheduleView.java
@@ -37,8 +37,8 @@ public class ScheduleView extends CoordinatorLayout {
         viewPager.setAdapter(viewPagerAdapter);
     }
 
-    public void updateWith(Schedule schedule) {
-        viewPagerAdapter.updateWith(schedule.pages());
+    public void updateWith(Schedule schedule, ScheduleViewPagerAdapter.OnEventClickedListener listener) {
+        viewPagerAdapter.updateWith(schedule.pages(), listener);
         progressBar.setVisibility(GONE);
     }
 }

--- a/app/src/main/java/com/connfa/schedule/view/ScheduleViewPagerAdapter.java
+++ b/app/src/main/java/com/connfa/schedule/view/ScheduleViewPagerAdapter.java
@@ -1,6 +1,7 @@
 package com.connfa.schedule.view;
 
 import android.content.Context;
+import android.support.annotation.Nullable;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -19,12 +20,16 @@ public class ScheduleViewPagerAdapter extends ViewPagerAdapter<SchedulePageView>
 
     private List<SchedulePage> pages = Collections.emptyList();
 
-    public ScheduleViewPagerAdapter(Context context) {
+    @Nullable
+    private OnEventClickedListener listener;
+
+    ScheduleViewPagerAdapter(Context context) {
         this.context = context;
     }
 
-    public void updateWith(List<SchedulePage> pages) {
+    void updateWith(List<SchedulePage> pages, OnEventClickedListener listener) {
         this.pages = pages;
+        this.listener = listener;
         notifyDataSetChanged();
     }
 
@@ -42,7 +47,7 @@ public class ScheduleViewPagerAdapter extends ViewPagerAdapter<SchedulePageView>
     @Override
     protected void bindView(SchedulePageView view, int position) {
         List<Event> events = pages.get(position).events();
-        view.updateWith(events);
+        view.updateWith(events, listener);
     }
 
     @Override
@@ -53,5 +58,10 @@ public class ScheduleViewPagerAdapter extends ViewPagerAdapter<SchedulePageView>
     @Override
     public boolean isViewFromObject(View view, Object object) {
         return view == object;
+    }
+
+    public interface OnEventClickedListener {
+
+        void onEventClicked(/* TODO pass eventId  */);
     }
 }

--- a/app/src/main/res/layout/ac_event_details.xml
+++ b/app/src/main/res/layout/ac_event_details.xml
@@ -96,7 +96,7 @@
               android:layout_width="17dp"
               android:layout_height="17dp"
               android:layout_gravity="center"
-              tools:src="@drawable/ic_launcher" />
+              tools:src="@drawable/ic_experience_advanced" />
           </LinearLayout>
 
         </LinearLayout>

--- a/app/src/main/res/layout/activity_event_details.xml
+++ b/app/src/main/res/layout/activity_event_details.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.design.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:app="http://schemas.android.com/apk/res-auto"
+  android:layout_width="match_parent"
+  android:layout_height="match_parent"
+  android:fitsSystemWindows="true">
+
+  <android.support.design.widget.AppBarLayout
+    android:id="@+id/appbar"
+    android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:fitsSystemWindows="true">
+
+    <android.support.design.widget.CollapsingToolbarLayout
+      android:id="@+id/collapsing_toolbar"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:fitsSystemWindows="true"
+      app:layout_scrollFlags="scroll|exitUntilCollapsed"
+      app:contentScrim="?attr/colorPrimary"
+      app:expandedTitleMarginStart="48dp"
+      app:expandedTitleMarginEnd="64dp">
+
+      <ImageView
+        android:id="@+id/backdrop"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:fitsSystemWindows="true"
+        android:scaleType="centerCrop"
+        android:src="@drawable/event_details_header"
+        app:layout_collapseMode="parallax" />
+
+      <android.support.v7.widget.Toolbar
+        android:id="@+id/toolbar"
+        android:layout_width="match_parent"
+        android:layout_height="?attr/actionBarSize"
+        app:layout_collapseMode="pin"
+        app:popupTheme="@style/ThemeOverlay.AppCompat.Light" />
+
+    </android.support.design.widget.CollapsingToolbarLayout>
+
+  </android.support.design.widget.AppBarLayout>
+
+  <android.support.v4.widget.NestedScrollView
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    app:layout_behavior="@string/appbar_scrolling_view_behavior">
+
+    <LinearLayout
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:orientation="vertical">
+
+      <TextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_margin="16dp"
+        android:text="Stocazzo"
+        android:textAppearance="@style/TextAppearance.AppCompat.Display1"/>
+
+    </LinearLayout>
+
+  </android.support.v4.widget.NestedScrollView>
+
+  <android.support.design.widget.FloatingActionButton
+    android:id="@+id/favorite_fab"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:layout_margin="16dp"
+    android:src="@drawable/ic_favorite_empty"
+    android:clickable="true"
+    app:layout_anchor="@id/appbar"
+    app:layout_anchorGravity="bottom|end" />
+
+</android.support.design.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/activity_event_details.xml
+++ b/app/src/main/res/layout/activity_event_details.xml
@@ -15,7 +15,7 @@
     <android.support.design.widget.CollapsingToolbarLayout
       android:id="@+id/collapsing_toolbar"
       android:layout_width="match_parent"
-      android:layout_height="wrap_content"
+      android:layout_height="match_parent"
       android:fitsSystemWindows="true"
       app:layout_scrollFlags="scroll|exitUntilCollapsed"
       app:contentScrim="?attr/colorPrimary"
@@ -26,6 +26,7 @@
         android:id="@+id/backdrop"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:minHeight="180dp"
         android:fitsSystemWindows="true"
         android:scaleType="centerCrop"
         android:src="@drawable/event_details_header"
@@ -56,7 +57,8 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_margin="16dp"
-        android:text="Stocazzo"
+        android:paddingBottom="600dp"
+        android:text="Temp test lol stuff what is this I don't even\n\n\n\n\n\nOh hey I can scroll!\n\n\n\n\n\n\nSuch hax0r 👨‍💻"
         android:textAppearance="@style/TextAppearance.AppCompat.Display1"/>
 
     </LinearLayout>

--- a/app/src/main/res/layout/activity_schedule.xml
+++ b/app/src/main/res/layout/activity_schedule.xml
@@ -9,13 +9,13 @@
 
   <android.support.design.widget.AppBarLayout
     style="@style/Connfa.Appbar"
+    android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"
     android:layout_width="match_parent"
     android:layout_height="wrap_content">
 
     <android.support.v7.widget.Toolbar
       android:id="@+id/toolbar"
       style="@style/Connfa.Toolbar.Schedule"
-      android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"
       android:layout_width="match_parent"
       android:layout_height="?attr/actionBarSize"
       app:layout_collapseMode="none" />

--- a/app/src/main/res/layout/item_event.xml
+++ b/app/src/main/res/layout/item_event.xml
@@ -6,7 +6,6 @@
   android:layout_width="match_parent"
   android:layout_height="wrap_content"
   android:background="@drawable/selector_light"
-  android:clickable="true"
   android:orientation="vertical">
 
   <LinearLayout
@@ -86,7 +85,6 @@
             android:layout_marginBottom="4dp"
             android:layout_marginRight="8dp"
             android:layout_weight="1.0"
-            android:clickable="false"
             android:textColor="@color/black_100"
             android:textSize="@dimen/text_size_medium"
             app:custom_font="@string/roboto_regular"
@@ -97,7 +95,7 @@
             android:layout_width="15dp"
             android:layout_height="15dp"
             android:layout_gravity="center"
-            tools:src="@drawable/ic_launcher" />
+            tools:src="@drawable/ic_experience_advanced" />
 
         </LinearLayout>
 

--- a/app/src/main/res/values/color.xml
+++ b/app/src/main/res/values/color.xml
@@ -21,8 +21,9 @@
 
   <color name="item_selection">#4f3b9a</color>
 
-  <color name="primary_dark">#06335b</color>
+  <color name="accent">#6aa611</color>
   <color name="primary">#06335b</color>
+  <color name="primary_dark">#06335b</color>
 
   <color name="event_primary">#06335b</color>
   <color name="event">#4077aa</color>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -43,6 +43,8 @@
 
   <style name="Theme.Connfa.Schedule" parent="Theme.ConnfaNew" />
 
-  <style name="Theme.Connfa.EventDetails" parent="Theme.ConnfaNew" />
+  <style name="Theme.Connfa.EventDetails" parent="Theme.ConnfaNew">
+    <item name="android:statusBarColor">#0000</item>
+  </style>
 
 </resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -37,8 +37,9 @@
   </style>
 
   <style name="Theme.ConnfaNew" parent="Theme.AppCompat.Light.NoActionBar">
-    <item name="colorPrimaryDark">@color/primary_dark</item>
     <item name="colorPrimary">@color/primary</item>
+    <item name="colorPrimaryDark">@color/primary_dark</item>
+    <item name="colorAccent">@color/accent</item>
   </style>
 
   <style name="Theme.Connfa.Schedule" parent="Theme.ConnfaNew" />

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -36,13 +36,13 @@
     <item name="colorControlNormal">@color/white</item>
   </style>
 
-  <style name="Theme.ConnfaNew" parent="Theme.AppCompat.NoActionBar">
-    <item name="android:windowBackground">@color/white</item>
+  <style name="Theme.ConnfaNew" parent="Theme.AppCompat.Light.NoActionBar">
     <item name="colorPrimaryDark">@color/primary_dark</item>
     <item name="colorPrimary">@color/primary</item>
   </style>
 
-  <style name="Theme.Connfa.Schedule" parent="Theme.ConnfaNew">
-  </style>
+  <style name="Theme.Connfa.Schedule" parent="Theme.ConnfaNew" />
+
+  <style name="Theme.Connfa.EventDetails" parent="Theme.ConnfaNew" />
 
 </resources>


### PR DESCRIPTION
This PR adds the first bits to have an event details:

 * Click listener for schedule items
 * EventDetailsActivity's base layout (no logic nor real data views yet) with LOADS of TODOs on extracting values and all, this is just so we can parallelise data fetching and UI impl from this point onwards

![scrolly](https://cloud.githubusercontent.com/assets/153802/22460012/eaf4c176-e79a-11e6-9b5f-b7b7f9cfe346.gif)
