### PR TITLE
SQ-79/Use new palette 🖌️

### DIFF
--- a/.idea/codeStyleSettings.xml
+++ b/.idea/codeStyleSettings.xml
@@ -28,7 +28,12 @@
           <option name="USE_CUSTOM_SETTINGS" value="true" />
           <option name="VALUE_RESOURCE_FILE_SETTINGS">
             <value>
-              <option name="WRAP_ATTRIBUTES" value="2" />
+              <option name="WRAP_ATTRIBUTES" value="4" />
+            </value>
+          </option>
+          <option name="OTHER_SETTINGS">
+            <value>
+              <option name="WRAP_ATTRIBUTES" value="4" />
             </value>
           </option>
         </AndroidXmlCodeStyleSettings>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -7,7 +7,7 @@
 
   <application
     android:name="net.squanchy.SquanchyApplication"
-    android:theme="@style/Theme.Squanchy.Home"
+    android:theme="@style/Theme.Squanchy"
     android:allowBackup="true"
     android:fullBackupContent="false"
     android:icon="@mipmap/ic_launcher"

--- a/app/src/main/res/layout/activity_schedule.xml
+++ b/app/src/main/res/layout/activity_schedule.xml
@@ -5,27 +5,27 @@
   android:id="@+id/content_root"
   android:layout_width="match_parent"
   android:layout_height="match_parent"
+  android:fitsSystemWindows="true"
   tools:context="net.squanchy.schedule.ScheduleActivity">
 
   <android.support.design.widget.AppBarLayout
     style="@style/Squanchy.Appbar"
     android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content">
+    android:layout_height="wrap_content"
+    android:fitsSystemWindows="false">
 
     <android.support.v7.widget.Toolbar
       android:id="@+id/toolbar"
       android:layout_width="match_parent"
-      android:layout_height="?attr/actionBarSize"
-      app:layout_collapseMode="none" />
+      android:layout_height="?attr/actionBarSize" />
 
     <android.support.design.widget.TabLayout
       android:id="@+id/tabstrip"
       style="@style/Squanchy.Tabs.Schedule"
       android:layout_width="match_parent"
-      android:layout_height="?attr/actionBarSize"
-      app:layout_collapseMode="pin" />
-
+      android:layout_height="?attr/actionBarSize" />
+    
   </android.support.design.widget.AppBarLayout>
 
   <android.support.v4.view.ViewPager

--- a/app/src/main/res/layout/activity_schedule.xml
+++ b/app/src/main/res/layout/activity_schedule.xml
@@ -15,7 +15,6 @@
 
     <android.support.v7.widget.Toolbar
       android:id="@+id/toolbar"
-      style="@style/Squanchy.Toolbar.Schedule"
       android:layout_width="match_parent"
       android:layout_height="?attr/actionBarSize"
       app:layout_collapseMode="none" />

--- a/app/src/main/res/layout/activity_social_feed.xml
+++ b/app/src/main/res/layout/activity_social_feed.xml
@@ -7,7 +7,6 @@
 
   <android.support.v7.widget.Toolbar
     android:id="@+id/toolbar"
-    style="@style/Squanchy.Toolbar.SocialFeed"
     android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"
     android:layout_width="match_parent"
     android:layout_height="@dimen/toolbar_height" />

--- a/app/src/main/res/layout/activity_speaker_list.xml
+++ b/app/src/main/res/layout/activity_speaker_list.xml
@@ -15,7 +15,6 @@
 
     <android.support.v7.widget.Toolbar
       android:id="@+id/toolbar"
-      style="@style/Squanchy.Toolbar.SpeakerList"
       android:layout_width="match_parent"
       android:layout_height="?attr/actionBarSize" />
 

--- a/app/src/main/res/values/color.xml
+++ b/app/src/main/res/values/color.xml
@@ -21,10 +21,6 @@
 
   <color name="item_selection">#4f3b9a</color>
 
-  <color name="accent">#6aa611</color>
-  <color name="primary">#06335b</color>
-  <color name="primary_dark">#06335b</color>
-
   <color name="event_primary">#06335b</color>
   <color name="event">#4077aa</color>
   <color name="event_date">#0b73d4</color>

