### PR TITLE
SQ-51/Add event details items to UI (part 1)

### DIFF
--- a/app/src/main/java/net/squanchy/eventdetails/EventDetailsActivity.java
+++ b/app/src/main/java/net/squanchy/eventdetails/EventDetailsActivity.java
@@ -5,9 +5,9 @@ import android.content.Intent;
 import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.Toolbar;
-import android.widget.Toast;
 
 import net.squanchy.R;
+import net.squanchy.eventdetails.widget.EventDetailsCoordinatorLayout;
 
 import io.reactivex.android.schedulers.AndroidSchedulers;
 import io.reactivex.disposables.Disposable;
@@ -19,6 +19,7 @@ public class EventDetailsActivity extends AppCompatActivity {
 
     private EventDetailsService service;
     private Disposable subscription;
+    private EventDetailsCoordinatorLayout coordinatorLayout;
 
     public static Intent createIntent(Context context, int dayId, int eventId) {
         Intent intent = new Intent(context, EventDetailsActivity.class);
@@ -38,6 +39,8 @@ public class EventDetailsActivity extends AppCompatActivity {
 
         EventDetailsComponent component = EventDetailsInjector.obtain(this);
         service = component.service();
+
+        coordinatorLayout = (EventDetailsCoordinatorLayout) findViewById(R.id.event_details_root);
     }
 
     @Override
@@ -47,9 +50,10 @@ public class EventDetailsActivity extends AppCompatActivity {
         Intent intent = getIntent();
         int dayId = intent.getIntExtra(EXTRA_DAY, -1);
         int eventId = intent.getIntExtra(EXTRA_EVENT_ID, -1);
+
         subscription = service.event(dayId, eventId)
                 .observeOn(AndroidSchedulers.mainThread())
-                .subscribe(event -> Toast.makeText(this, "Event: " + event, Toast.LENGTH_LONG).show());
+                .subscribe(event -> coordinatorLayout.updateWith(event));
     }
 
     @Override

--- a/app/src/main/java/net/squanchy/eventdetails/domain/view/ExperienceLevel.java
+++ b/app/src/main/java/net/squanchy/eventdetails/domain/view/ExperienceLevel.java
@@ -1,0 +1,30 @@
+package net.squanchy.eventdetails.domain.view;
+
+import android.support.annotation.IntRange;
+import android.support.annotation.StringRes;
+
+import net.squanchy.R;
+
+public enum ExperienceLevel {
+    BEGINNER(0, R.string.experience_level_beginner),
+    INTERMEDIATE(1, R.string.experience_level_intermediate),
+    ADVANCED(2, R.string.experience_level_advanced);
+
+    private final int rawLevel;
+    private final int labelStringResId;
+
+    ExperienceLevel(int rawLevel, @StringRes int labelStringResId) {
+        this.rawLevel = rawLevel;
+        this.labelStringResId = labelStringResId;
+    }
+
+    @IntRange(from = 0, to = 2)
+    public int rawLevel() {
+        return rawLevel;
+    }
+
+    @StringRes
+    public int labelStringResId() {
+        return labelStringResId;
+    }
+}

--- a/app/src/main/java/net/squanchy/eventdetails/widget/EventDetailsCoordinatorLayout.java
+++ b/app/src/main/java/net/squanchy/eventdetails/widget/EventDetailsCoordinatorLayout.java
@@ -1,0 +1,35 @@
+package net.squanchy.eventdetails.widget;
+
+import android.content.Context;
+import android.support.design.widget.CoordinatorLayout;
+import android.support.design.widget.FloatingActionButton;
+import android.util.AttributeSet;
+
+import net.squanchy.R;
+import net.squanchy.schedule.domain.view.Event;
+
+public class EventDetailsCoordinatorLayout extends CoordinatorLayout {
+
+    private FloatingActionButton floatingActionButton;
+    private EventDetailsHeaderLayout headerLayout;
+
+    public EventDetailsCoordinatorLayout(Context context, AttributeSet attrs) {
+        this(context, attrs, 0);
+    }
+
+    public EventDetailsCoordinatorLayout(Context context, AttributeSet attrs, int defStyleAttr) {
+        super(context, attrs, defStyleAttr);
+    }
+
+    @Override
+    protected void onFinishInflate() {
+        super.onFinishInflate();
+
+        floatingActionButton = (FloatingActionButton) findViewById(R.id.favorite_fab);
+        headerLayout = (EventDetailsHeaderLayout) findViewById(R.id.event_details_header);
+    }
+
+    public void updateWith(Event event) {
+        headerLayout.updateWith(event);
+    }
+}

--- a/app/src/main/java/net/squanchy/eventdetails/widget/EventDetailsCoordinatorLayout.java
+++ b/app/src/main/java/net/squanchy/eventdetails/widget/EventDetailsCoordinatorLayout.java
@@ -12,6 +12,7 @@ public class EventDetailsCoordinatorLayout extends CoordinatorLayout {
 
     private FloatingActionButton floatingActionButton;
     private EventDetailsHeaderLayout headerLayout;
+    private EventDetailsLayout detailsLayout;
 
     public EventDetailsCoordinatorLayout(Context context, AttributeSet attrs) {
         this(context, attrs, 0);
@@ -27,9 +28,11 @@ public class EventDetailsCoordinatorLayout extends CoordinatorLayout {
 
         floatingActionButton = (FloatingActionButton) findViewById(R.id.favorite_fab);
         headerLayout = (EventDetailsHeaderLayout) findViewById(R.id.event_details_header);
+        detailsLayout = (EventDetailsLayout) findViewById(R.id.event_details);
     }
 
     public void updateWith(Event event) {
         headerLayout.updateWith(event);
+        detailsLayout.updateWith(event);
     }
 }

--- a/app/src/main/java/net/squanchy/eventdetails/widget/EventDetailsHeaderLayout.java
+++ b/app/src/main/java/net/squanchy/eventdetails/widget/EventDetailsHeaderLayout.java
@@ -1,0 +1,22 @@
+package net.squanchy.eventdetails.widget;
+
+import android.content.Context;
+import android.support.design.widget.CollapsingToolbarLayout;
+import android.util.AttributeSet;
+
+import net.squanchy.schedule.domain.view.Event;
+
+public class EventDetailsHeaderLayout extends CollapsingToolbarLayout {
+
+    public EventDetailsHeaderLayout(Context context, AttributeSet attrs) {
+        this(context, attrs, 0);
+    }
+
+    public EventDetailsHeaderLayout(Context context, AttributeSet attrs, int defStyleAttr) {
+        super(context, attrs, defStyleAttr);
+    }
+
+    void updateWith(Event event) {
+        setTitle(event.title());
+    }
+}

--- a/app/src/main/java/net/squanchy/eventdetails/widget/EventDetailsLayout.java
+++ b/app/src/main/java/net/squanchy/eventdetails/widget/EventDetailsLayout.java
@@ -1,0 +1,59 @@
+package net.squanchy.eventdetails.widget;
+
+import android.content.Context;
+import android.support.annotation.Nullable;
+import android.util.AttributeSet;
+import android.view.View;
+import android.widget.LinearLayout;
+import android.widget.TextView;
+
+import net.squanchy.R;
+import net.squanchy.eventdetails.domain.view.ExperienceLevel;
+import net.squanchy.schedule.domain.view.Event;
+
+public class EventDetailsLayout extends LinearLayout {
+
+    private TextView placeView;
+    private TextView speakersView;
+    private TextView trackView;
+    private ExperienceLevelIconView experienceLevelIconView;
+    private TextView experienceLevelLabelView;
+
+    public EventDetailsLayout(Context context, @Nullable AttributeSet attrs) {
+        this(context, attrs, 0);
+    }
+
+    public EventDetailsLayout(Context context, @Nullable AttributeSet attrs, int defStyle) {
+        super(context, attrs, defStyle);
+        super.setOrientation(VERTICAL);
+    }
+
+    @Override
+    public void setOrientation(int orientation) {
+        throw new UnsupportedOperationException("Changing orientation is not supported for EventDetailsLayout");
+    }
+
+    @Override
+    protected void onFinishInflate() {
+        super.onFinishInflate();
+
+        View.inflate(getContext(), R.layout.merge_event_details_layout, this);
+
+        placeView = (TextView) findViewById(R.id.place_view);
+        speakersView = (TextView) findViewById(R.id.speakers_view);
+        trackView = (TextView) findViewById(R.id.track_view);
+        experienceLevelIconView = (ExperienceLevelIconView) findViewById(R.id.experience_level_icon);
+        experienceLevelLabelView = (TextView) findViewById(R.id.experience_level_label);
+    }
+
+    public void updateWith(Event event) {
+        // TODO create proper EventDetails model that we can use here
+        placeView.setVisibility(event.placeVisibility());
+        placeView.setText(event.place());
+        speakersView.setVisibility(event.speakersVisibility());
+        speakersView.setText(event.speakers());
+        trackView.setVisibility(event.trackVisibility());
+        experienceLevelIconView.setExperienceLevel(ExperienceLevel.BEGINNER);
+        experienceLevelLabelView.setText(ExperienceLevel.BEGINNER.labelStringResId());
+    }
+}

--- a/app/src/main/java/net/squanchy/eventdetails/widget/ExperienceLevelIconView.java
+++ b/app/src/main/java/net/squanchy/eventdetails/widget/ExperienceLevelIconView.java
@@ -1,0 +1,32 @@
+package net.squanchy.eventdetails.widget;
+
+import android.content.Context;
+import android.graphics.drawable.Drawable;
+import android.util.AttributeSet;
+import android.widget.ImageView;
+
+import net.squanchy.R;
+import net.squanchy.eventdetails.domain.view.ExperienceLevel;
+
+public class ExperienceLevelIconView extends ImageView {
+
+    public ExperienceLevelIconView(Context context, AttributeSet attrs) {
+        this(context, attrs, 0);
+    }
+
+    public ExperienceLevelIconView(Context context, AttributeSet attrs, int defStyleAttr) {
+        super(context, attrs, defStyleAttr);
+    }
+
+    @Override
+    protected void onFinishInflate() {
+        super.onFinishInflate();
+
+        super.setImageResource(R.drawable.ic_experience);
+    }
+
+    public void setExperienceLevel(ExperienceLevel experienceLevel) {
+        Drawable drawable = getDrawable();
+        drawable.setLevel(experienceLevel.rawLevel());
+    }
+}

--- a/app/src/main/java/net/squanchy/speaker/view/SpeakerAdapter.java
+++ b/app/src/main/java/net/squanchy/speaker/view/SpeakerAdapter.java
@@ -15,7 +15,7 @@ import net.squanchy.speaker.Speaker;
 
 class SpeakerAdapter extends RecyclerView.Adapter<SpeakerViewHolder> {
 
-    private List<Speaker> speakerList = Collections.emptyList();
+    private List<Speaker> speakers = Collections.emptyList();
     @Nullable
     private SpeakersView.OnSpeakerClickedListener listener;
     private final Context context;
@@ -25,13 +25,18 @@ class SpeakerAdapter extends RecyclerView.Adapter<SpeakerViewHolder> {
         setHasStableIds(true);
     }
 
-    public void updateWith(List<Speaker> speakerList, @Nullable SpeakersView.OnSpeakerClickedListener listener) {
-        this.speakerList = speakerList;
-        this.listener = listener;
+    @Override
+    public long getItemId(int position) {
+        return speakers.get(position).id();
     }
 
     public List<Speaker> speakers() {
-        return speakerList;
+        return speakers;
+    }
+
+    public void updateWith(List<Speaker> speakerList, @Nullable SpeakersView.OnSpeakerClickedListener listener) {
+        this.speakers = speakerList;
+        this.listener = listener;
     }
 
     @Override
@@ -42,11 +47,11 @@ class SpeakerAdapter extends RecyclerView.Adapter<SpeakerViewHolder> {
 
     @Override
     public void onBindViewHolder(SpeakerViewHolder holder, int position) {
-        holder.updateWith(speakerList.get(position), listener);
+        holder.updateWith(speakers.get(position), listener);
     }
 
     @Override
     public int getItemCount() {
-        return speakerList.size();
+        return speakers.size();
     }
 }

--- a/app/src/main/java/net/squanchy/speaker/view/SpeakersView.java
+++ b/app/src/main/java/net/squanchy/speaker/view/SpeakersView.java
@@ -16,7 +16,7 @@ public class SpeakersView extends RecyclerView {
     private SpeakerAdapter adapter;
 
     public SpeakersView(Context context, @Nullable AttributeSet attrs) {
-        super(context, attrs);
+        this(context, attrs, 0);
     }
 
     public SpeakersView(Context context, @Nullable AttributeSet attrs, int defStyle) {
@@ -35,7 +35,7 @@ public class SpeakersView extends RecyclerView {
     }
 
     public void updateWith(List<Speaker> newData, OnSpeakerClickedListener listener) {
-        DiffUtil.Callback callback = new SpeakerDiffCallback(adapter.speakers(), newData);
+        DiffUtil.Callback callback = new SpeakerDiffCallback(adapter.speakers(), newData);       // TODO move off of the UI thread
         DiffUtil.DiffResult diffResult = DiffUtil.calculateDiff(callback, true);
         adapter.updateWith(newData, listener);
         diffResult.dispatchUpdatesTo(adapter);
@@ -68,16 +68,16 @@ public class SpeakersView extends RecyclerView {
 
         @Override
         public boolean areItemsTheSame(int oldItemPosition, int newItemPosition) {
-            Speaker oldEvent = oldSpeakers.get(oldItemPosition);
-            Speaker newEvent = newSpeakers.get(newItemPosition);
-            return oldEvent.id() == newEvent.id();
+            Speaker oldSpeaker = oldSpeakers.get(oldItemPosition);
+            Speaker newSpeaker = newSpeakers.get(newItemPosition);
+            return oldSpeaker.id() == newSpeaker.id();
         }
 
         @Override
         public boolean areContentsTheSame(int oldItemPosition, int newItemPosition) {
-            Speaker oldEvent = oldSpeakers.get(oldItemPosition);
-            Speaker newEvent = newSpeakers.get(newItemPosition);
-            return oldEvent.equals(newEvent);
+            Speaker oldSpeaker = oldSpeakers.get(oldItemPosition);
+            Speaker newSpeaker = newSpeakers.get(newItemPosition);
+            return oldSpeaker.equals(newSpeaker);
         }
     }
 }

--- a/app/src/main/res/drawable/ic_experience.xml
+++ b/app/src/main/res/drawable/ic_experience.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<level-list xmlns:android="http://schemas.android.com/apk/res/android">
+
+  <item
+    android:minLevel="0"
+    android:maxLevel="0"
+    android:drawable="@drawable/ic_experience_beginner" />
+
+  <item
+    android:minLevel="1"
+    android:maxLevel="1"
+    android:drawable="@drawable/ic_experience_intermediate" />
+
+  <item
+    android:minLevel="2"
+    android:maxLevel="2"
+    android:drawable="@drawable/ic_experience_advanced" />
+
+</level-list>

--- a/app/src/main/res/layout/activity_event_details.xml
+++ b/app/src/main/res/layout/activity_event_details.xml
@@ -50,7 +50,7 @@
     android:layout_height="match_parent"
     app:layout_behavior="@string/appbar_scrolling_view_behavior">
 
-    <net.squanchy.eventdetails.widget.EventDetailsView
+    <net.squanchy.eventdetails.widget.EventDetailsLayout
       android:id="@+id/event_details"
       android:layout_width="match_parent"
       android:layout_height="wrap_content" />

--- a/app/src/main/res/layout/activity_event_details.xml
+++ b/app/src/main/res/layout/activity_event_details.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.design.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<net.squanchy.eventdetails.widget.EventDetailsCoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
   xmlns:app="http://schemas.android.com/apk/res-auto"
+  android:id="@+id/event_details_root"
   android:layout_width="match_parent"
   android:layout_height="match_parent"
   android:fitsSystemWindows="true">
@@ -12,8 +13,8 @@
     android:layout_height="wrap_content"
     android:fitsSystemWindows="true">
 
-    <android.support.design.widget.CollapsingToolbarLayout
-      android:id="@+id/collapsing_toolbar"
+    <net.squanchy.eventdetails.widget.EventDetailsHeaderLayout
+      android:id="@+id/event_details_header"
       android:layout_width="match_parent"
       android:layout_height="match_parent"
       android:fitsSystemWindows="true"
@@ -37,9 +38,10 @@
         android:layout_width="match_parent"
         android:layout_height="?attr/actionBarSize"
         app:layout_collapseMode="pin"
+        app:titleTextColor="?android:textColorPrimary"
         app:popupTheme="@style/ThemeOverlay.AppCompat.Light" />
 
-    </android.support.design.widget.CollapsingToolbarLayout>
+    </net.squanchy.eventdetails.widget.EventDetailsHeaderLayout>
 
   </android.support.design.widget.AppBarLayout>
 
@@ -48,20 +50,10 @@
     android:layout_height="match_parent"
     app:layout_behavior="@string/appbar_scrolling_view_behavior">
 
-    <LinearLayout
+    <net.squanchy.eventdetails.widget.EventDetailsView
+      android:id="@+id/event_details"
       android:layout_width="match_parent"
-      android:layout_height="wrap_content"
-      android:orientation="vertical">
-
-      <TextView
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_margin="16dp"
-        android:paddingBottom="600dp"
-        android:text="Temp test lol stuff what is this I don't even\n\n\n\n\n\nOh hey I can scroll!\n\n\n\n\n\n\nSuch hax0r 👨‍💻"
-        android:textAppearance="@style/TextAppearance.AppCompat.Display1"/>
-
-    </LinearLayout>
+      android:layout_height="wrap_content" />
 
   </android.support.v4.widget.NestedScrollView>
 
@@ -75,4 +67,4 @@
     app:layout_anchor="@id/appbar"
     app:layout_anchorGravity="bottom|end" />
 
-</android.support.design.widget.CoordinatorLayout>
+</net.squanchy.eventdetails.widget.EventDetailsCoordinatorLayout>

--- a/app/src/main/res/layout/merge_event_details_layout.xml
+++ b/app/src/main/res/layout/merge_event_details_layout.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="utf-8"?>
+<merge xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:tools="http://schemas.android.com/tools"
+  tools:layout_width="match_parent"
+  tools:layout_height="match_parent"
+  tools:parentTag="LinearLayout"
+  tools:orientation="vertical">
+
+  <LinearLayout
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="horizontal">
+
+    <net.squanchy.eventdetails.widget.ExperienceLevelIconView
+      android:id="@+id/experience_level_icon"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content" />
+
+    <TextView
+      android:id="@+id/experience_level_label"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:padding="8dp"
+      android:textAppearance="@style/TextAppearance.AppCompat.Body1"
+      tools:text="Android" />
+
+  </LinearLayout>
+
+  <TextView
+    android:id="@+id/track_view"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:padding="8dp"
+    android:textAppearance="@style/TextAppearance.AppCompat.Body1"
+    tools:text="Android" />
+
+  <TextView
+    android:id="@+id/place_view"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:drawableStart="@drawable/ic_place"
+    android:padding="8dp"
+    android:textAppearance="@style/TextAppearance.AppCompat.Body1"
+    tools:text="Big room, 1st floor" />
+
+  <TextView
+    android:id="@+id/speakers_view"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:drawableStart="@drawable/ic_speakers"
+    android:padding="8dp"
+    android:textAppearance="@style/TextAppearance.AppCompat.Body1"
+    tools:text="Otto Von Bismark, Ruby Rubacuori, Ivan The Terrible" />
+
+</merge>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -10,7 +10,10 @@
   <string name="social_events">Social Events</string>
   <string name="search">Search</string>
   <string name="filter">Filter</string>
-  <string name="experience_level">Experience level:</string>
+  <string name="experience_level">Experience level: %s</string>
+  <string name="experience_level_beginner">beginner</string>
+  <string name="experience_level_intermediate">intermediate</string>
+  <string name="experience_level_advanced">advanced</string>
   <string name="tracks">Tracks</string>
   <string name="exp_levels">Experience Levels</string>
   <string name="NoConnectionMessage">Internet connection is not available at this moment. Please, try later</string>


### PR DESCRIPTION
This PR begins adding the views we need to populate the event details. Note that, since there is no proper `EventDetails` viewmodel yet (next PR), we only add a few pieces of information. More work is needed (next PR) to tidy up the layouts and all (resources, styles, etc). This also has some cleanups for `SpeakersAdapter` and related classes.

![screenshot-2017-02-14_21 15 53 907](https://cloud.githubusercontent.com/assets/153802/22949619/c7e76f60-f2fa-11e6-84a5-ce32e3e8e61a.png)
