### PR TITLE
Bottom tabs alpha

### DIFF
--- a/app/src/main/res/color/bottom_navigation_item.xml
+++ b/app/src/main/res/color/bottom_navigation_item.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+
+  <item android:color="@color/white" android:state_checked="true" />
+  <item android:color="@color/white_60" android:state_checked="false" />
+
+</selector>

--- a/app/src/main/res/layout/activity_home.xml
+++ b/app/src/main/res/layout/activity_home.xml
@@ -17,8 +17,8 @@
     android:layout_height="wrap_content"
     android:layout_alignParentBottom="true"
     android:background="?colorPrimary"
-    app:itemIconTint="?colorControlNormal"
-    app:itemTextColor="?colorControlNormal"
+    app:itemIconTint="@color/bottom_navigation_text"
+    app:itemTextColor="@color/bottom_navigation_text"
     app:menu="@menu/bottom_bar_menu" />
 
 </LinearLayout>

--- a/app/src/main/res/layout/activity_home.xml
+++ b/app/src/main/res/layout/activity_home.xml
@@ -17,8 +17,8 @@
     android:layout_height="wrap_content"
     android:layout_alignParentBottom="true"
     android:background="?colorPrimary"
-    app:itemIconTint="@color/bottom_navigation_text"
-    app:itemTextColor="@color/bottom_navigation_text"
+    app:itemIconTint="@color/bottom_navigation_item"
+    app:itemTextColor="@color/bottom_navigation_item"
     app:menu="@menu/bottom_bar_menu" />
 
 </LinearLayout>

--- a/app/src/main/res/values/palette.xml
+++ b/app/src/main/res/values/palette.xml
@@ -34,6 +34,6 @@
 
   <color name="shadows">#19000000</color>
   <color name="white">#ffffff</color>
-  <color name="white_87">#ddffffff</color>
+  <color name="white_60">#99ffffff</color>
 
 </resources>

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,5 +1,5 @@
 ext {
-    supportLibVersion = '25.1.1'
+    supportLibVersion = '25.2.0'
     playServicesVersion = '10.2.0'
     daggerVersion = '2.9'
 


### PR DESCRIPTION
Update the support lib to v25.2.0 (critical bug fixes and all), use a selector for bottom tabs' tinting so we follow specs (60% alpha on unselected item).

Before | After
--- | ---
 ![image](https://cloud.githubusercontent.com/assets/153802/23306463/f685cabe-faa3-11e6-8afa-fa7a492b9699.png) | ![image](https://cloud.githubusercontent.com/assets/153802/23306451/e86a8870-faa3-11e6-9889-4cf11e49cd11.png)
