### PR TITLE
SQ-51/Refactor services and rename models

### DIFF
--- a/app/src/main/java/net/squanchy/eventdetails/EventDetailsService.java
+++ b/app/src/main/java/net/squanchy/eventdetails/EventDetailsService.java
@@ -3,7 +3,7 @@ package net.squanchy.eventdetails;
 import net.squanchy.schedule.domain.view.Event;
 import net.squanchy.service.firebase.FirebaseSquanchyRepository;
 import net.squanchy.service.firebase.model.FirebaseEvent;
-import net.squanchy.service.firebase.model.FirebaseSpeaker;
+import net.squanchy.service.firebase.model.FirebaseSpeakers;
 
 import io.reactivex.Observable;
 import io.reactivex.schedulers.Schedulers;
@@ -21,7 +21,7 @@ class EventDetailsService {
 
     public Observable<Event> event(int dayId, int eventId) {
         Observable<FirebaseEvent> eventObservable = repository.event(dayId, eventId);
-        Observable<FirebaseSpeaker.Holder> speakersObservable = repository.speakers();
+        Observable<FirebaseSpeakers> speakersObservable = repository.speakers();
 
         return Observable.combineLatest(
                 eventObservable,

--- a/app/src/main/java/net/squanchy/eventdetails/EventDetailsService.java
+++ b/app/src/main/java/net/squanchy/eventdetails/EventDetailsService.java
@@ -1,11 +1,16 @@
 package net.squanchy.eventdetails;
 
+import java.util.List;
+
 import net.squanchy.schedule.domain.view.Event;
 import net.squanchy.service.firebase.FirebaseSquanchyRepository;
 import net.squanchy.service.firebase.model.FirebaseEvent;
+import net.squanchy.service.firebase.model.FirebaseSpeaker;
 import net.squanchy.service.firebase.model.FirebaseSpeakers;
+import net.squanchy.support.lang.Lists;
 
 import io.reactivex.Observable;
+import io.reactivex.functions.BiFunction;
 import io.reactivex.schedulers.Schedulers;
 
 import static net.squanchy.support.lang.Lists.find;
@@ -26,19 +31,33 @@ class EventDetailsService {
         return Observable.combineLatest(
                 eventObservable,
                 speakersObservable,
-                (firebaseEvent, speakerHolder) -> Event.create(
-                        firebaseEvent.eventId,
-                        dayId,
-                        firebaseEvent.name,
-                        firebaseEvent.place,
-                        firebaseEvent.experienceLevel,
-                        map(
-                                map(firebaseEvent.speakers, speakerId -> find(
-                                        speakerHolder.speakers, speaker -> speaker.speakerId.equals(speakerId))
-                                ),
-                                speaker -> speaker == null ? "" : speaker.firstName + " " + speaker.lastName
-                        )
-                )
+                combineIntoEvent(dayId)
         ).subscribeOn(Schedulers.io());
+    }
+
+    private BiFunction<FirebaseEvent, FirebaseSpeakers, Event> combineIntoEvent(int dayId) {
+        return (apiEvent, apiSpeakers) -> {
+            List<FirebaseSpeaker> speakers = speakersForEvent(apiEvent, apiSpeakers);
+            return Event.create(
+                    apiEvent.eventId,
+                    dayId,
+                    apiEvent.name,
+                    apiEvent.place,
+                    apiEvent.experienceLevel,
+                    map(speakers, toSpeakerName())
+            );
+        };
+    }
+
+    private List<FirebaseSpeaker> speakersForEvent(FirebaseEvent apiEvent, FirebaseSpeakers apiSpeakers) {
+        return map(apiEvent.speakers, speakerId -> findSpeaker(apiSpeakers, speakerId));
+    }
+
+    private FirebaseSpeaker findSpeaker(FirebaseSpeakers apiSpeakers, long speakerId) {
+        return find(apiSpeakers.speakers, apiSpeaker -> apiSpeaker.speakerId.equals(speakerId));
+    }
+
+    private Lists.Function<FirebaseSpeaker, String> toSpeakerName() {
+        return apiSpeaker -> apiSpeaker != null ? apiSpeaker.firstName + " " + apiSpeaker.lastName : null;
     }
 }

--- a/app/src/main/java/net/squanchy/schedule/ScheduleService.java
+++ b/app/src/main/java/net/squanchy/schedule/ScheduleService.java
@@ -35,11 +35,11 @@ class ScheduleService {
         return Observable.combineLatest(
                 sessionsObservable,
                 speakersObservable,
-                composeIntoSchedule()
+                combineIntoSchedule()
         ).subscribeOn(Schedulers.io());
     }
 
-    private BiFunction<FirebaseSchedule, FirebaseSpeakers, Schedule> composeIntoSchedule() {
+    private BiFunction<FirebaseSchedule, FirebaseSpeakers, Schedule> combineIntoSchedule() {
         return (apiSchedule, apiSpeakers) -> {
             List<SchedulePage> pages = map(apiSchedule.days, toSchedulePage(apiSchedule, apiSpeakers));
             return Schedule.create(pages);

--- a/app/src/main/java/net/squanchy/schedule/ScheduleService.java
+++ b/app/src/main/java/net/squanchy/schedule/ScheduleService.java
@@ -6,11 +6,15 @@ import net.squanchy.schedule.domain.view.Event;
 import net.squanchy.schedule.domain.view.Schedule;
 import net.squanchy.schedule.domain.view.SchedulePage;
 import net.squanchy.service.firebase.FirebaseSquanchyRepository;
+import net.squanchy.service.firebase.model.FirebaseDay;
 import net.squanchy.service.firebase.model.FirebaseEvent;
+import net.squanchy.service.firebase.model.FirebaseSchedule;
 import net.squanchy.service.firebase.model.FirebaseSpeaker;
+import net.squanchy.service.firebase.model.FirebaseSpeakers;
+import net.squanchy.support.lang.Lists;
 
 import io.reactivex.Observable;
-import io.reactivex.schedulers.Schedulers;
+import io.reactivex.functions.BiFunction;
 
 import static net.squanchy.support.lang.Lists.find;
 import static net.squanchy.support.lang.Lists.map;
@@ -24,33 +28,52 @@ class ScheduleService {
     }
 
     public Observable<Schedule> schedule() {
-        Observable<FirebaseEvent.Holder> eventObservable = repository.sessions();
-        Observable<FirebaseSpeaker.Holder> speakersObservable = repository.speakers();
+        Observable<FirebaseSchedule> eventObservable = repository.sessions();
+        Observable<FirebaseSpeakers> speakersObservable = repository.speakers();
 
         return Observable.combineLatest(
                 eventObservable,
                 speakersObservable,
-                (eventHolder, speakerHolder) -> {
+                composeIntoSchedule()
+        );
+    }
 
-                    List<SchedulePage> pages = map(eventHolder.days, day -> SchedulePage.create(
-                            day.date,
-                            map(day.events, firebaseEvent -> Event.create(
-                                    firebaseEvent.eventId,
-                                    eventHolder.days.indexOf(day),      // TODO do this less crappily
-                                    firebaseEvent.name,
-                                    firebaseEvent.place,
-                                    firebaseEvent.experienceLevel,
-                                    map(
-                                            map(firebaseEvent.speakers, speakerId -> find(
-                                                    speakerHolder.speakers, speaker -> speaker.speakerId.equals(speakerId))
-                                            ),
-                                            speaker -> speaker == null ? "" : speaker.firstName + " " + speaker.lastName
-                                    ))
-                            )
-                    ));
+    private BiFunction<FirebaseSchedule, FirebaseSpeakers, Schedule> composeIntoSchedule() {
+        return (eventHolder, speakerHolder) -> {
+            List<SchedulePage> pages = map(eventHolder.days, toSchedulePage(eventHolder, speakerHolder));
+            return Schedule.create(pages);
+        };
+    }
 
-                    return Schedule.create(pages);
-                }
-        ).subscribeOn(Schedulers.io());
+    private Lists.Function<FirebaseDay, SchedulePage> toSchedulePage(FirebaseSchedule eventHolder, FirebaseSpeakers speakerHolder) {
+        return day -> SchedulePage.create(
+                day.date,
+                map(day.events, toEvent(eventHolder, speakerHolder, day))
+        );
+    }
+
+    private Lists.Function<FirebaseEvent, Event> toEvent(FirebaseSchedule eventHolder, FirebaseSpeakers speakerHolder, FirebaseDay day) {
+        return firebaseEvent -> {
+            List<FirebaseSpeaker> speakers = speakersForEvent(firebaseEvent, speakerHolder);
+            return Event.create(
+                    firebaseEvent.eventId,
+                    eventHolder.days.indexOf(day),      // TODO do this less crappily
+                    firebaseEvent.name,
+                    firebaseEvent.place,
+                    firebaseEvent.experienceLevel,
+                    map(speakers, toSpeakerName()));
+        };
+    }
+
+    private List<FirebaseSpeaker> speakersForEvent(FirebaseEvent firebaseEvent, FirebaseSpeakers speakerHolder) {
+        return map(firebaseEvent.speakers, speakerId -> findSpeaker(speakerHolder, speakerId));
+    }
+
+    private FirebaseSpeaker findSpeaker(FirebaseSpeakers speakerHolder, Long speakerId) {
+        return find(speakerHolder.speakers, speaker -> speaker.speakerId.equals(speakerId));
+    }
+
+    private Lists.Function<FirebaseSpeaker, String> toSpeakerName() {
+        return firebaseSpeaker -> firebaseSpeaker != null ? firebaseSpeaker.firstName + " " + firebaseSpeaker.lastName : null;
     }
 }

--- a/app/src/main/java/net/squanchy/service/firebase/FirebaseSquanchyRepository.java
+++ b/app/src/main/java/net/squanchy/service/firebase/FirebaseSquanchyRepository.java
@@ -6,15 +6,16 @@ import com.google.firebase.database.DatabaseReference;
 import com.google.firebase.database.ValueEventListener;
 
 import net.squanchy.service.firebase.model.FirebaseEvent;
-import net.squanchy.service.firebase.model.FirebaseFloorPlan;
-import net.squanchy.service.firebase.model.FirebaseInfoItem;
-import net.squanchy.service.firebase.model.FirebaseLevel;
-import net.squanchy.service.firebase.model.FirebaseLocation;
-import net.squanchy.service.firebase.model.FirebasePoi;
+import net.squanchy.service.firebase.model.FirebaseFloorPlans;
+import net.squanchy.service.firebase.model.FirebaseInfoItems;
+import net.squanchy.service.firebase.model.FirebaseLevels;
+import net.squanchy.service.firebase.model.FirebaseLocations;
+import net.squanchy.service.firebase.model.FirebasePois;
+import net.squanchy.service.firebase.model.FirebaseSchedule;
 import net.squanchy.service.firebase.model.FirebaseSettings;
-import net.squanchy.service.firebase.model.FirebaseSpeaker;
-import net.squanchy.service.firebase.model.FirebaseTrack;
-import net.squanchy.service.firebase.model.FirebaseType;
+import net.squanchy.service.firebase.model.FirebaseSpeakers;
+import net.squanchy.service.firebase.model.FirebaseTracks;
+import net.squanchy.service.firebase.model.FirebaseTypes;
 
 import io.reactivex.Observable;
 import io.reactivex.ObservableEmitter;
@@ -28,48 +29,48 @@ public final class FirebaseSquanchyRepository {
         this.database = database;
     }
 
-    public Observable<FirebaseSettings.Holder> settings() {
-        return observeChild("settings", FirebaseSettings.Holder.class);
+    public Observable<FirebaseSettings> settings() {
+        return observeChild("settings", FirebaseSettings.class);
     }
 
-    public Observable<FirebaseFloorPlan.Holder> floorPlans() {
-        return observeChild("floorPlans", FirebaseFloorPlan.Holder.class);
+    public Observable<FirebaseFloorPlans> floorPlans() {
+        return observeChild("floorPlans", FirebaseFloorPlans.class);
     }
 
-    public Observable<FirebaseInfoItem.General> info() {
-        return observeChild("info", FirebaseInfoItem.General.class);
+    public Observable<FirebaseInfoItems> info() {
+        return observeChild("info", FirebaseInfoItems.class);
     }
 
-    public Observable<FirebaseLevel.Holder> levels() {
-        return observeChild("levels", FirebaseLevel.Holder.class);
+    public Observable<FirebaseLevels> levels() {
+        return observeChild("levels", FirebaseLevels.class);
     }
 
-    public Observable<FirebaseLocation.Holder> locations() {
-        return observeChild("locations", FirebaseLocation.Holder.class);
+    public Observable<FirebaseLocations> locations() {
+        return observeChild("locations", FirebaseLocations.class);
     }
 
-    public Observable<FirebasePoi.Holder> pois() {
-        return observeChild("pois", FirebasePoi.Holder.class);
+    public Observable<FirebasePois> pois() {
+        return observeChild("pois", FirebasePois.class);
     }
 
-    public Observable<FirebaseSpeaker.Holder> speakers() {
-        return observeChild("speakers", FirebaseSpeaker.Holder.class);
+    public Observable<FirebaseSpeakers> speakers() {
+        return observeChild("speakers", FirebaseSpeakers.class);
     }
 
-    public Observable<FirebaseTrack.Holder> tracks() {
-        return observeChild("tracks", FirebaseTrack.Holder.class);
+    public Observable<FirebaseTracks> tracks() {
+        return observeChild("tracks", FirebaseTracks.class);
     }
 
-    public Observable<FirebaseType.Holder> types() {
-        return observeChild("types", FirebaseType.Holder.class);
+    public Observable<FirebaseTypes> types() {
+        return observeChild("types", FirebaseTypes.class);
     }
 
-    public Observable<FirebaseEvent.Holder> socialEvents() {
-        return observeChild("socialEvents", FirebaseEvent.Holder.class);
+    public Observable<FirebaseSchedule> socialEvents() {
+        return observeChild("socialEvents", FirebaseSchedule.class);
     }
 
-    public Observable<FirebaseEvent.Holder> sessions() {
-        return observeChild("sessions", FirebaseEvent.Holder.class);
+    public Observable<FirebaseSchedule> sessions() {
+        return observeChild("sessions", FirebaseSchedule.class);
     }
 
     public Observable<FirebaseEvent> event(int dayId, int eventId) {

--- a/app/src/main/java/net/squanchy/service/firebase/model/FirebaseDay.java
+++ b/app/src/main/java/net/squanchy/service/firebase/model/FirebaseDay.java
@@ -1,0 +1,14 @@
+package net.squanchy.service.firebase.model;
+
+import java.util.List;
+
+public class FirebaseDay {
+
+    public String date;
+
+    public List<FirebaseEvent> programEvents;
+
+    public List<FirebaseEvent> bofsEvents;
+
+    public List<FirebaseEvent> events;
+}

--- a/app/src/main/java/net/squanchy/service/firebase/model/FirebaseEvent.java
+++ b/app/src/main/java/net/squanchy/service/firebase/model/FirebaseEvent.java
@@ -31,21 +31,4 @@ public class FirebaseEvent {
     public Boolean deleted;
 
     public String version;
-
-    public static class Holder {
-
-        public List<Day> days;
-
-    }
-
-    public static class Day {
-
-        public String date;
-
-        public List<FirebaseEvent> programEvents;
-
-        public List<FirebaseEvent> bofsEvents;
-
-        public List<FirebaseEvent> events;
-    }
 }

--- a/app/src/main/java/net/squanchy/service/firebase/model/FirebaseFloorPlan.java
+++ b/app/src/main/java/net/squanchy/service/firebase/model/FirebaseFloorPlan.java
@@ -1,16 +1,10 @@
 package net.squanchy.service.firebase.model;
 
-import java.util.List;
-
 public class FirebaseFloorPlan {
+
     public Long floorPlanId;
     public String floorPlanName;
     public String floorPlanImageURL;
     public Boolean deleted;
     public Long order;
-
-    public static class Holder {
-
-        public List<FirebaseFloorPlan> floorPlans;
-    }
 }

--- a/app/src/main/java/net/squanchy/service/firebase/model/FirebaseFloorPlans.java
+++ b/app/src/main/java/net/squanchy/service/firebase/model/FirebaseFloorPlans.java
@@ -1,0 +1,8 @@
+package net.squanchy.service.firebase.model;
+
+import java.util.List;
+
+public class FirebaseFloorPlans {
+
+    public List<FirebaseFloorPlan> floorPlans;
+}

--- a/app/src/main/java/net/squanchy/service/firebase/model/FirebaseInfoItem.java
+++ b/app/src/main/java/net/squanchy/service/firebase/model/FirebaseInfoItem.java
@@ -1,8 +1,5 @@
 package net.squanchy.service.firebase.model;
 
-import java.util.HashMap;
-import java.util.List;
-
 public class FirebaseInfoItem {
 
     public Long infoId;
@@ -14,13 +11,4 @@ public class FirebaseInfoItem {
     public Long order;
 
     public Boolean deleted;
-
-    public static class General {
-
-        public HashMap<String, String> title;
-
-        public List<FirebaseInfoItem> info;
-
-    }
-
 }

--- a/app/src/main/java/net/squanchy/service/firebase/model/FirebaseInfoItems.java
+++ b/app/src/main/java/net/squanchy/service/firebase/model/FirebaseInfoItems.java
@@ -1,0 +1,11 @@
+package net.squanchy.service.firebase.model;
+
+import java.util.HashMap;
+import java.util.List;
+
+public class FirebaseInfoItems {
+
+    public HashMap<String, String> title;
+
+    public List<FirebaseInfoItem> info;
+}

--- a/app/src/main/java/net/squanchy/service/firebase/model/FirebaseLevel.java
+++ b/app/src/main/java/net/squanchy/service/firebase/model/FirebaseLevel.java
@@ -1,7 +1,5 @@
 package net.squanchy.service.firebase.model;
 
-import java.util.List;
-
 public class FirebaseLevel {
 
     public Long levelId;
@@ -11,10 +9,4 @@ public class FirebaseLevel {
     public Long order;
 
     public Boolean deleted;
-
-    public static class Holder {
-
-        public List<FirebaseLevel> levels;
-
-    }
 }

--- a/app/src/main/java/net/squanchy/service/firebase/model/FirebaseLevels.java
+++ b/app/src/main/java/net/squanchy/service/firebase/model/FirebaseLevels.java
@@ -1,0 +1,8 @@
+package net.squanchy.service.firebase.model;
+
+import java.util.List;
+
+public class FirebaseLevels {
+
+    public List<FirebaseLevel> levels;
+}

--- a/app/src/main/java/net/squanchy/service/firebase/model/FirebaseLocation.java
+++ b/app/src/main/java/net/squanchy/service/firebase/model/FirebaseLocation.java
@@ -1,7 +1,5 @@
 package net.squanchy.service.firebase.model;
 
-import java.util.List;
-
 public class FirebaseLocation {
 
     public Long locationId;
@@ -19,9 +17,4 @@ public class FirebaseLocation {
     public Long order;
 
     public Boolean deleted;
-
-    public static class Holder {
-
-        public List<FirebaseLocation> locations;
-    }
 }

--- a/app/src/main/java/net/squanchy/service/firebase/model/FirebaseLocations.java
+++ b/app/src/main/java/net/squanchy/service/firebase/model/FirebaseLocations.java
@@ -1,0 +1,8 @@
+package net.squanchy.service.firebase.model;
+
+import java.util.List;
+
+public class FirebaseLocations {
+
+    public List<FirebaseLocation> locations;
+}

--- a/app/src/main/java/net/squanchy/service/firebase/model/FirebasePoi.java
+++ b/app/src/main/java/net/squanchy/service/firebase/model/FirebasePoi.java
@@ -1,7 +1,5 @@
 package net.squanchy.service.firebase.model;
 
-import java.util.List;
-
 public class FirebasePoi {
 
     public Long poiId;
@@ -17,10 +15,4 @@ public class FirebasePoi {
     public Long order;
 
     public Boolean deleted;
-
-    public static class Holder {
-
-        public List<FirebasePoi> poi;
-
-    }
 }

--- a/app/src/main/java/net/squanchy/service/firebase/model/FirebasePois.java
+++ b/app/src/main/java/net/squanchy/service/firebase/model/FirebasePois.java
@@ -1,0 +1,8 @@
+package net.squanchy.service.firebase.model;
+
+import java.util.List;
+
+public class FirebasePois {
+
+    public List<FirebasePoi> poi;
+}

--- a/app/src/main/java/net/squanchy/service/firebase/model/FirebaseSchedule.java
+++ b/app/src/main/java/net/squanchy/service/firebase/model/FirebaseSchedule.java
@@ -1,0 +1,8 @@
+package net.squanchy.service.firebase.model;
+
+import java.util.List;
+
+public class FirebaseSchedule {
+
+    public List<FirebaseDay> days;
+}

--- a/app/src/main/java/net/squanchy/service/firebase/model/FirebaseSettings.java
+++ b/app/src/main/java/net/squanchy/service/firebase/model/FirebaseSettings.java
@@ -11,10 +11,4 @@ public class FirebaseSettings {
     public String timeZone;
 
     public String twitterSearchQuery;
-
-    public static class Holder {
-
-        public FirebaseSettings settings;
-
-    }
 }

--- a/app/src/main/java/net/squanchy/service/firebase/model/FirebaseSpeaker.java
+++ b/app/src/main/java/net/squanchy/service/firebase/model/FirebaseSpeaker.java
@@ -1,7 +1,5 @@
 package net.squanchy.service.firebase.model;
 
-import java.util.List;
-
 public class FirebaseSpeaker {
 
     public Long speakerId;
@@ -27,10 +25,4 @@ public class FirebaseSpeaker {
     public Boolean deleted;
 
     public String email;
-
-    public static class Holder {
-
-        public List<FirebaseSpeaker> speakers;
-
-    }
 }

--- a/app/src/main/java/net/squanchy/service/firebase/model/FirebaseSpeakers.java
+++ b/app/src/main/java/net/squanchy/service/firebase/model/FirebaseSpeakers.java
@@ -1,0 +1,8 @@
+package net.squanchy.service.firebase.model;
+
+import java.util.List;
+
+public class FirebaseSpeakers {
+
+    public List<FirebaseSpeaker> speakers;
+}

--- a/app/src/main/java/net/squanchy/service/firebase/model/FirebaseTrack.java
+++ b/app/src/main/java/net/squanchy/service/firebase/model/FirebaseTrack.java
@@ -1,7 +1,5 @@
 package net.squanchy.service.firebase.model;
 
-import java.util.List;
-
 public class FirebaseTrack {
 
     public Long trackId;
@@ -11,10 +9,4 @@ public class FirebaseTrack {
     public Long order;
 
     public Boolean deleted;
-
-    public static class Holder {
-
-        public List<FirebaseTrack> tracks;
-
-    }
 }

--- a/app/src/main/java/net/squanchy/service/firebase/model/FirebaseTracks.java
+++ b/app/src/main/java/net/squanchy/service/firebase/model/FirebaseTracks.java
@@ -1,0 +1,8 @@
+package net.squanchy.service.firebase.model;
+
+import java.util.List;
+
+public class FirebaseTracks {
+
+    public List<FirebaseTrack> tracks;
+}

--- a/app/src/main/java/net/squanchy/service/firebase/model/FirebaseType.java
+++ b/app/src/main/java/net/squanchy/service/firebase/model/FirebaseType.java
@@ -1,7 +1,5 @@
 package net.squanchy.service.firebase.model;
 
-import java.util.List;
-
 public class FirebaseType {
 
     public Long typeId;
@@ -13,11 +11,4 @@ public class FirebaseType {
     public Long order;
 
     public Boolean deleted;
-
-    public static class Holder {
-
-        public List<FirebaseType> types;
-
-    }
-
 }

--- a/app/src/main/java/net/squanchy/service/firebase/model/FirebaseTypes.java
+++ b/app/src/main/java/net/squanchy/service/firebase/model/FirebaseTypes.java
@@ -1,0 +1,8 @@
+package net.squanchy.service.firebase.model;
+
+import java.util.List;
+
+public class FirebaseTypes {
+
+    public List<FirebaseType> types;
+}


### PR DESCRIPTION
This PR refactors the services (schedule and event details) extracting methods to make the logic more readable, and renames the (view)models to drop their Connfa-originated names and adopt names that actually represent what they are.