### PR TITLE
SQ-SC/Circular reveal in tabs

### DIFF
--- a/app/src/main/java/me/eugeniomarletti/renderthread/CanvasProperty.java
+++ b/app/src/main/java/me/eugeniomarletti/renderthread/CanvasProperty.java
@@ -1,0 +1,10 @@
+package me.eugeniomarletti.renderthread;
+
+@SuppressWarnings("unused")
+public abstract class CanvasProperty<T> {
+
+    CanvasProperty() {
+    }
+
+    public abstract boolean isHardware();
+}

--- a/app/src/main/java/me/eugeniomarletti/renderthread/CanvasUtils.java
+++ b/app/src/main/java/me/eugeniomarletti/renderthread/CanvasUtils.java
@@ -1,0 +1,26 @@
+package me.eugeniomarletti.renderthread;
+
+import android.graphics.Canvas;
+import android.graphics.Paint;
+import android.graphics.RectF;
+import android.os.Build;
+import android.support.annotation.NonNull;
+
+public final class CanvasUtils {
+
+    private CanvasUtils() {
+    }
+
+    private static final RectF TMP_RECT = Build.VERSION.SDK_INT < 21 ? new RectF() : null;
+
+    public static void drawRoundRect(
+            @NonNull Canvas canvas, float left, float top, float right, float bottom, float rx, float ry, @NonNull Paint paint) {
+
+        if (Build.VERSION.SDK_INT < 21) {
+            TMP_RECT.set(left, top, right, bottom);
+            canvas.drawRoundRect(TMP_RECT, rx, ry, paint);
+        } else {
+            canvas.drawRoundRect(left, top, right, bottom, rx, ry, paint);
+        }
+    }
+}

--- a/app/src/main/java/me/eugeniomarletti/renderthread/HardwareCanvasProperty.java
+++ b/app/src/main/java/me/eugeniomarletti/renderthread/HardwareCanvasProperty.java
@@ -1,0 +1,27 @@
+package me.eugeniomarletti.renderthread;
+
+import android.support.annotation.NonNull;
+
+import me.eugeniomarletti.renderthread.typeannotation.CanvasProperty;
+
+public final class HardwareCanvasProperty<T> extends me.eugeniomarletti.renderthread.CanvasProperty<T> {
+
+    @NonNull
+    @CanvasProperty
+    private final Object property;
+
+    HardwareCanvasProperty(@CanvasProperty @NonNull Object property) {
+        this.property = property;
+    }
+
+    @NonNull
+    @CanvasProperty
+    Object getProperty() {
+        return property;
+    }
+
+    @Override
+    public boolean isHardware() {
+        return true;
+    }
+}

--- a/app/src/main/java/me/eugeniomarletti/renderthread/RenderThread.java
+++ b/app/src/main/java/me/eugeniomarletti/renderthread/RenderThread.java
@@ -1,0 +1,122 @@
+package me.eugeniomarletti.renderthread;
+
+import android.animation.Animator;
+import android.graphics.Canvas;
+import android.graphics.Paint;
+import android.graphics.drawable.Drawable;
+import android.support.annotation.FloatRange;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+
+import me.eugeniomarletti.renderthread.typeannotation.DisplayListCanvas;
+import me.eugeniomarletti.renderthread.typeannotation.RenderNodeAnimator;
+
+@SuppressWarnings("unused")
+public final class RenderThread {
+
+    private RenderThread() {
+    }
+
+    private static RenderThreadDelegate DELEGATE;
+
+    static {
+        init(false);
+    }
+
+    public static void init(boolean skipAndroidVersionCheck) {
+        RenderThreadDelegate delegate = DELEGATE;
+        if (delegate == null || !delegate.isSupported()) {
+            RenderThreadMethods methods = RenderThreadMethods.create(skipAndroidVersionCheck);
+            if (methods != null) {
+                DELEGATE = new RenderThreadDelegateHw(methods);
+            } else {
+                DELEGATE = new RenderThreadDelegate();
+            }
+        }
+    }
+
+    public static boolean isSupported() {
+        return DELEGATE.isSupported();
+    }
+
+    @NonNull
+    public static CanvasProperty<Float> createCanvasProperty(@NonNull Canvas canvas, float initialValue) {
+        return createCanvasProperty(canvas, initialValue, true);
+    }
+
+    @NonNull
+    public static CanvasProperty<Float> createCanvasProperty(@NonNull Canvas canvas, float initialValue, boolean useRenderThread) {
+        return DELEGATE.createCanvasProperty(canvas, initialValue, useRenderThread);
+    }
+
+    @NonNull
+    public static CanvasProperty<Paint> createCanvasProperty(@NonNull Canvas canvas, @NonNull Paint initialValue) {
+        return createCanvasProperty(canvas, initialValue, true);
+    }
+
+    @NonNull
+    public static CanvasProperty<Paint> createCanvasProperty(@NonNull Canvas canvas, @NonNull Paint initialValue, boolean useRenderThread) {
+        return DELEGATE.createCanvasProperty(canvas, initialValue, useRenderThread);
+    }
+
+    public static boolean isDisplayListCanvas(@NonNull Canvas canvas) {
+        return DELEGATE.isDisplayListCanvas(canvas);
+    }
+
+    public static void setAnimatorTarget(@RenderNodeAnimator @NonNull Animator animator, @DisplayListCanvas @NonNull Canvas target) {
+        DELEGATE.setTarget(animator, target);
+    }
+
+    public static void drawCircle(
+            @NonNull Canvas canvas,
+            @NonNull CanvasProperty<Float> cx,
+            @NonNull CanvasProperty<Float> cy,
+            @NonNull CanvasProperty<Float> radius,
+            @NonNull CanvasProperty<Paint> paint) {
+
+        DELEGATE.drawCircle(canvas, cx, cy, radius, paint);
+    }
+
+    public static void drawRoundRect(
+            @NonNull Canvas canvas,
+            @NonNull CanvasProperty<Float> left,
+            @NonNull CanvasProperty<Float> top,
+            @NonNull CanvasProperty<Float> right,
+            @NonNull CanvasProperty<Float> bottom,
+            @NonNull CanvasProperty<Float> rx,
+            @NonNull CanvasProperty<Float> ry,
+            @NonNull CanvasProperty<Paint> paint) {
+
+        DELEGATE.drawRoundRect(canvas, left, top, right, bottom, rx, ry, paint);
+    }
+
+    @NonNull
+    public static Animator createFloatAnimator(
+            @NonNull Drawable drawable,
+            @NonNull Canvas canvas,
+            @NonNull CanvasProperty<Float> property,
+            float targetValue) {
+
+        return DELEGATE.createFloatAnimator(drawable, canvas, property, targetValue);
+    }
+
+    @NonNull
+    public static Animator createPaintAlphaAnimator(
+            @Nullable Drawable drawable,
+            @NonNull Canvas canvas,
+            @NonNull CanvasProperty<Paint> property,
+            @FloatRange(from = 0f, to = 255f) float targetValue) {
+
+        return DELEGATE.createPaintAlphaAnimator(drawable, canvas, property, targetValue);
+    }
+
+    @NonNull
+    public static Animator createPaintStrokeWidthAnimator(
+            @Nullable Drawable drawable,
+            @NonNull Canvas canvas,
+            @NonNull CanvasProperty<Paint> property,
+            float targetValue) {
+
+        return DELEGATE.createPaintStrokeWidthAnimator(drawable, canvas, property, targetValue);
+    }
+}

