### PR TITLE
SQ-91/Fix build crashing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:2.3.0-rc1'
         classpath 'com.google.gms:google-services:3.0.0'
         classpath 'com.github.triplet.gradle:play-publisher:1.1.5'
     }

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -31,7 +31,7 @@ ext {
                     rxAndroid        : 'io.reactivex.rxjava2:rxandroid:2.0.1',
                     supportAppCompat : "com.android.support:appcompat-v7:${supportLibVersion}",
                     supportDesign    : "com.android.support:design:${supportLibVersion}",
-                    timber           : 'com.jakewharton.timber:timber:4.3.1',
+                    timber           : 'com.jakewharton.timber:timber:4.5.1',
                     tweetUi          : 'com.twitter.sdk.android:tweet-ui:2.2.0',
                     viewPagerAdapter : 'com.novoda:view-pager-adapter:0.9.1'
             ]


### PR DESCRIPTION
Updated gradle plugin `2.3.0-RC1` fixes the build error `!zip.isFile()` we got since upping minSDK to 21 (and allows using Instant Run on AS 2.3)