### PR TITLE
Add image loader

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -102,6 +102,7 @@ dependencies {
     compile libraries.app.firebaseAuth
     compile libraries.app.firebaseDb
     compile libraries.app.firebaseMessaging
+    compile libraries.app.firebaseUiStorage
     compile libraries.app.glide
     compile libraries.app.glideOkHttp3
     compile libraries.app.jodaTimeAndroid

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -96,37 +96,30 @@ play {
 }
 
 dependencies {
-    compile libraries.app.timber
-
-    compile libraries.app.jodaTimeAndroid
-
-    compile libraries.app.playAnalytics
-
+    compile libraries.app.calligraphy
+    compile libraries.app.crashlytics
     compile libraries.app.firebase
+    compile libraries.app.firebaseAuth
     compile libraries.app.firebaseDb
     compile libraries.app.firebaseMessaging
-    compile libraries.app.firebaseAuth
-
+    compile libraries.app.glide
+    compile libraries.app.glideOkHttp3
+    compile libraries.app.jodaTimeAndroid
+    compile libraries.app.optional
+    compile libraries.app.playAnalytics
     compile libraries.app.rx
     compile libraries.app.rxAndroid
-
     compile libraries.app.supportAppCompat
     compile libraries.app.supportDesign
-
-    compile libraries.app.crashlytics
+    compile libraries.app.timber
     compile libraries.app.tweetUi
-
     compile libraries.app.viewPagerAdapter
-
-    compile libraries.app.calligraphy
 
     apt libraries.app.autoValue
     provided libraries.app.autoValue
 
-    compile libraries.app.dagger
     apt libraries.app.daggerCompiler
-
-    compile libraries.app.optional
+    compile libraries.app.dagger
 
     retrolambdaConfig libraries.app.retrolambda
 }

--- a/app/src/main/java/net/squanchy/SquanchyApplication.java
+++ b/app/src/main/java/net/squanchy/SquanchyApplication.java
@@ -54,7 +54,7 @@ public class SquanchyApplication extends Application {
     @MainThread
     public ApplicationComponent applicationComponent() {
         if (applicationComponent == null) {
-            applicationComponent = ApplicationComponent.Factory.create(this);
+            applicationComponent = ApplicationComponent.Factory.create();
         }
 
         return applicationComponent;

--- a/app/src/main/java/net/squanchy/imageloader/GlideImageLoader.java
+++ b/app/src/main/java/net/squanchy/imageloader/GlideImageLoader.java
@@ -13,9 +13,11 @@ final class GlideImageLoader implements ImageLoader {
     private static final String FIREBASE_STORAGE_URL_SCHEMA = "gs://";
 
     private final RequestManager requestManager;
+    private final FirebaseImageLoader firebaseImageLoader;
 
-    GlideImageLoader(RequestManager requestManager) {
+    GlideImageLoader(RequestManager requestManager, FirebaseImageLoader firebaseImageLoader) {
         this.requestManager = requestManager;
+        this.firebaseImageLoader = firebaseImageLoader;
     }
 
     @Override
@@ -28,7 +30,7 @@ final class GlideImageLoader implements ImageLoader {
 
     @Override
     public ImageRequest load(StorageReference storageReference) {
-        return new GlideFirebaseImageRequest(requestManager, storageReference);
+        return new GlideFirebaseImageRequest(requestManager, storageReference, firebaseImageLoader);
     }
 
     private static final class GlideUrlImageRequest extends GlideImageRequest<Uri> {
@@ -53,15 +55,17 @@ final class GlideImageLoader implements ImageLoader {
     private static final class GlideFirebaseImageRequest extends GlideImageRequest<StorageReference> {
 
         private final StorageReference storageReference;
+        private final FirebaseImageLoader firebaseLoader;
 
-        GlideFirebaseImageRequest(RequestManager requestManager, StorageReference storageReference) {
+        GlideFirebaseImageRequest(RequestManager requestManager, StorageReference storageReference, FirebaseImageLoader firebaseImageLoader) {
             super(requestManager);
             this.storageReference = storageReference;
+            this.firebaseLoader = firebaseImageLoader;
         }
 
         DrawableTypeRequest<StorageReference> startLoading() {
             return glide()
-                    .using(new FirebaseImageLoader())
+                    .using(firebaseLoader)
                     .load(storageReference);
         }
     }

--- a/app/src/main/java/net/squanchy/imageloader/GlideImageLoader.java
+++ b/app/src/main/java/net/squanchy/imageloader/GlideImageLoader.java
@@ -1,11 +1,9 @@
 package net.squanchy.imageloader;
 
-import android.content.Context;
 import android.net.Uri;
 import android.widget.ImageView;
 
 import com.bumptech.glide.DrawableTypeRequest;
-import com.bumptech.glide.Glide;
 import com.bumptech.glide.RequestManager;
 import com.firebase.ui.storage.images.FirebaseImageLoader;
 import com.google.firebase.storage.StorageReference;
@@ -14,10 +12,10 @@ final class GlideImageLoader implements ImageLoader {
 
     private static final String FIREBASE_STORAGE_URL_SCHEMA = "gs://";
 
-    private final Context context;
+    private final RequestManager requestManager;
 
-    GlideImageLoader(Context context) {
-        this.context = context;
+    GlideImageLoader(RequestManager requestManager) {
+        this.requestManager = requestManager;
     }
 
     @Override
@@ -25,20 +23,20 @@ final class GlideImageLoader implements ImageLoader {
         if (url.startsWith(FIREBASE_STORAGE_URL_SCHEMA)) {
             throw new IllegalArgumentException("To load images from Firebase Storage please obtain the StorageReference first and use that one.");
         }
-        return new GlideUrlImageRequest(context, url);
+        return new GlideUrlImageRequest(requestManager, url);
     }
 
     @Override
     public ImageRequest load(StorageReference storageReference) {
-        return new GlideFirebaseImageRequest(context, storageReference);
+        return new GlideFirebaseImageRequest(requestManager, storageReference);
     }
 
     private static final class GlideUrlImageRequest extends GlideImageRequest<Uri> {
 
         private final Uri uri;
 
-        GlideUrlImageRequest(Context context, String url) {
-            super(context);
+        GlideUrlImageRequest(RequestManager requestManager, String url) {
+            super(requestManager);
             this.uri = Uri.parse(url);
         }
 
@@ -56,8 +54,8 @@ final class GlideImageLoader implements ImageLoader {
 
         private final StorageReference storageReference;
 
-        GlideFirebaseImageRequest(Context context, StorageReference storageReference) {
-            super(context);
+        GlideFirebaseImageRequest(RequestManager requestManager, StorageReference storageReference) {
+            super(requestManager);
             this.storageReference = storageReference;
         }
 
@@ -70,10 +68,10 @@ final class GlideImageLoader implements ImageLoader {
 
     private abstract static class GlideImageRequest<T> implements ImageRequest<T> {
 
-        private final Context context;
+        private final RequestManager requestManager;
 
-        GlideImageRequest(Context context) {
-            this.context = context;
+        GlideImageRequest(RequestManager requestManager) {
+            this.requestManager = requestManager;
         }
 
         @Override
@@ -84,7 +82,7 @@ final class GlideImageLoader implements ImageLoader {
         abstract DrawableTypeRequest<T> startLoading();
 
         final RequestManager glide() {
-            return Glide.with(context);
+            return requestManager;
         }
     }
 }

--- a/app/src/main/java/net/squanchy/imageloader/GlideImageLoader.java
+++ b/app/src/main/java/net/squanchy/imageloader/GlideImageLoader.java
@@ -1,0 +1,90 @@
+package net.squanchy.imageloader;
+
+import android.content.Context;
+import android.net.Uri;
+import android.widget.ImageView;
+
+import com.bumptech.glide.DrawableTypeRequest;
+import com.bumptech.glide.Glide;
+import com.bumptech.glide.RequestManager;
+import com.firebase.ui.storage.images.FirebaseImageLoader;
+import com.google.firebase.storage.StorageReference;
+
+final class GlideImageLoader implements ImageLoader {
+
+    private static final String FIREBASE_STORAGE_URL_SCHEMA = "gs://";
+
+    private final Context context;
+
+    GlideImageLoader(Context context) {
+        this.context = context;
+    }
+
+    @Override
+    public ImageRequest load(String url) {
+        if (url.startsWith(FIREBASE_STORAGE_URL_SCHEMA)) {
+            throw new IllegalArgumentException("To load images from Firebase Storage please obtain the StorageReference first and use that one.");
+        }
+        return new GlideUrlImageRequest(context, url);
+    }
+
+    @Override
+    public ImageRequest load(StorageReference storageReference) {
+        return new GlideFirebaseImageRequest(context, storageReference);
+    }
+
+    private static final class GlideUrlImageRequest extends GlideImageRequest<Uri> {
+
+        private final Uri uri;
+
+        GlideUrlImageRequest(Context context, String url) {
+            super(context);
+            this.uri = Uri.parse(url);
+        }
+
+        public void into(ImageView imageView) {
+            startLoading().into(imageView);
+        }
+
+        @Override
+        DrawableTypeRequest<Uri> startLoading() {
+            return glide().load(uri);
+        }
+    }
+
+    private static final class GlideFirebaseImageRequest extends GlideImageRequest<StorageReference> {
+
+        private final StorageReference storageReference;
+
+        GlideFirebaseImageRequest(Context context, StorageReference storageReference) {
+            super(context);
+            this.storageReference = storageReference;
+        }
+
+        DrawableTypeRequest<StorageReference> startLoading() {
+            return glide()
+                    .using(new FirebaseImageLoader())
+                    .load(storageReference);
+        }
+    }
+
+    private abstract static class GlideImageRequest<T> implements ImageRequest<T> {
+
+        private final Context context;
+
+        GlideImageRequest(Context context) {
+            this.context = context;
+        }
+
+        @Override
+        public void into(ImageView imageView) {
+            startLoading().into(imageView);
+        }
+
+        abstract DrawableTypeRequest<T> startLoading();
+
+        final RequestManager glide() {
+            return Glide.with(context);
+        }
+    }
+}

--- a/app/src/main/java/net/squanchy/imageloader/ImageLoader.java
+++ b/app/src/main/java/net/squanchy/imageloader/ImageLoader.java
@@ -1,0 +1,10 @@
+package net.squanchy.imageloader;
+
+import com.google.firebase.storage.StorageReference;
+
+public interface ImageLoader {
+
+    ImageRequest load(String url);
+
+    ImageRequest load(StorageReference storageReference);
+}

--- a/app/src/main/java/net/squanchy/imageloader/ImageLoaderComponent.java
+++ b/app/src/main/java/net/squanchy/imageloader/ImageLoaderComponent.java
@@ -1,10 +1,7 @@
 package net.squanchy.imageloader;
 
-import net.squanchy.injection.ActivityLifecycle;
-
 import dagger.Component;
 
-@ActivityLifecycle
 @Component(modules = {ImageLoaderModule.class})
 public interface ImageLoaderComponent {
 

--- a/app/src/main/java/net/squanchy/imageloader/ImageLoaderComponent.java
+++ b/app/src/main/java/net/squanchy/imageloader/ImageLoaderComponent.java
@@ -1,0 +1,12 @@
+package net.squanchy.imageloader;
+
+import net.squanchy.injection.ActivityLifecycle;
+
+import dagger.Component;
+
+@ActivityLifecycle
+@Component(modules = {ImageLoaderModule.class})
+public interface ImageLoaderComponent {
+
+    ImageLoader imageLoader();
+}

--- a/app/src/main/java/net/squanchy/imageloader/ImageLoaderInjector.java
+++ b/app/src/main/java/net/squanchy/imageloader/ImageLoaderInjector.java
@@ -1,0 +1,16 @@
+package net.squanchy.imageloader;
+
+import android.content.Context;
+
+public final class ImageLoaderInjector {
+
+    private ImageLoaderInjector() {
+        // no instances
+    }
+
+    public static ImageLoaderComponent obtain(Context context) {
+        return DaggerImageLoaderComponent.builder()
+                .imageLoaderModule(new ImageLoaderModule(context))
+                .build();
+    }
+}

--- a/app/src/main/java/net/squanchy/imageloader/ImageLoaderModule.java
+++ b/app/src/main/java/net/squanchy/imageloader/ImageLoaderModule.java
@@ -2,6 +2,9 @@ package net.squanchy.imageloader;
 
 import android.content.Context;
 
+import com.bumptech.glide.Glide;
+import com.bumptech.glide.RequestManager;
+
 import dagger.Module;
 import dagger.Provides;
 
@@ -15,7 +18,12 @@ class ImageLoaderModule {
     }
 
     @Provides
-    ImageLoader imageLoader() {
-        return new GlideImageLoader(context);
+    RequestManager glideRequestManager() {
+        return Glide.with(context);
+    };
+
+    @Provides
+    ImageLoader imageLoader(RequestManager requestManager) {
+        return new GlideImageLoader(requestManager);
     }
 }

--- a/app/src/main/java/net/squanchy/imageloader/ImageLoaderModule.java
+++ b/app/src/main/java/net/squanchy/imageloader/ImageLoaderModule.java
@@ -4,6 +4,7 @@ import android.content.Context;
 
 import com.bumptech.glide.Glide;
 import com.bumptech.glide.RequestManager;
+import com.firebase.ui.storage.images.FirebaseImageLoader;
 
 import dagger.Module;
 import dagger.Provides;
@@ -20,10 +21,15 @@ class ImageLoaderModule {
     @Provides
     RequestManager glideRequestManager() {
         return Glide.with(context);
-    };
+    }
 
     @Provides
-    ImageLoader imageLoader(RequestManager requestManager) {
-        return new GlideImageLoader(requestManager);
+    FirebaseImageLoader firebaseImageLoader() {
+        return new FirebaseImageLoader();
+    }
+
+    @Provides
+    ImageLoader imageLoader(RequestManager requestManager, FirebaseImageLoader firebaseImageLoader) {
+        return new GlideImageLoader(requestManager, firebaseImageLoader);
     }
 }

--- a/app/src/main/java/net/squanchy/imageloader/ImageLoaderModule.java
+++ b/app/src/main/java/net/squanchy/imageloader/ImageLoaderModule.java
@@ -1,0 +1,21 @@
+package net.squanchy.imageloader;
+
+import android.content.Context;
+
+import dagger.Module;
+import dagger.Provides;
+
+@Module
+class ImageLoaderModule {
+
+    private final Context context;
+
+    ImageLoaderModule(Context context) {
+        this.context = context;
+    }
+
+    @Provides
+    ImageLoader imageLoader() {
+        return new GlideImageLoader(context);
+    }
+}

--- a/app/src/main/java/net/squanchy/imageloader/ImageRequest.java
+++ b/app/src/main/java/net/squanchy/imageloader/ImageRequest.java
@@ -1,0 +1,8 @@
+package net.squanchy.imageloader;
+
+import android.widget.ImageView;
+
+public interface ImageRequest<T> {
+
+    void into(ImageView imageView);
+}

--- a/app/src/main/java/net/squanchy/injection/ApplicationComponent.java
+++ b/app/src/main/java/net/squanchy/injection/ApplicationComponent.java
@@ -20,7 +20,7 @@ public interface ApplicationComponent {
             // non-instantiable
         }
 
-        public static ApplicationComponent create(SquanchyApplication application) {
+        public static ApplicationComponent create() {
             return DaggerApplicationComponent.builder()
                     .firebaseModule(new FirebaseModule())
                     .build();

--- a/app/src/main/java/net/squanchy/schedule/view/SpeakerView.java
+++ b/app/src/main/java/net/squanchy/schedule/view/SpeakerView.java
@@ -1,16 +1,26 @@
 package net.squanchy.schedule.view;
 
 import android.content.Context;
-import android.graphics.drawable.ColorDrawable;
 import android.util.AttributeSet;
 import android.widget.ImageView;
 import android.widget.LinearLayout;
 import android.widget.TextView;
 
+import com.google.firebase.storage.FirebaseStorage;
+import com.google.firebase.storage.StorageReference;
+
+import java.util.Locale;
+
 import net.squanchy.R;
+import net.squanchy.imageloader.ImageLoader;
+import net.squanchy.imageloader.ImageLoaderInjector;
 
 public class SpeakerView extends LinearLayout {
 
+    private static final String SPEAKER_PHOTO_PATH_TEMPLATE = "speakers/%s";
+
+    private final ImageLoader imageLoader;
+    
     private ImageView speakerPhotoView;
     private TextView speakerNameView;
 
@@ -25,6 +35,7 @@ public class SpeakerView extends LinearLayout {
     public SpeakerView(Context context, AttributeSet attrs, int defStyleAttr, int defStyleRes) {
         super(context, attrs, defStyleAttr, defStyleRes);
 
+        imageLoader = ImageLoaderInjector.obtain(context).imageLoader();
         super.setOrientation(HORIZONTAL);
     }
 
@@ -43,6 +54,8 @@ public class SpeakerView extends LinearLayout {
 
     public void updateWith(String speakersNames) {
         speakerNameView.setText(speakersNames);
-        speakerPhotoView.setImageDrawable(new ColorDrawable(0xFF67B6E2)); // TODO bind photo too
+        String path = String.format(Locale.US, SPEAKER_PHOTO_PATH_TEMPLATE, "squanchy.webp");   // TODO use actual speaker ID
+        StorageReference photoReference = FirebaseStorage.getInstance().getReference(path);
+        imageLoader.load(photoReference).into(speakerPhotoView);
     }
 }

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -20,6 +20,7 @@ ext {
                     firebaseDb       : "com.google.firebase:firebase-database:${playServicesVersion}",
                     firebaseMessaging: "com.google.firebase:firebase-messaging:${playServicesVersion}",
                     firebaseAuth     : "com.google.firebase:firebase-auth:${playServicesVersion}",
+                    firebaseUiStorage: "com.firebaseui:firebase-ui-storage:1.2.0",
                     glide            : 'com.github.bumptech.glide:glide:3.7.0',
                     glideOkHttp3     : 'com.github.bumptech.glide:okhttp3-integration:1.4.0@aar',
                     jodaTimeAndroid  : 'net.danlew:android.joda:2.9.5.1',

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,6 +1,6 @@
 ext {
     supportLibVersion = '25.1.1'
-    playServicesVersion = '10.0.1'
+    playServicesVersion = '10.2.0'
     daggerVersion = '2.9'
 
     gradlePlugins = [

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -20,6 +20,8 @@ ext {
                     firebaseDb       : "com.google.firebase:firebase-database:${playServicesVersion}",
                     firebaseMessaging: "com.google.firebase:firebase-messaging:${playServicesVersion}",
                     firebaseAuth     : "com.google.firebase:firebase-auth:${playServicesVersion}",
+                    glide            : 'com.github.bumptech.glide:glide:3.7.0',
+                    glideOkHttp3     : 'com.github.bumptech.glide:okhttp3-integration:1.4.0@aar',
                     jodaTimeAndroid  : 'net.danlew:android.joda:2.9.5.1',
                     optional         : 'com.hadisatrio:optional:v1.0.1',
                     playAnalytics    : "com.google.android.gms:play-services-analytics:${playServicesVersion}",


### PR DESCRIPTION
This PR:
 * Bumps Firebase/Play Services from 10.0.1 to 10.2.0
 * Adds Glide, Glide-OkHttp3, and FirebaseUI-storage dependencies
 * Defines the `ImageLoader` interface, and its Glide-powered implementation
 * Injects and uses the `ImageLoader` to load speaker photos (dummy for now, we don't have that data yet)

 Before | After
 --- | --- 
 ![image](https://cloud.githubusercontent.com/assets/153802/23223878/8fc81e30-f92c-11e6-8db2-2220340f3db8.png) | ![image](https://cloud.githubusercontent.com/assets/153802/23223280/e53913ee-f92a-11e6-9283-ed47d98fe0b9.png)