--- a/app/src/main/java/me/eugeniomarletti/renderthread/RenderThreadDelegate.java
+++ b/app/src/main/java/me/eugeniomarletti/renderthread/RenderThreadDelegate.java
@@ -1,0 +1,334 @@
+package me.eugeniomarletti.renderthread;
+
+import android.animation.Animator;
+import android.animation.ValueAnimator;
+import android.graphics.Canvas;
+import android.graphics.Paint;
+import android.graphics.drawable.Drawable;
+import android.support.annotation.FloatRange;
+import android.support.annotation.IntRange;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+
+import me.eugeniomarletti.renderthread.typeannotation.DisplayListCanvas;
+import me.eugeniomarletti.renderthread.typeannotation.RenderNodeAnimator;
+
+class RenderThreadDelegate {
+
+    RenderThreadDelegate() {
+    }
+
+    public boolean isSupported() {
+        return false;
+    }
+
+    @NonNull
+    public CanvasProperty<Float> createCanvasProperty(@NonNull Canvas canvas, float initialValue, boolean useRenderThread) {
+        CanvasProperty<Float> hw = null;
+        if (useRenderThread && isDisplayListCanvas(canvas)) {
+            hw = createHardwareCanvasProperty(initialValue);
+        }
+        if (hw != null) {
+            return hw;
+        } else {
+            return createSoftwareCanvasProperty(initialValue);
+        }
+    }
+
+    @NonNull
+    public CanvasProperty<Paint> createCanvasProperty(@NonNull Canvas canvas, @NonNull Paint initialValue, boolean useRenderThread) {
+        CanvasProperty<Paint> hw = null;
+        if (useRenderThread && isDisplayListCanvas(canvas)) {
+            hw = createHardwareCanvasProperty(initialValue);
+        }
+        if (hw != null) {
+            return hw;
+        } else {
+            return createSoftwareCanvasProperty(initialValue);
+        }
+    }
+
+    @Nullable
+    protected HardwareCanvasProperty<Float> createHardwareCanvasProperty(float initialValue) {
+        return null;
+    }
+
+    @Nullable
+    protected HardwareCanvasProperty<Paint> createHardwareCanvasProperty(@NonNull Paint initialValue) {
+        return null;
+    }
+
+    @NonNull
+    protected SoftwareCanvasProperty<Float> createSoftwareCanvasProperty(float initialValue) {
+        return new SoftwareCanvasProperty<>(initialValue);
+    }
+
+    @NonNull
+    protected SoftwareCanvasProperty<Paint> createSoftwareCanvasProperty(@NonNull Paint initialValue) {
+        return new SoftwareCanvasProperty<>(initialValue);
+    }
+
+    public boolean isDisplayListCanvas(@NonNull Canvas canvas) {
+        return false;
+    }
+
+    public void setTarget(@RenderNodeAnimator @NonNull Animator animator, @DisplayListCanvas @NonNull Canvas target) {
+        throw new UnsupportedOperationException();
+    }
+
+    public void drawCircle(
+            @NonNull Canvas canvas,
+            @NonNull CanvasProperty<Float> cx,
+            @NonNull CanvasProperty<Float> cy,
+            @NonNull CanvasProperty<Float> radius,
+            @NonNull CanvasProperty<Paint> paint) {
+
+        boolean cxHw = cx.isHardware();
+        boolean cyHw = cy.isHardware();
+        boolean radiusHw = radius.isHardware();
+        boolean paintHw = paint.isHardware();
+
+        boolean allHw = cxHw && cyHw && radiusHw && paintHw;
+        if (allHw) {
+            drawCircleHardware(
+                    canvas,
+                    (HardwareCanvasProperty<Float>) cx,
+                    (HardwareCanvasProperty<Float>) cy,
+                    (HardwareCanvasProperty<Float>) radius,
+                    (HardwareCanvasProperty<Paint>) paint);
+            return;
+        }
+
+        boolean allSw = !cxHw && !cyHw && !radiusHw && !paintHw;
+        if (allSw) {
+            drawCircleSoftware(
+                    canvas,
+                    (SoftwareCanvasProperty<Float>) cx,
+                    (SoftwareCanvasProperty<Float>) cy,
+                    (SoftwareCanvasProperty<Float>) radius,
+                    (SoftwareCanvasProperty<Paint>) paint);
+            return;
+        }
+
+        throwMixedPropertiesException();
+    }
+
+    protected void drawCircleHardware(
+            @DisplayListCanvas @NonNull Canvas canvas,
+            @NonNull HardwareCanvasProperty<Float> cx,
+            @NonNull HardwareCanvasProperty<Float> cy,
+            @NonNull HardwareCanvasProperty<Float> radius,
+            @NonNull HardwareCanvasProperty<Paint> paint) {
+
+        throw new UnsupportedOperationException();
+    }
+
+    protected void drawCircleSoftware(
+            @NonNull Canvas canvas,
+            @NonNull SoftwareCanvasProperty<Float> cx,
+            @NonNull SoftwareCanvasProperty<Float> cy,
+            @NonNull SoftwareCanvasProperty<Float> radius,
+            @NonNull SoftwareCanvasProperty<Paint> paint) {
+
+        canvas.drawCircle(cx.getValue(), cy.getValue(), radius.getValue(), paint.getValue());
+    }
+
+    public void drawRoundRect(
+            @NonNull Canvas canvas,
+            @NonNull CanvasProperty<Float> left,
+            @NonNull CanvasProperty<Float> top,
+            @NonNull CanvasProperty<Float> right,
+            @NonNull CanvasProperty<Float> bottom,
+            @NonNull CanvasProperty<Float> rx,
+            @NonNull CanvasProperty<Float> ry,
+            @NonNull CanvasProperty<Paint> paint) {
+
+        boolean leftHw = left.isHardware();
+        boolean topHw = top.isHardware();
+        boolean rightHw = right.isHardware();
+        boolean bottomHw = bottom.isHardware();
+        boolean rxHw = rx.isHardware();
+        boolean ryHw = ry.isHardware();
+        boolean paintHw = paint.isHardware();
+
+        boolean allHw = leftHw && topHw && rightHw && bottomHw && rxHw && ryHw && paintHw;
+        if (allHw) {
+            drawRoundRectHardware(
+                    canvas,
+                    (HardwareCanvasProperty<Float>) left,
+                    (HardwareCanvasProperty<Float>) top,
+                    (HardwareCanvasProperty<Float>) right,
+                    (HardwareCanvasProperty<Float>) bottom,
+                    (HardwareCanvasProperty<Float>) rx,
+                    (HardwareCanvasProperty<Float>) ry,
+                    (HardwareCanvasProperty<Paint>) paint);
+            return;
+        }
+
+        boolean allSw = !leftHw && !topHw && !rightHw && !bottomHw && !rxHw && !ryHw && !paintHw;
+        if (allSw) {
+            drawRoundRectSoftware(
+                    canvas,
+                    (SoftwareCanvasProperty<Float>) left,
+                    (SoftwareCanvasProperty<Float>) top,
+                    (SoftwareCanvasProperty<Float>) right,
+                    (SoftwareCanvasProperty<Float>) bottom,
+                    (SoftwareCanvasProperty<Float>) rx,
+                    (SoftwareCanvasProperty<Float>) ry,
+                    (SoftwareCanvasProperty<Paint>) paint);
+            return;
+        }
+
+        throwMixedPropertiesException();
+    }
+
+    protected void drawRoundRectHardware(
+            @DisplayListCanvas @NonNull Canvas canvas,
+            @NonNull HardwareCanvasProperty<Float> left,
+            @NonNull HardwareCanvasProperty<Float> top,
+            @NonNull HardwareCanvasProperty<Float> right,
+            @NonNull HardwareCanvasProperty<Float> bottom,
+            @NonNull HardwareCanvasProperty<Float> rx,
+            @NonNull HardwareCanvasProperty<Float> ry,
+            @NonNull HardwareCanvasProperty<Paint> paint) {
+
+        throw new UnsupportedOperationException();
+    }
+
+    protected void drawRoundRectSoftware(
+            @NonNull Canvas canvas,
+            @NonNull SoftwareCanvasProperty<Float> left,
+            @NonNull SoftwareCanvasProperty<Float> top,
+            @NonNull SoftwareCanvasProperty<Float> right,
+            @NonNull SoftwareCanvasProperty<Float> bottom,
+            @NonNull SoftwareCanvasProperty<Float> rx,
+            @NonNull SoftwareCanvasProperty<Float> ry,
+            @NonNull SoftwareCanvasProperty<Paint> paint) {
+
+        CanvasUtils.drawRoundRect(
+                canvas, left.getValue(), top.getValue(), right.getValue(), bottom.getValue(), rx.getValue(), ry.getValue(), paint.getValue());
+    }
+
+    protected void throwMixedPropertiesException() {
+        throw new IllegalArgumentException("Properties must be either all software or all hardware.");
+    }
+
+    @NonNull
+    public Animator createFloatAnimator(
+            @NonNull Drawable drawable,
+            @NonNull Canvas canvas,
+            @NonNull CanvasProperty<Float> property,
+            float targetValue) {
+
+        if (property.isHardware()) {
+            return createHardwareFloatAnimator(canvas, (HardwareCanvasProperty<Float>) property, targetValue);
+        } else {
+            return createSoftwareFloatAnimator(drawable, (SoftwareCanvasProperty<Float>) property, targetValue);
+        }
+    }
+
+    @NonNull
+    public Animator createPaintAlphaAnimator(
+            @Nullable Drawable drawable,
+            @NonNull Canvas canvas,
+            @NonNull CanvasProperty<Paint> property,
+            @FloatRange(from = 0f, to = 255f) float targetValue) {
+
+        if (property.isHardware()) {
+            return createHardwarePaintAlphaAnimator(canvas, (HardwareCanvasProperty<Paint>) property, targetValue);
+        } else {
+            return createSoftwarePaintAlphaAnimator(drawable, (SoftwareCanvasProperty<Paint>) property, Math.round(targetValue));
+        }
+    }
+
+    @NonNull
+    public Animator createPaintStrokeWidthAnimator(
+            @Nullable Drawable drawable,
+            @NonNull Canvas canvas,
+            @NonNull CanvasProperty<Paint> property,
+            float targetValue) {
+
+        if (property.isHardware()) {
+            return createHardwarePaintStrokeWidthAnimator(canvas, (HardwareCanvasProperty<Paint>) property, targetValue);
+        } else {
+            return createSoftwarePaintStrokeWidthAnimator(drawable, (SoftwareCanvasProperty<Paint>) property, targetValue);
+        }
+    }
+
+    @NonNull
+    protected Animator createHardwareFloatAnimator(
+            @DisplayListCanvas @Nullable Canvas canvas, @NonNull HardwareCanvasProperty<Float> property, float targetValue) {
+
+        throw new UnsupportedOperationException();
+    }
+
+    @NonNull
+    protected Animator createHardwarePaintAlphaAnimator(
+            @DisplayListCanvas @Nullable Canvas canvas,
+            @NonNull HardwareCanvasProperty<Paint> property,
+            @FloatRange(from = 0f, to = 255f) float targetValue) {
+
+        throw new UnsupportedOperationException();
+    }
+
+    @NonNull
+    protected Animator createHardwarePaintStrokeWidthAnimator(
+            @DisplayListCanvas @Nullable Canvas canvas, @NonNull HardwareCanvasProperty<Paint> property, float targetValue) {
+
+        throw new UnsupportedOperationException();
+    }
+
+    @NonNull
+    protected Animator createSoftwareFloatAnimator(
+            @Nullable final Drawable drawable, @NonNull final SoftwareCanvasProperty<Float> property, float targetValue) {
+
+        ValueAnimator animator = ValueAnimator.ofFloat(property.getValue(), targetValue);
+        animator.addUpdateListener(
+                new ValueAnimator.AnimatorUpdateListener() {
+                    @Override
+                    public void onAnimationUpdate(ValueAnimator animation) {
+                        property.setValue((float) animation.getAnimatedValue());
+                        if (drawable != null) {
+                            drawable.invalidateSelf();
+                        }
+                    }
+                });
+        return animator;
+    }
+
+    @NonNull
+    protected Animator createSoftwarePaintAlphaAnimator(
+            @Nullable final Drawable drawable, @NonNull final SoftwareCanvasProperty<Paint> property, @IntRange(from = 0, to = 255) int targetValue) {
+
+        ValueAnimator animator = ValueAnimator.ofInt(property.getValue().getAlpha(), Math.round(targetValue));
+        animator.addUpdateListener(
+                new ValueAnimator.AnimatorUpdateListener() {
+                    @Override
+                    public void onAnimationUpdate(ValueAnimator animation) {
+                        property.getValue().setAlpha((int) animation.getAnimatedValue());
+                        if (drawable != null) {
+                            drawable.invalidateSelf();
+                        }
+                    }
+                });
+        return animator;
+    }
+
+    @NonNull
+    protected Animator createSoftwarePaintStrokeWidthAnimator(
+            @Nullable final Drawable drawable, @NonNull final SoftwareCanvasProperty<Paint> property, float targetValue) {
+
+        ValueAnimator animator = ValueAnimator.ofFloat(property.getValue().getStrokeWidth(), targetValue);
+        animator.addUpdateListener(
+                new ValueAnimator.AnimatorUpdateListener() {
+                    @Override
+                    public void onAnimationUpdate(ValueAnimator animation) {
+                        property.getValue().setStrokeWidth((float) animation.getAnimatedValue());
+                        if (drawable != null) {
+                            drawable.invalidateSelf();
+                        }
+                    }
+                });
+        return animator;
+    }
+}

