### PR TITLE
SQ-SC/Support D-Pad nav in bottombar

### DIFF
--- a/app/src/main/java/net/squanchy/navigation/HomeActivity.java
+++ b/app/src/main/java/net/squanchy/navigation/HomeActivity.java
@@ -51,6 +51,12 @@ public class HomeActivity extends TypefaceStyleableActivity {
         selectInitialPage(selectedPage);
     }
 
+    @Override
+    protected void onStart() {
+        super.onStart();
+        selectInitialPage(currentSection);
+    }
+
     private void collectPageViewsInto(Map<BottomNavigationSection, View> pageViews) {
         pageViews.put(BottomNavigationSection.SCHEDULE, pageContainer.findViewById(R.id.schedule_content_root));
         pageViews.put(BottomNavigationSection.FAVORITES, pageContainer.findViewById(R.id.favorites_content_root));

--- a/app/src/main/java/net/squanchy/support/view/Hotspot.java
+++ b/app/src/main/java/net/squanchy/support/view/Hotspot.java
@@ -1,0 +1,30 @@
+package net.squanchy.support.view;
+
+import android.view.MotionEvent;
+import android.view.View;
+
+import com.google.auto.value.AutoValue;
+
+@AutoValue
+public abstract class Hotspot {
+
+    public static Hotspot from(MotionEvent motionEvent) {
+        return new AutoValue_Hotspot(motionEvent.getX(), motionEvent.getY());
+    }
+
+    @SuppressWarnings("MagicNumber")    // Just dividing by two to get the centre
+    public static Hotspot fromCenterOf(View view) {
+        float x = view.getX() + view.getWidth() / 2f;
+        float y = view.getY() + view.getHeight() / 2f;
+
+        return new AutoValue_Hotspot(x, y);
+    }
+
+    public abstract float x();
+
+    public abstract float y();
+
+    public Hotspot offsetToParent(View parent) {
+        return new AutoValue_Hotspot(x() + parent.getX(), y() + parent.getY());
+    }
+}

--- a/app/src/main/java/net/squanchy/support/widget/InterceptingBottomNavigationView.java
+++ b/app/src/main/java/net/squanchy/support/widget/InterceptingBottomNavigationView.java
@@ -22,15 +22,11 @@ import net.squanchy.support.view.Hotspot;
 
 public class InterceptingBottomNavigationView extends BottomNavigationView {
 
-    private int revealDurationMillis;
-
     private Optional<MotionEvent> lastUpEvent = Optional.absent();
+    private Optional<OnNavigationItemSelectedListener> listener = Optional.absent();
+    private Optional<ColorProvider> colorProvider = Optional.absent();
 
-    @Nullable
-    private OnNavigationItemSelectedListener listener;
-
-    @Nullable
-    private ColorProvider colorProvider;
+    private int revealDurationMillis;
 
     public InterceptingBottomNavigationView(Context context, AttributeSet attrs) {
         this(context, attrs, 0);
@@ -45,12 +41,12 @@ public class InterceptingBottomNavigationView extends BottomNavigationView {
 
     private boolean onItemSelected(MenuItem menuItem) {
         boolean itemSelected = true;
-        if (listener != null) {
-            itemSelected = listener.onNavigationItemSelected(menuItem);
+        if (listener.isPresent()) {
+            itemSelected = listener.get().onNavigationItemSelected(menuItem);
         }
 
-        if (itemSelected && colorProvider != null) {
-            startCircularReveal(colorProvider.getSelectedItemColor(), menuItem);
+        if (itemSelected && colorProvider.isPresent()) {
+            startCircularReveal(colorProvider.get().getSelectedItemColor(), menuItem);
         }
 
         return itemSelected;
@@ -137,7 +133,7 @@ public class InterceptingBottomNavigationView extends BottomNavigationView {
 
     @Override
     public void setOnNavigationItemSelectedListener(@Nullable OnNavigationItemSelectedListener listener) {
-        this.listener = listener;
+        this.listener = Optional.ofNullable(listener);
     }
 
     @Override
@@ -151,7 +147,7 @@ public class InterceptingBottomNavigationView extends BottomNavigationView {
     }
 
     public void setColorProvider(@Nullable ColorProvider colorProvider) {
-        this.colorProvider = colorProvider;
+        this.colorProvider = Optional.ofNullable(colorProvider);
     }
 
     public void selectItemAt(@IntRange(from = 0) int position) {


### PR DESCRIPTION
This PR adds the missing keyboard and a11y support for the bottom bar navigation as per #102. The app won't crash anymore when you select a tab with Talkback or D-Pad (assuming you manage the latter; seems D-Pad focus traversal is borked at the moment). The PR also fixes problems when resuming the activity if it had not been unloaded from memory, where the bottom bar would have the wrong colour.