--- a/app/src/main/res/values/palette.xml
+++ b/app/src/main/res/values/palette.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<resources>
+
+  <color name="primary">#ec6e61</color>
+  <color name="primary_dark">#d76255</color>
+  <color name="primary_dark_text">#c25246</color>
+  <color name="accent">#67b6e2</color>
+
+  <color name="primary_blue">#80c7db</color>
+  <color name="primary_dark_blue">#5ea1b3</color>
+  <color name="primary_dark_text_blue">#498a9c</color>
+
+  <color name="primary_purple">#9d6acf</color>
+  <color name="primary_dark_purple">#8051ae</color>
+
+  <color name="primary_azure">#1da1f2</color>
+
+  <color name="status_bar">#11000000</color>
+
+  <color name="text_inverse">#ffffff</color>
+
+  <color name="button_inverse">#fafdff</color>
+  <color name="button_inverse_text_blue">#68929e</color>
+  <color name="button_inverse_text">#bc5c51</color>
+
+  <color name="primary_text">#4e4e4e</color>
+  <color name="secondary_text">#6b6b6b</color>
+  <color name="tertiary_text">#4d4d4d</color>
+  <color name="hint_text">#bfbfbf</color>
+  <color name="text_inverse_inactive">#99ffffff</color>
+
+  <color name="shadows">#19000000</color>
+  <color name="white_87">#ddffffff</color>
+  ˚
+</resources>

--- a/app/src/main/res/values/palette.xml
+++ b/app/src/main/res/values/palette.xml
@@ -32,5 +32,5 @@
 
   <color name="shadows">#19000000</color>
   <color name="white_87">#ddffffff</color>
-  ˚
+
 </resources>

--- a/app/src/main/res/values/palette.xml
+++ b/app/src/main/res/values/palette.xml
@@ -18,8 +18,6 @@
 
   <color name="status_bar">#11000000</color>
 
-  <color name="text_inverse">#ffffff</color>
-
   <color name="button_inverse">#fafdff</color>
   <color name="button_inverse_text_blue">#68929e</color>
   <color name="button_inverse_text">#bc5c51</color>
@@ -28,6 +26,8 @@
   <color name="secondary_text">#6b6b6b</color>
   <color name="tertiary_text">#4d4d4d</color>
   <color name="hint_text">#bfbfbf</color>
+
+  <color name="text_inverse">#ffffff</color>
   <color name="text_inverse_inactive">#99ffffff</color>
 
   <color name="shadows">#19000000</color>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -9,15 +9,14 @@
     <item name="android:elevation">@dimen/toolbar_elevation</item>
   </style>
 
-  <style name="Squanchy.Toolbar" parent="Widget.AppCompat.Light.ActionBar" >
-    <item name="fontPath">?titleTypeface</item>
+  <style name="Squanchy.Toolbar" parent="Widget.AppCompat.Light.ActionBar">
+    <item name="android:titleTextStyle">@style/Squanchy.Toolbar.TextAppearance</item>
+    <item name="android:subtitleTextStyle">@style/Squanchy.Toolbar.TextAppearance</item>
   </style>
 
-  <style name="Squanchy.Toolbar.SocialFeed" />
-
-  <style name="Squanchy.Toolbar.Schedule" />
-
-  <style name="Squanchy.Toolbar.SpeakerList" />
+  <style name="Squanchy.Toolbar.TextAppearance" parent="TextAppearance.AppCompat.Widget.ActionBar.Title.Inverse">
+    <item name="fontPath">?titleTypeface</item>
+  </style>
 
   <style name="Squanchy.Tabs" parent="Widget.Design.TabLayout" />
 

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -7,7 +7,13 @@
     <item name="colorAccent">@color/accent</item>
     <item name="colorControlNormal">@color/white_200</item>
     <item name="android:statusBarColor">@color/status_bar</item>
+    <item name="android:textColorPrimary">@color/primary_text</item>
+    <item name="android:textColorPrimaryInverse">@color/text_inverse</item>
+    <item name="android:textColorSecondary">@color/secondary_text</item>
+    <item name="android:textColorTertiary">@color/tertiary_text</item>
+    <item name="android:textColorHint">@color/hint_text</item>
     <item name="android:windowBackground">@color/white</item>