--- a/app/src/main/java/me/eugeniomarletti/renderthread/RenderThreadDelegateHw.java
+++ b/app/src/main/java/me/eugeniomarletti/renderthread/RenderThreadDelegateHw.java
@@ -1,0 +1,128 @@
+package me.eugeniomarletti.renderthread;
+
+import android.animation.Animator;
+import android.graphics.Canvas;
+import android.graphics.Paint;
+import android.support.annotation.FloatRange;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+
+import me.eugeniomarletti.renderthread.typeannotation.DisplayListCanvas;
+import me.eugeniomarletti.renderthread.typeannotation.RenderNodeAnimator;
+
+final class RenderThreadDelegateHw extends RenderThreadDelegate {
+
+    @NonNull
+    private final RenderThreadMethods renderThread;
+    
+    RenderThreadDelegateHw(@NonNull RenderThreadMethods renderThread) {
+        this.renderThread = renderThread;
+    }
+
+    @Override
+    public boolean isSupported() {
+        return true;
+    }
+
+    @NonNull
+    @Override
+    protected HardwareCanvasProperty<Float> createHardwareCanvasProperty(float initialValue) {
+        return new HardwareCanvasProperty<>(renderThread.createCanvasProperty(initialValue));
+    }
+
+    @NonNull
+    @Override
+    protected HardwareCanvasProperty<Paint> createHardwareCanvasProperty(@NonNull Paint initialValue) {
+        return new HardwareCanvasProperty<>(renderThread.createCanvasProperty(initialValue));
+    }
+
+    @Override
+    public boolean isDisplayListCanvas(@NonNull Canvas canvas) {
+        return canvas.isHardwareAccelerated() && renderThread.instanceOfDisplayListCanvas(canvas);
+    }
+
+    private void ensureDisplayListCanvas(@NonNull Canvas canvas) {
+        if (!isDisplayListCanvas(canvas)) {
+            throw new IllegalArgumentException("Canvas is not hardware accelerated.");
+        }
+    }
+
+    @Override
+    public void setTarget(@RenderNodeAnimator @NonNull Animator animator, @DisplayListCanvas @NonNull Canvas target) {
+        ensureDisplayListCanvas(target);
+        renderThread.setTarget(animator, target);
+    }
+
+    @Override
+    protected void drawCircleHardware(
+            @DisplayListCanvas @NonNull Canvas canvas,
+            @NonNull HardwareCanvasProperty<Float> cx,
+            @NonNull HardwareCanvasProperty<Float> cy,
+            @NonNull HardwareCanvasProperty<Float> radius,
+            @NonNull HardwareCanvasProperty<Paint> paint) {
+
+        ensureDisplayListCanvas(canvas);
+        renderThread.drawCircle(canvas, cx.getProperty(), cy.getProperty(), radius.getProperty(), paint.getProperty());
+    }
+
+    @Override
+    protected void drawRoundRectHardware(
+            @DisplayListCanvas @NonNull Canvas canvas,
+            @NonNull HardwareCanvasProperty<Float> left,
+            @NonNull HardwareCanvasProperty<Float> top,
+            @NonNull HardwareCanvasProperty<Float> right,
+            @NonNull HardwareCanvasProperty<Float> bottom,
+            @NonNull HardwareCanvasProperty<Float> rx,
+            @NonNull HardwareCanvasProperty<Float> ry,
+            @NonNull HardwareCanvasProperty<Paint> paint) {
+
+        ensureDisplayListCanvas(canvas);
+        renderThread.drawRoundRect(
+                canvas,
+                left.getProperty(),
+                top.getProperty(),
+                right.getProperty(),
+                bottom.getProperty(),
+                rx.getProperty(),
+                ry.getProperty(),
+                paint.getProperty());
+    }
+
+    @NonNull
+    @Override
+    protected Animator createHardwareFloatAnimator(
+            @DisplayListCanvas @Nullable Canvas canvas, @NonNull HardwareCanvasProperty<Float> property, float targetValue) {
+
+        Animator animator = renderThread.createFloatRenderNodeAnimator(property.getProperty(), targetValue);
+        if (canvas != null) {
+            setTarget(animator, canvas);
+        }
+        return animator;
+    }
+
+    @NonNull
+    @Override
+    protected Animator createHardwarePaintAlphaAnimator(
+            @DisplayListCanvas @Nullable Canvas canvas,
+            @NonNull HardwareCanvasProperty<Paint> property,
+            @FloatRange(from = 0f, to = 255f) float targetValue) {
+
+        Animator animator = renderThread.createPaintAlphaRenderNodeAnimator(property.getProperty(), targetValue);
+        if (canvas != null) {
+            setTarget(animator, canvas);
+        }
+        return animator;
+    }
+
+    @NonNull
+    @Override
+    protected Animator createHardwarePaintStrokeWidthAnimator(
+            @DisplayListCanvas @Nullable Canvas canvas, @NonNull HardwareCanvasProperty<Paint> property, float targetValue) {
+
+        Animator animator = renderThread.createPaintStrokeWidthRenderNodeAnimator(property.getProperty(), targetValue);
+        if (canvas != null) {
+            setTarget(animator, canvas);
+        }
+        return animator;
+    }
+}

--- a/app/src/main/java/me/eugeniomarletti/renderthread/RenderThreadMethods.java
+++ b/app/src/main/java/me/eugeniomarletti/renderthread/RenderThreadMethods.java
@@ -1,0 +1,381 @@
+package me.eugeniomarletti.renderthread;
+
+import android.animation.Animator;
+import android.graphics.Canvas;
+import android.graphics.Paint;
+import android.os.Build;
+import android.support.annotation.FloatRange;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.util.Log;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+import net.squanchy.BuildConfig;
+
+import me.eugeniomarletti.renderthread.typeannotation.CanvasProperty;
+import me.eugeniomarletti.renderthread.typeannotation.DisplayListCanvas;
+import me.eugeniomarletti.renderthread.typeannotation.RenderNodeAnimator;
+
+final class RenderThreadMethods {
+
+    private static final int MAX_SUPPORTED_ANDROID_VERSION = 25;
+    private static final int MIN_SUPPORTED_ANDROID_VERSION = 21;
+
+    @NonNull
+    private final Class<?> displayListCanvas;
+    @NonNull
+    private final Method displayListCanvas_drawCircle;
+    @NonNull
+    private final Method displayListCanvas_drawRoundRect;
+
+    @NonNull
+    private final Method canvasProperty_createFloat;
+    @NonNull
+    private final Method canvasProperty_createPaint;
+
+    @NonNull
+    private final Constructor<Animator> renderNodeAnimator_float;
+    @NonNull
+    private final Constructor<Animator> renderNodeAnimator_paint;
+    @NonNull
+    private final Method renderNodeAnimator_setTarget;
+    private final int renderNodeAnimator_paintField_strokeWidth;
+    private final int renderNodeAnimator_paintField_alpha;
+
+    private RenderThreadMethods(
+            @NonNull Class<?> displayListCanvas,
+            @NonNull Method displayListCanvas_drawCircle,
+            @NonNull Method displayListCanvas_drawRoundRect,
+            @NonNull Method canvasProperty_createFloat,
+            @NonNull Method canvasProperty_createPaint,
+            @NonNull Constructor<Animator> renderNodeAnimator_float,
+            @NonNull Constructor<Animator> renderNodeAnimator_paint,
+            @NonNull Method renderNodeAnimator_setTarget,
+            int renderNodeAnimator_paintField_strokeWidth,
+            int renderNodeAnimator_paintField_alpha) {
+
+        this.displayListCanvas = displayListCanvas;
+        this.displayListCanvas_drawCircle = displayListCanvas_drawCircle;
+        this.displayListCanvas_drawRoundRect = displayListCanvas_drawRoundRect;
+        this.canvasProperty_createFloat = canvasProperty_createFloat;
+        this.canvasProperty_createPaint = canvasProperty_createPaint;
+        this.renderNodeAnimator_float = renderNodeAnimator_float;
+        this.renderNodeAnimator_paint = renderNodeAnimator_paint;
+        this.renderNodeAnimator_setTarget = renderNodeAnimator_setTarget;
+        this.renderNodeAnimator_paintField_strokeWidth = renderNodeAnimator_paintField_strokeWidth;
+        this.renderNodeAnimator_paintField_alpha = renderNodeAnimator_paintField_alpha;
+    }
+
+    @Nullable
+    static RenderThreadMethods create(boolean skipAndroidVersionCheck) {
+        int sdk = Build.VERSION.SDK_INT;
+        if (!skipAndroidVersionCheck && !isSupportedAndroidVersion(sdk)) {
+            return null;
+        }
+        try {
+            ClassLoader classLoader = RenderThreadMethods.class.getClassLoader();
+            Class<?> displayListCanvas = loadDisplayListCanvasClassOrEquivalent(sdk, classLoader);
+            Class<?> canvasProperty = loadCanvasPropertyClass(classLoader);
+            Class<Animator> renderNodeAnimatorClass = loadRenderNodeAnimatorClass(classLoader);
+            Method displayListCanvas_drawCircle = getDisplayListCanvasDrawCircleMethod(displayListCanvas, canvasProperty);
+            Method displayListCanvas_drawRoundRect = getDisplayListCanvasDrawRoundRectMethod(displayListCanvas, canvasProperty);
+            Method canvasProperty_createFloat = getCanvasPropertyCreateFloatMethod(canvasProperty);
+            Method canvasProperty_createPaint = getCanvasPropertyCreatePaintMethod(canvasProperty);
+            Constructor<Animator> renderNodeAnimator_float = getRenderNodeAnimatorFloatConstructor(canvasProperty, renderNodeAnimatorClass);
+            Constructor<Animator> renderNodeAnimator_paint = getRenderNodeAnimatorPaintConstructor(canvasProperty, renderNodeAnimatorClass);
+            Method renderNodeAnimator_setTarget = getRenderNodeAnimatorSetTargetMethod(renderNodeAnimatorClass);
+            int renderNodeAnimator_paintField_strokeWidth = getRenderNodeAnimatorPaintStrokeWidthConstant(renderNodeAnimatorClass);
+            int renderNodeAnimator_paintField_alpha = getRenderNodeAnimatorPaintAlphaConstant(renderNodeAnimatorClass);
+
+            return new RenderThreadMethods(
+                    displayListCanvas,
+                    displayListCanvas_drawCircle,
+                    displayListCanvas_drawRoundRect,
+                    canvasProperty_createFloat,
+                    canvasProperty_createPaint,
+                    renderNodeAnimator_float,
+                    renderNodeAnimator_paint,
+                    renderNodeAnimator_setTarget,
+                    renderNodeAnimator_paintField_strokeWidth,
+                    renderNodeAnimator_paintField_alpha);
+
+        } catch (Exception e) {
+            logW("Error while getting render thread methods.", e);
+            return null;
+        }
+    }
+
+    public static boolean isSupportedAndroidVersion(int sdk) {
+        return sdk >= MIN_SUPPORTED_ANDROID_VERSION && sdk <= MAX_SUPPORTED_ANDROID_VERSION;
+    }
+
+    @NonNull
+    private static Class<?> loadDisplayListCanvasClassOrEquivalent(int sdk, @NonNull ClassLoader classLoader) throws ClassNotFoundException {
+        ClassNotFoundException error;
+        if (sdk >= 22) {
+            try {
+                return loadDisplayListCanvasClass(classLoader);
+            } catch (ClassNotFoundException e) {
+                error = e;
+            }
+            try {
+                return loadGLES20CanvasClass(classLoader);
+            } catch (ClassNotFoundException ignore) {
+            }
+        } else {
+            try {
+                return loadGLES20CanvasClass(classLoader);
+            } catch (ClassNotFoundException e) {
+                error = e;
+            }
+            try {
+                return loadDisplayListCanvasClass(classLoader);
+            } catch (ClassNotFoundException ignore) {
+            }
+        }
+        throw error;
+    }
+
+    @NonNull
+    private static Class<?> loadDisplayListCanvasClass(@NonNull ClassLoader classLoader) throws ClassNotFoundException {
+        return classLoader.loadClass("android.view.DisplayListCanvas");
+    }
+
+    @NonNull
+    private static Class<?> loadGLES20CanvasClass(@NonNull ClassLoader classLoader) throws ClassNotFoundException {
+        return classLoader.loadClass("android.view.GLES20Canvas");
+    }
+
+    @NonNull
+    private static Class<?> loadCanvasPropertyClass(@NonNull ClassLoader classLoader) throws ClassNotFoundException {
+        return classLoader.loadClass("android.graphics.CanvasProperty");
+    }
+
+    @NonNull
+    private static Class<Animator> loadRenderNodeAnimatorClass(@NonNull ClassLoader classLoader) throws ClassNotFoundException {
+        return castClass(classLoader.loadClass("android.view.RenderNodeAnimator"), Animator.class);
+    }
+
+    @NonNull
+    private static <T> Class<T> castClass(@NonNull Class<?> originalClass, @NonNull Class<T> targetClass) {
+        if (!targetClass.isAssignableFrom(originalClass)) {
+            throw new ClassCastException(String.format("Cannot cast class %s to %s.", originalClass, targetClass));
+        }
+        //noinspection unchecked
+        return (Class<T>) originalClass;
+    }
+
+    @NonNull
+    private static Method getDisplayListCanvasDrawCircleMethod(@NonNull Class<?> displayListCanvas, @NonNull Class<?> canvasProperty)
+            throws NoSuchMethodException {
+
+        Method displayListCanvas_drawCircle = displayListCanvas.getDeclaredMethod(
+                "drawCircle", canvasProperty, canvasProperty, canvasProperty, canvasProperty);
+        displayListCanvas_drawCircle.setAccessible(true);
+        return displayListCanvas_drawCircle;
+    }
+
+    @NonNull
+    private static Method getDisplayListCanvasDrawRoundRectMethod(@NonNull Class<?> displayListCanvas, @NonNull Class<?> canvasProperty)
+            throws NoSuchMethodException {
+
+        Method displayListCanvas_drawRoundRect = displayListCanvas.getDeclaredMethod(
+                "drawRoundRect", canvasProperty, canvasProperty, canvasProperty, canvasProperty, canvasProperty, canvasProperty, canvasProperty);
+        displayListCanvas_drawRoundRect.setAccessible(true);
+        return displayListCanvas_drawRoundRect;
+    }
+
+    @NonNull
+    private static Method getCanvasPropertyCreateFloatMethod(@NonNull Class<?> canvasProperty) throws NoSuchMethodException {
+        Method canvasProperty_createFloat = canvasProperty.getDeclaredMethod("createFloat", float.class);
+        canvasProperty_createFloat.setAccessible(true);
+        return canvasProperty_createFloat;
+    }
+
+    @NonNull
+    private static Method getCanvasPropertyCreatePaintMethod(@NonNull Class<?> canvasProperty) throws NoSuchMethodException {
+        Method canvasProperty_createPaint = canvasProperty.getDeclaredMethod("createPaint", Paint.class);
+        canvasProperty_createPaint.setAccessible(true);
+        return canvasProperty_createPaint;
+    }
+
+    @NonNull
+    private static Constructor<Animator> getRenderNodeAnimatorFloatConstructor(
+            @NonNull Class<?> canvasProperty, @NonNull Class<Animator> renderNodeAnimatorClass) throws NoSuchMethodException {
+
+        Constructor<Animator> renderNodeAnimator_float = renderNodeAnimatorClass.getConstructor(canvasProperty, float.class);
+        renderNodeAnimator_float.setAccessible(true);
+        return renderNodeAnimator_float;
+    }
+
+    @NonNull
+    private static Constructor<Animator> getRenderNodeAnimatorPaintConstructor(
+            @NonNull Class<?> canvasProperty, @NonNull Class<Animator> renderNodeAnimatorClass) throws NoSuchMethodException {
+
+        Constructor<Animator> renderNodeAnimator_paint = renderNodeAnimatorClass.getConstructor(canvasProperty, int.class, float.class);
+        renderNodeAnimator_paint.setAccessible(true);
+        return renderNodeAnimator_paint;
+    }
+
+    @NonNull
+    private static Method getRenderNodeAnimatorSetTargetMethod(@NonNull Class<Animator> renderNodeAnimatorClass) throws NoSuchMethodException {
+        Method renderNodeAnimator_setTarget = renderNodeAnimatorClass.getDeclaredMethod("setTarget", Canvas.class);
+        renderNodeAnimator_setTarget.setAccessible(true);
+        return renderNodeAnimator_setTarget;
+    }
+
+    private static int getRenderNodeAnimatorPaintStrokeWidthConstant(
+            @NonNull Class<Animator> renderNodeAnimatorClass) throws NoSuchFieldException, IllegalAccessException {
+
+        return getStaticIntConstant(renderNodeAnimatorClass, "PAINT_STROKE_WIDTH");
+    }
+
+    private static int getRenderNodeAnimatorPaintAlphaConstant(
+            @NonNull Class<Animator> renderNodeAnimatorClass) throws NoSuchFieldException, IllegalAccessException {
+
+        return getStaticIntConstant(renderNodeAnimatorClass, "PAINT_ALPHA");
+    }
+
+    private static int getStaticIntConstant(@NonNull Class<Animator> klass, @NonNull String fieldName)
+            throws NoSuchFieldException, IllegalAccessException {
+
+        Field constant = klass.getDeclaredField(fieldName);
+        constant.setAccessible(true);
+        return constant.getInt(null);
+    }
+
+    private static void logW(@NonNull String message, @NonNull Exception e) {
+        if (BuildConfig.DEBUG) {
+            Log.w(RenderThreadMethods.class.getSimpleName(), message, e);
+        }
+    }
+
+    @NonNull
+    @CanvasProperty(Float.class)
+    public Object createCanvasProperty(float initialValue) {
+        //noinspection TryWithIdenticalCatches
+        try {
+            return canvasProperty_createFloat.invoke(null, initialValue);
+        } catch (IllegalAccessException e) {
+            throw new RuntimeException(e);
+        } catch (InvocationTargetException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @NonNull
+    @CanvasProperty(Paint.class)
+    public Object createCanvasProperty(@NonNull Paint initialValue) {
+        //noinspection TryWithIdenticalCatches
+        try {
+            return canvasProperty_createPaint.invoke(null, initialValue);
+        } catch (IllegalAccessException e) {
+            throw new RuntimeException(e);
+        } catch (InvocationTargetException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public boolean instanceOfDisplayListCanvas(@Nullable Canvas canvas) {
+        return displayListCanvas.isInstance(canvas);
+    }
+
+    public void drawCircle(
+            @DisplayListCanvas @NonNull Canvas canvas,
+            @CanvasProperty(Float.class) @NonNull Object cx,
+            @CanvasProperty(Float.class) @NonNull Object cy,
+            @CanvasProperty(Float.class) @NonNull Object radius,
+            @CanvasProperty(Paint.class) @NonNull Object paint) {
+
+        //noinspection TryWithIdenticalCatches
+        try {
+            displayListCanvas_drawCircle.invoke(canvas, cx, cy, radius, paint);
+        } catch (IllegalAccessException e) {
+            throw new RuntimeException(e);
+        } catch (InvocationTargetException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public void drawRoundRect(
+            @DisplayListCanvas @NonNull Canvas canvas,
+            @CanvasProperty(Float.class) @NonNull Object left,
+            @CanvasProperty(Float.class) @NonNull Object top,
+            @CanvasProperty(Float.class) @NonNull Object right,
+            @CanvasProperty(Float.class) @NonNull Object bottom,
+            @CanvasProperty(Float.class) @NonNull Object rx,
+            @CanvasProperty(Float.class) @NonNull Object ry,
+            @CanvasProperty(Paint.class) @NonNull Object paint) {
+
+        //noinspection TryWithIdenticalCatches
+        try {
+            displayListCanvas_drawRoundRect.invoke(canvas, left, top, right, bottom, rx, ry, paint);
+        } catch (IllegalAccessException e) {
+            throw new RuntimeException(e);
+        } catch (InvocationTargetException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @NonNull
+    @RenderNodeAnimator
+    public Animator createFloatRenderNodeAnimator(@CanvasProperty(Float.class) @NonNull Object canvasProperty, float targetValue) {
+        //noinspection TryWithIdenticalCatches
+        try {
+            return renderNodeAnimator_float.newInstance(canvasProperty, targetValue);
+        } catch (InstantiationException e) {
+            throw new RuntimeException(e);
+        } catch (IllegalAccessException e) {
+            throw new RuntimeException(e);
+        } catch (InvocationTargetException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @NonNull
+    @RenderNodeAnimator
+    public Animator createPaintAlphaRenderNodeAnimator(
+            @CanvasProperty(Paint.class) @NonNull Object canvasProperty, @FloatRange(from = 0f, to = 255f) float targetValue) {
+
+        //noinspection TryWithIdenticalCatches
+        try {
+            return renderNodeAnimator_paint.newInstance(canvasProperty, renderNodeAnimator_paintField_alpha, targetValue);
+        } catch (InstantiationException e) {
+            throw new RuntimeException(e);
+        } catch (IllegalAccessException e) {
+            throw new RuntimeException(e);
+        } catch (InvocationTargetException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @NonNull
+    @RenderNodeAnimator
+    public Animator createPaintStrokeWidthRenderNodeAnimator(@CanvasProperty(Paint.class) @NonNull Object canvasProperty, float targetValue) {
+        //noinspection TryWithIdenticalCatches
+        try {
+            return renderNodeAnimator_paint.newInstance(canvasProperty, renderNodeAnimator_paintField_strokeWidth, targetValue);
+        } catch (InstantiationException e) {
+            throw new RuntimeException(e);
+        } catch (IllegalAccessException e) {
+            throw new RuntimeException(e);
+        } catch (InvocationTargetException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public void setTarget(@RenderNodeAnimator @NonNull Animator animator, @DisplayListCanvas @NonNull Canvas target) {
+        //noinspection TryWithIdenticalCatches
+        try {
+            renderNodeAnimator_setTarget.invoke(animator, target);
+        } catch (IllegalAccessException e) {
+            throw new RuntimeException(e);
+        } catch (InvocationTargetException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/app/src/main/java/me/eugeniomarletti/renderthread/SoftwareCanvasProperty.java
+++ b/app/src/main/java/me/eugeniomarletti/renderthread/SoftwareCanvasProperty.java
@@ -1,0 +1,27 @@
+package me.eugeniomarletti.renderthread;
+
+import android.support.annotation.NonNull;
+
+public final class SoftwareCanvasProperty<T> extends CanvasProperty<T> {
+
+    @NonNull
+    private T value;
+
+    SoftwareCanvasProperty(@NonNull T initialValue) {
+        value = initialValue;
+    }
+
+    @NonNull
+    T getValue() {
+        return value;
+    }
+
+    void setValue(@NonNull T value) {
+        this.value = value;
+    }
+
+    @Override
+    public boolean isHardware() {
+        return false;
+    }
+}

--- a/app/src/main/java/me/eugeniomarletti/renderthread/typeannotation/CanvasProperty.java
+++ b/app/src/main/java/me/eugeniomarletti/renderthread/typeannotation/CanvasProperty.java
@@ -1,0 +1,11 @@
+package me.eugeniomarletti.renderthread.typeannotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@Documented
+@Retention(RetentionPolicy.SOURCE)
+public @interface CanvasProperty {
+    @SuppressWarnings("unused") Class value() default Void.class;
+}

--- a/app/src/main/java/me/eugeniomarletti/renderthread/typeannotation/DisplayListCanvas.java
+++ b/app/src/main/java/me/eugeniomarletti/renderthread/typeannotation/DisplayListCanvas.java
@@ -1,0 +1,10 @@
+package me.eugeniomarletti.renderthread.typeannotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@Documented
+@Retention(RetentionPolicy.SOURCE)
+public @interface DisplayListCanvas {
+}

--- a/app/src/main/java/me/eugeniomarletti/renderthread/typeannotation/RenderNodeAnimator.java
+++ b/app/src/main/java/me/eugeniomarletti/renderthread/typeannotation/RenderNodeAnimator.java
@@ -1,0 +1,10 @@
+package me.eugeniomarletti.renderthread.typeannotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@Documented
+@Retention(RetentionPolicy.SOURCE)
+public @interface RenderNodeAnimator {
+}

--- a/app/src/main/java/net/squanchy/navigation/HomeActivity.java
+++ b/app/src/main/java/net/squanchy/navigation/HomeActivity.java
@@ -139,6 +139,7 @@ public class HomeActivity extends TypefaceStyleableActivity {
     private void selectInitialPage(BottomNavigationSection section) {
         swapPageTo(section);
         bottomNavigationView.cancelTransitions();
+        bottomNavigationView.selectItemAt(section.ordinal());
 
         Resources.Theme theme = getThemeFor(section);
         bottomNavigationView.setBackgroundColor(getColorFromTheme(theme, android.support.design.R.attr.colorPrimary));

--- a/app/src/main/java/net/squanchy/navigation/HomeActivity.java
+++ b/app/src/main/java/net/squanchy/navigation/HomeActivity.java
@@ -22,6 +22,8 @@ import net.squanchy.support.widget.InterceptingBottomNavigationView;
 
 public class HomeActivity extends TypefaceStyleableActivity {
 
+    private static final String STATE_KEY_SELECTED_PAGE_INDEX = "HomeActivity.selected_page_index";
+
     private final Map<BottomNavigationSection, View> pageViews = new HashMap<>(4);
 
     private int pageFadeDurationMillis;
@@ -43,7 +45,13 @@ public class HomeActivity extends TypefaceStyleableActivity {
         bottomNavigationView = (InterceptingBottomNavigationView) findViewById(R.id.bottom_navigation);
         setupBottomNavigation(bottomNavigationView);
 
-        selectPage(BottomNavigationSection.SCHEDULE);
+        BottomNavigationSection selectedPage = getSelectedSectionOrDefault(savedInstanceState);
+        selectPage(selectedPage);
+    }
+
+    private BottomNavigationSection getSelectedSectionOrDefault(Bundle savedInstanceState) {
+        int selectedPageIndex = savedInstanceState.getInt(STATE_KEY_SELECTED_PAGE_INDEX, BottomNavigationSection.SCHEDULE.ordinal());
+        return BottomNavigationSection.values()[selectedPageIndex];
     }
 
     private void collectPageViewsInto(Map<BottomNavigationSection, View> pageViews) {
@@ -125,5 +133,11 @@ public class HomeActivity extends TypefaceStyleableActivity {
         ValueAnimator animator = ValueAnimator.ofArgb(currentColor, targetColor).setDuration(pageFadeDurationMillis);
         animator.addUpdateListener(listener);
         animator.start();
+    }
+
+    @Override
+    protected void onSaveInstanceState(Bundle outState) {
+        outState.putInt(STATE_KEY_SELECTED_PAGE_INDEX, currentSection.ordinal());
+        super.onSaveInstanceState(outState);
     }
 }

--- a/app/src/main/java/net/squanchy/navigation/HomeActivity.java
+++ b/app/src/main/java/net/squanchy/navigation/HomeActivity.java
@@ -143,6 +143,7 @@ public class HomeActivity extends TypefaceStyleableActivity {
 
         Resources.Theme theme = getThemeFor(section);
         bottomNavigationView.setBackgroundColor(getColorFromTheme(theme, android.support.design.R.attr.colorPrimary));
+        getWindow().setStatusBarColor(getColorFromTheme(theme, android.R.attr.statusBarColor));
 
         currentSection = section;
     }

--- a/app/src/main/java/net/squanchy/navigation/HomeActivity.java
+++ b/app/src/main/java/net/squanchy/navigation/HomeActivity.java
@@ -2,12 +2,10 @@ package net.squanchy.navigation;
 
 import android.animation.ValueAnimator;
 import android.content.res.Resources;
-import android.graphics.drawable.ColorDrawable;
 import android.os.Bundle;
 import android.support.annotation.AttrRes;
 import android.support.annotation.ColorInt;
 import android.support.annotation.Nullable;
-import android.support.design.widget.BottomNavigationView;
 import android.support.transition.Fade;
 import android.support.transition.TransitionManager;
 import android.util.TypedValue;
@@ -20,6 +18,7 @@ import java.util.Map;
 
 import net.squanchy.R;
 import net.squanchy.fonts.TypefaceStyleableActivity;
+import net.squanchy.support.widget.InterceptingBottomNavigationView;
 
 public class HomeActivity extends TypefaceStyleableActivity {
 
@@ -28,7 +27,7 @@ public class HomeActivity extends TypefaceStyleableActivity {
     private int pageFadeDurationMillis;
 
     private BottomNavigationSection currentSection;
-    private BottomNavigationView bottomNavigationView;
+    private InterceptingBottomNavigationView bottomNavigationView;
     private ViewGroup pageContainer;
 
     @Override
@@ -36,12 +35,12 @@ public class HomeActivity extends TypefaceStyleableActivity {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_home);
 
-        pageFadeDurationMillis = getResources().getInteger(android.R.integer.config_mediumAnimTime);
+        pageFadeDurationMillis = getResources().getInteger(android.R.integer.config_shortAnimTime);
 
         pageContainer = (ViewGroup) findViewById(R.id.page_container);
         collectPageViewsInto(pageViews);
 
-        bottomNavigationView = (BottomNavigationView) findViewById(R.id.bottom_navigation);
+        bottomNavigationView = (InterceptingBottomNavigationView) findViewById(R.id.bottom_navigation);
         setupBottomNavigation(bottomNavigationView);
 
         selectPage(BottomNavigationSection.SCHEDULE);
@@ -54,9 +53,9 @@ public class HomeActivity extends TypefaceStyleableActivity {
         pageViews.put(BottomNavigationSection.VENUE_INFO, pageContainer.findViewById(R.id.venue_content_root));
     }
 
-    private void setupBottomNavigation(BottomNavigationView bottomNavigationView) {
+    private void setupBottomNavigation(InterceptingBottomNavigationView bottomNavigationView) {
         BottomNavigationHelper.disableShiftMode(bottomNavigationView);
-        bottomNavigationView.setBackground(bottomNavigationView.getBackground().mutate());
+        bottomNavigationView.setRevealDurationMillis(pageFadeDurationMillis);
 
         bottomNavigationView.setOnNavigationItemSelectedListener(
                 item -> {
@@ -96,7 +95,7 @@ public class HomeActivity extends TypefaceStyleableActivity {
 
         Resources.Theme theme = getThemeFor(section);
         setStatusBarColor(getColorFromTheme(theme, android.R.attr.statusBarColor));
-        setBottomNavigationBarColor(getColorFromTheme(theme, android.support.design.R.attr.colorPrimary));
+        bottomNavigationView.setColorProvider(() -> getColorFromTheme(theme, android.support.design.R.attr.colorPrimary));
 
         currentSection = section;
     }
@@ -120,13 +119,6 @@ public class HomeActivity extends TypefaceStyleableActivity {
         int currentStatusBarColor = window.getStatusBarColor();
 
         animateColor(currentStatusBarColor, color, animation -> window.setStatusBarColor((int) animation.getAnimatedValue()));
-    }
-
-    private void setBottomNavigationBarColor(@ColorInt int color) {
-        ColorDrawable backgroundDrawable = (ColorDrawable) bottomNavigationView.getBackground();
-        int currentBackgroundColor = backgroundDrawable.getColor();
-
-        animateColor(currentBackgroundColor, color, animation -> backgroundDrawable.setColor((int) animation.getAnimatedValue()));
     }
 
     private void animateColor(@ColorInt int currentColor, @ColorInt int targetColor, ValueAnimator.AnimatorUpdateListener listener) {

--- a/app/src/main/java/net/squanchy/support/graphics/CircularRevealDrawable.java
+++ b/app/src/main/java/net/squanchy/support/graphics/CircularRevealDrawable.java
@@ -44,12 +44,13 @@ public class CircularRevealDrawable extends ColorDrawable {
     public static CircularRevealDrawable from(int initialColor) {
         CircularRevealDrawable revealDrawable = new CircularRevealDrawable();
         revealDrawable.setColor(initialColor);
+        revealDrawable.targetColor = initialColor;
         return revealDrawable;
     }
 
-    public void animateToColor(@ColorInt int color, @IntRange(from = 0) int durationMillis) {
+    public void animateToColor(@ColorInt int newColor, @IntRange(from = 0) int durationMillis) {
         revealDuration = durationMillis;
-        pendingTargetColor = color;
+        pendingTargetColor = newColor;
         startAnimationOnNextDraw = true;
         setColor(targetColor);
     }
@@ -108,6 +109,12 @@ public class CircularRevealDrawable extends ColorDrawable {
         super.onBoundsChange(bounds);
         width = bounds.width();
         height = bounds.height();
+    }
+
+    @Override
+    public void setColor(int color) {
+        targetColor = color;
+        super.setColor(color);
     }
 
     public void cancelTransitions() {

--- a/app/src/main/java/net/squanchy/support/graphics/CircularRevealDrawable.java
+++ b/app/src/main/java/net/squanchy/support/graphics/CircularRevealDrawable.java
@@ -41,9 +41,9 @@ public class CircularRevealDrawable extends ColorDrawable {
     @ColorInt
     private int targetColor;
 
-    public static CircularRevealDrawable from(ColorDrawable colorDrawable) {
+    public static CircularRevealDrawable from(int initialColor) {
         CircularRevealDrawable revealDrawable = new CircularRevealDrawable();
-        revealDrawable.setColor(colorDrawable.getColor());
+        revealDrawable.setColor(initialColor);
         return revealDrawable;
     }
 
@@ -82,10 +82,8 @@ public class CircularRevealDrawable extends ColorDrawable {
         radiusProperty = RenderThread.createCanvasProperty(canvas, initialRadius);
         paintProperty = RenderThread.createCanvasProperty(canvas, animationPaint);
 
-        if (radiusAnimator != null && radiusAnimator.isRunning()) {
-            radiusAnimator.cancel();
-            setColor(targetColor);
-        }
+        cancelTransitions();
+
         radiusAnimator = RenderThread.createFloatAnimator(this, canvas, radiusProperty, targetRadius);
         radiusAnimator.setInterpolator(interpolator);
         radiusAnimator.setDuration(revealDuration);
@@ -110,5 +108,14 @@ public class CircularRevealDrawable extends ColorDrawable {
         super.onBoundsChange(bounds);
         width = bounds.width();
         height = bounds.height();
+    }
+
+    public void cancelTransitions() {
+        if (radiusAnimator == null || !radiusAnimator.isRunning()) {
+            return;
+        }
+
+        radiusAnimator.cancel();
+        setColor(targetColor);
     }
 }

--- a/app/src/main/java/net/squanchy/support/graphics/CircularRevealDrawable.java
+++ b/app/src/main/java/net/squanchy/support/graphics/CircularRevealDrawable.java
@@ -1,0 +1,134 @@
+package net.squanchy.support.graphics;
+
+import android.animation.Animator;
+import android.graphics.Canvas;
+import android.graphics.Paint;
+import android.graphics.Rect;
+import android.graphics.drawable.ColorDrawable;
+import android.support.annotation.ColorInt;
+import android.support.annotation.IntRange;
+import android.support.v4.view.animation.FastOutLinearInInterpolator;
+import android.view.animation.Interpolator;
+
+import me.eugeniomarletti.renderthread.CanvasProperty;
+import me.eugeniomarletti.renderthread.RenderThread;
+
+public class CircularRevealDrawable extends ColorDrawable {
+
+    private final Paint animationPaint = new Paint(Paint.ANTI_ALIAS_FLAG);
+
+    private final SimpleAnimationEndListener animationEndListener = new SimpleAnimationEndListener() {
+        @Override
+        public void onAnimationEnd(Animator animation) {
+            setColor(targetColor);
+        }
+    };
+    
+    private final Interpolator interpolator = new FastOutLinearInInterpolator();
+
+    private Animator radiusAnimator;
+
+    private CanvasProperty<Float> centerXProperty;
+    private CanvasProperty<Float> centerYProperty;
+    private CanvasProperty<Float> radiusProperty;
+    private CanvasProperty<Paint> paintProperty;
+
+    private boolean startAnimationOnNextDraw;
+
+    private int durationMillis;
+
+    private float hotspotX;
+    private float hotspotY;
+    private int width;
+    private int height;
+
+    @ColorInt
+    private int targetColor;
+
+    public static CircularRevealDrawable from(ColorDrawable colorDrawable) {
+        CircularRevealDrawable revealDrawable = new CircularRevealDrawable();
+        revealDrawable.setColor(colorDrawable.getColor());
+        return revealDrawable;
+    }
+
+    public void animateToColor(@ColorInt int color, @IntRange(from = 0) int durationMillis) {
+        targetColor = color;
+        startAnimationOnNextDraw = true;
+        this.durationMillis = durationMillis;
+        invalidateSelf();
+    }
+
+    @Override
+    public void draw(Canvas canvas) {
+        // 1. Let the "main" color be drawn
+        super.draw(canvas);
+
+        // 2. If we just got a reveal start request, go with it
+        if (startAnimationOnNextDraw) {
+            initializeAnimation(canvas);
+            radiusAnimator.start();
+            startAnimationOnNextDraw = false;
+        }
+
+        if (centerXProperty != null && centerYProperty != null && radiusProperty != null && paintProperty != null) {
+            RenderThread.drawCircle(canvas, centerXProperty, centerYProperty, radiusProperty, paintProperty);
+        }
+    }
+
+    private void initializeAnimation(Canvas canvas) {
+        float initialRadius = 0f;
+        float targetRadius = calculateTargetRadius();
+        animationPaint.setColor(targetColor);
+
+        centerXProperty = RenderThread.createCanvasProperty(canvas, hotspotX);
+        centerYProperty = RenderThread.createCanvasProperty(canvas, hotspotY);
+        radiusProperty = RenderThread.createCanvasProperty(canvas, initialRadius);
+        paintProperty = RenderThread.createCanvasProperty(canvas, animationPaint);
+
+        if (radiusAnimator != null) {
+            radiusAnimator.cancel();
+        }
+        radiusAnimator = RenderThread.createFloatAnimator(this, canvas, radiusProperty, targetRadius);
+        radiusAnimator.setInterpolator(interpolator);
+        radiusAnimator.setDuration(durationMillis);
+        radiusAnimator.addListener(animationEndListener);
+    }
+
+    private float calculateTargetRadius() {
+        float maxXDistance = Math.max(hotspotX, width - hotspotX);
+        float maxYDistance = Math.max(hotspotY, height - hotspotY);
+        return (float) Math.sqrt(maxXDistance * maxXDistance + maxYDistance * maxYDistance);
+    }
+
+    @Override
+    public void setHotspot(float x, float y) {
+        super.setHotspot(x, y);
+        hotspotX = x;
+        hotspotY = y;
+    }
+
+    @Override
+    protected void onBoundsChange(Rect bounds) {
+        super.onBoundsChange(bounds);
+        width = bounds.width();
+        height = bounds.height();
+    }
+
+    private abstract static class SimpleAnimationEndListener implements Animator.AnimatorListener {
+
+        @Override
+        public void onAnimationStart(Animator animation) {
+            // Don't care
+        }
+
+        @Override
+        public void onAnimationCancel(Animator animation) {
+            // Don't care
+        }
+
+        @Override
+        public void onAnimationRepeat(Animator animation) {
+            // Don't care
+        }
+    }
+}

--- a/app/src/main/java/net/squanchy/support/widget/InterceptingBottomNavigationView.java
+++ b/app/src/main/java/net/squanchy/support/widget/InterceptingBottomNavigationView.java
@@ -60,6 +60,16 @@ public class InterceptingBottomNavigationView extends BottomNavigationView {
     }
 
     @Override
+    public void setBackgroundColor(@ColorInt int color) {
+        Drawable background = getBackground();
+        if (background instanceof CircularRevealDrawable) {
+            updateBackgroundColor(background, color);
+        } else {
+            setBackgroundColor(color);
+        }
+    }
+
+    @Override
     public void setBackground(Drawable background) {
         if (background instanceof ColorDrawable) {
             Drawable currentBackground = getBackground();

--- a/app/src/main/java/net/squanchy/support/widget/InterceptingBottomNavigationView.java
+++ b/app/src/main/java/net/squanchy/support/widget/InterceptingBottomNavigationView.java
@@ -1,0 +1,92 @@
+package net.squanchy.support.widget;
+
+import android.content.Context;
+import android.graphics.drawable.ColorDrawable;
+import android.graphics.drawable.Drawable;
+import android.support.annotation.ColorInt;
+import android.support.annotation.IntRange;
+import android.support.annotation.Nullable;
+import android.support.design.widget.BottomNavigationView;
+import android.util.AttributeSet;
+import android.view.MenuItem;
+import android.view.MotionEvent;
+
+import net.squanchy.support.graphics.CircularRevealDrawable;
+
+public class InterceptingBottomNavigationView extends BottomNavigationView {
+
+    private int revealDurationMillis;
+
+    private MotionEvent lastUpEvent;
+    private OnNavigationItemSelectedListener listener;
+    private ColorProvider colorProvider;
+
+    public InterceptingBottomNavigationView(Context context, AttributeSet attrs) {
+        this(context, attrs, 0);
+    }
+
+    public InterceptingBottomNavigationView(Context context, AttributeSet attrs, int defStyleAttr) {
+        super(context, attrs, defStyleAttr);
+
+        super.setOnNavigationItemSelectedListener(this::onItemSelected);
+        revealDurationMillis = getResources().getInteger(android.R.integer.config_shortAnimTime);
+    }
+
+    public void setRevealDurationMillis(@IntRange(from = 0) int revealDurationMillis) {
+        this.revealDurationMillis = revealDurationMillis;
+    }
+
+    @Override
+    public void setBackground(Drawable background) {
+        if (background instanceof ColorDrawable) {
+            super.setBackground(CircularRevealDrawable.from((ColorDrawable) background));
+        } else {
+            throw new IllegalArgumentException("Only ColorDrawables allowed");
+        }
+    }
+
+    private boolean onItemSelected(MenuItem menuItem) {
+        boolean itemSelected = true;
+        if (listener != null) {
+            itemSelected = listener.onNavigationItemSelected(menuItem);
+        }
+
+        if (itemSelected && colorProvider != null) {
+            startCircularRevealTo(colorProvider.getSelectedItemColor());
+        }
+
+        return itemSelected;
+    }
+
+    private void startCircularRevealTo(int color) {
+        CircularRevealDrawable revealDrawable = (CircularRevealDrawable) getBackground();
+        revealDrawable.setHotspot(
+                lastUpEvent.getX() - getX(),
+                lastUpEvent.getY() - getY()
+        );
+        revealDrawable.animateToColor(color, revealDurationMillis);
+    }
+
+    @Override
+    public void setOnNavigationItemSelectedListener(@Nullable OnNavigationItemSelectedListener listener) {
+        this.listener = listener;
+    }
+
+    @Override
+    public boolean onInterceptTouchEvent(MotionEvent ev) {
+        if (ev.getAction() == MotionEvent.ACTION_UP) {
+            lastUpEvent = ev;
+        }
+        return super.onInterceptTouchEvent(ev);
+    }
+
+    public void setColorProvider(ColorProvider colorProvider) {
+        this.colorProvider = colorProvider;
+    }
+
+    public interface ColorProvider {
+
+        @ColorInt
+        int getSelectedItemColor();
+    }
+}

--- a/app/src/main/java/net/squanchy/support/widget/InterceptingBottomNavigationView.java
+++ b/app/src/main/java/net/squanchy/support/widget/InterceptingBottomNavigationView.java
@@ -32,19 +32,6 @@ public class InterceptingBottomNavigationView extends BottomNavigationView {
         revealDurationMillis = getResources().getInteger(android.R.integer.config_shortAnimTime);
     }
 
-    public void setRevealDurationMillis(@IntRange(from = 0) int revealDurationMillis) {
-        this.revealDurationMillis = revealDurationMillis;
-    }
-
-    @Override
-    public void setBackground(Drawable background) {
-        if (background instanceof ColorDrawable) {
-            super.setBackground(CircularRevealDrawable.from((ColorDrawable) background));
-        } else {
-            throw new IllegalArgumentException("Only ColorDrawables allowed");
-        }
-    }
-
     private boolean onItemSelected(MenuItem menuItem) {
         boolean itemSelected = true;
         if (listener != null) {
@@ -65,6 +52,36 @@ public class InterceptingBottomNavigationView extends BottomNavigationView {
                 lastUpEvent.getY() - getY()
         );
         revealDrawable.animateToColor(color, revealDurationMillis);
+    }
+
+    public void setRevealDurationMillis(@IntRange(from = 0) int revealDurationMillis) {
+        this.revealDurationMillis = revealDurationMillis;
+    }
+
+    @Override
+    public void setBackground(Drawable background) {
+        if (background instanceof ColorDrawable) {
+            Drawable currentBackground = getBackground();
+            int newColor = ((ColorDrawable) background).getColor();
+            updateBackgroundColor(currentBackground, newColor);
+        } else {
+            throw new IllegalArgumentException("Only ColorDrawables are supported");
+        }
+    }
+
+    private void updateBackgroundColor(Drawable drawable, int newColor) {
+        if (drawable instanceof CircularRevealDrawable) {
+            ((CircularRevealDrawable) drawable).setColor(newColor);
+        } else {
+            super.setBackground(CircularRevealDrawable.from(newColor));
+        }
+    }
+
+    public void cancelTransitions() {
+        Drawable background = getBackground();
+        if (background instanceof CircularRevealDrawable) {
+            ((CircularRevealDrawable) background).cancelTransitions();
+        }
     }
 
     @Override

--- a/app/src/main/java/net/squanchy/support/widget/InterceptingBottomNavigationView.java
+++ b/app/src/main/java/net/squanchy/support/widget/InterceptingBottomNavigationView.java
@@ -6,6 +6,7 @@ import android.graphics.drawable.Drawable;
 import android.support.annotation.ColorInt;
 import android.support.annotation.IntRange;
 import android.support.annotation.Nullable;
+import android.support.design.internal.BottomNavigationMenuView;
 import android.support.design.widget.BottomNavigationView;
 import android.util.AttributeSet;
 import android.view.MenuItem;
@@ -99,6 +100,11 @@ public class InterceptingBottomNavigationView extends BottomNavigationView {
 
     public void setColorProvider(ColorProvider colorProvider) {
         this.colorProvider = colorProvider;
+    }
+
+    public void selectItemAt(@IntRange(from = 0) int position) {
+        getMenu().getItem(position).setChecked(true);
+        ((BottomNavigationMenuView) getChildAt(0)).updateMenuView();
     }
 
     public interface ColorProvider {

--- a/app/src/main/res/layout/activity_home.xml
+++ b/app/src/main/res/layout/activity_home.xml
@@ -29,12 +29,13 @@
 
   </FrameLayout>
 
-  <android.support.design.widget.BottomNavigationView
+  <net.squanchy.support.widget.InterceptingBottomNavigationView
     android:id="@+id/bottom_navigation"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:layout_alignParentBottom="true"
     android:background="?colorPrimary"
+    android:descendantFocusability="beforeDescendants"
     app:itemIconTint="@color/bottom_navigation_item"
     app:itemTextColor="@color/bottom_navigation_item"
     app:menu="@menu/bottom_bar_menu" />


### PR DESCRIPTION
A LOT of hacks, but we have buttery smooth circular reveals on the bottom tabs now! 🎉

I have inlined @Takhion's [`RenderThread`](https://github.com/Takhion/renderthread) in the codebase as I needed to do some changes. Will do a PR against mainline after things are cleaned up a bit and then un-inline and use the real dependency.

A lot of hacking also to get the touch events for the `BottomNavigationBar` which, in its infinite wisdom, lacks any sort of useful callbacks and hooks into its behaviour or appearance.

![bottom-tabs-reveal](https://cloud.githubusercontent.com/assets/153802/23519891/77b7ccc4-ff70-11e6-8cc1-2ff4a0736e57.gif)

TODO: circular reveals when the user selects a tab with a dpad/talkback are probably "broken" and might crash the app (there is no last "up" motion event set), will do that separately next.