+    <item name="android:actionBarStyle">@style/Squanchy.Toolbar</item>
     <item name="defaultRegularTypeface">@string/default_typeface_regular</item>
     <item name="defaultMediumTypeface">@string/default_typeface_medium</item>
     <item name="defaultBoldTypeface">@string/default_typeface_bold</item>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,56 +1,24 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
-  <style name="Theme.Squanchy" parent="Theme.AppCompat.NoActionBar">
-    <item name="android:windowBackground">@color/white</item>
-    <item name="colorAccent">@color/grey_100</item>
+  <style name="Theme.Squanchy" parent="Theme.AppCompat.Light.NoActionBar">
+    <item name="colorPrimary">@color/primary</item>
+    <item name="colorPrimaryDark">@color/primary_dark</item>
+    <item name="colorAccent">@color/accent</item>
     <item name="colorControlNormal">@color/white_200</item>
-    <item name="titleTypeface">@string/title_typeface</item>
+    <item name="android:statusBarColor">@color/status_bar</item>
+    <item name="android:windowBackground">@color/white</item>
     <item name="defaultRegularTypeface">@string/default_typeface_regular</item>
     <item name="defaultMediumTypeface">@string/default_typeface_medium</item>
     <item name="defaultBoldTypeface">@string/default_typeface_bold</item>
     <item name="defaultLightTypeface">@string/default_typeface_light</item>
+    <item name="titleTypeface">@string/title_typeface</item>
   </style>
 
-  <style name="Theme.Squanchy.Home" parent="Theme.Squanchy">
-    <item name="colorPrimaryDark">@color/primary_dark</item>
-    <item name="colorPrimary">@color/primary</item>
-  </style>
+  <style name="Theme.Squanchy.Schedule" parent="Theme.Squanchy" />
 
-  <style name="Theme.Squanchy.SocialFeed" parent="Theme.AppCompat.Light.NoActionBar">
-    <item name="colorControlNormal">@color/white_200</item>
-    <item name="colorPrimaryDark">@color/primary_dark</item>
-    <item name="colorPrimary">@color/primary</item>
-  </style>
+  <style name="Theme.Squanchy.EventDetails" parent="Theme.Squanchy" />
 
-  <style name="Theme.Squanchy.Speaker" parent="Theme.Squanchy">
-    <item name="colorPrimaryDark">@color/speaker_primary</item>
-    <item name="colorPrimary">@color/speaker_primary</item>
-    <item name="colorControlNormal">@color/white</item>
-  </style>
-
-  <style name="Theme.Squanchy.Event" parent="Theme.Squanchy">
-    <item name="colorPrimaryDark">@color/event_primary</item>
-    <item name="colorPrimary">@color/event_primary</item>
-    <item name="colorControlNormal">@color/white</item>
-  </style>
-
-  <style name="Theme.Squanchy.About" parent="Theme.Squanchy">
-    <item name="colorPrimaryDark">@color/primary_dark</item>
-    <item name="colorPrimary">@color/primary</item>
-    <item name="colorControlNormal">@color/white</item>
-  </style>
-
-  <style name="Theme.SquanchyNew" parent="Theme.AppCompat.Light.NoActionBar">
-    <item name="colorPrimary">@color/primary</item>
-    <item name="colorPrimaryDark">@color/primary_dark</item>
-    <item name="colorAccent">@color/accent</item>
-  </style>
-
-  <style name="Theme.Squanchy.Schedule" parent="Theme.SquanchyNew" />
-
-  <style name="Theme.Squanchy.EventDetails" parent="Theme.SquanchyNew">
-    <item name="android:statusBarColor">#0000</item>
-  </style>
+  <style name="Theme.Squanchy.SocialFeed" parent="Theme.Squanchy" />
 
 </resources>


### PR DESCRIPTION
As per title, this closes #79 ; it also fixes font in appbar (not for event details, `CollapsingToolbarLayout` is broken and ignores fonts), removes unused themes, improves XML formatting rules, and brings that good old fuzzy feel-good tingling.

![palette](https://cloud.githubusercontent.com/assets/153802/23108117/9bfb6dae-f708-11e6-836b-c2df84791928.png)
