### PR TITLE
Fixup optional usage

### DIFF
--- a/app/src/main/java/net/squanchy/support/lang/Func0.java
+++ b/app/src/main/java/net/squanchy/support/lang/Func0.java
@@ -1,0 +1,6 @@
+package net.squanchy.support.lang;
+
+public interface Func0<V> {
+
+    V call();
+}

--- a/app/src/main/java/net/squanchy/support/lang/Func1.java
+++ b/app/src/main/java/net/squanchy/support/lang/Func1.java
@@ -1,8 +1,6 @@
 package net.squanchy.support.lang;
 
-
 public interface Func1<T, R> {
 
-    R apply(T t);
-
+    R call(T t);
 }

--- a/app/src/main/java/net/squanchy/support/lang/Func2.java
+++ b/app/src/main/java/net/squanchy/support/lang/Func2.java
@@ -2,5 +2,5 @@ package net.squanchy.support.lang;
 
 public interface Func2<T, U, R> {
 
-    R apply(T t, U u);
+    R call(T t, U u);
 }

--- a/app/src/main/java/net/squanchy/support/lang/Lists.java
+++ b/app/src/main/java/net/squanchy/support/lang/Lists.java
@@ -13,7 +13,7 @@ public final class Lists {
 
         List<R> result = new ArrayList<>(list.size());
         for (T t : list) {
-            result.add(function.apply(t));
+            result.add(function.call(t));
         }
 
         return result;
@@ -21,7 +21,7 @@ public final class Lists {
 
     public static <T> T find(List<T> list, Func1<T, Boolean> predicate) {
         for (T t : list) {
-            if (predicate.apply(t)) {
+            if (predicate.call(t)) {
                 return t;
             }
         }

--- a/app/src/main/java/net/squanchy/support/lang/Lists.java
+++ b/app/src/main/java/net/squanchy/support/lang/Lists.java
@@ -31,10 +31,11 @@ public final class Lists {
     }
 
     public static <T, R> R reduce(R initial, List<T> list, Func2<R, T, R> reducer) {
+        R reducedValue = initial;
         for (T t : list) {
-            initial = reducer.apply(initial, t);
+            reducedValue = reducer.call(reducedValue, t);
         }
 
-        return initial;
+        return reducedValue;
     }
 }

--- a/app/src/main/java/net/squanchy/support/lang/Optional.java
+++ b/app/src/main/java/net/squanchy/support/lang/Optional.java
@@ -1,5 +1,7 @@
 package net.squanchy.support.lang;
 
+import android.support.annotation.Nullable;
+
 public final class Optional<T> {
 
     @SuppressWarnings("unchecked")  // Type erasure has us covered here, we don't care
@@ -45,20 +47,33 @@ public final class Optional<T> {
         return data;
     }
 
-    public <V> Optional<V> flatMap(Func1<T, Optional<V>> func) {
-        return isPresent() ? func.apply(data) : Optional.absent();
-    }
-
-    public void subscribe(Procedure1<T> onNext, Procedure0 onError) {
-        if (isPresent()) {
-            onNext.apply(data);
-        } else {
-            onError.apply();
-        }
-    }
-
     public T or(T elseCase) {
         return isPresent() ? get() : elseCase;
+    }
+
+    public Optional<T> or(Optional<T> elseCase) {
+        return isPresent() ? this : elseCase;
+    }
+
+    public Optional<T> or(Func0<Optional<T>> elseFunc) {
+        return isPresent() ? this : elseFunc.call();
+    }
+
+    @Nullable
+    public T orNull() {
+        return isPresent() ? get() : null;
+    }
+
+    public <V> Optional<V> map(final Func1<T, V> func) {
+        return flatMap(element -> of(func.call(element)));
+    }
+
+    public Optional<T> filter(final Predicate<T> predicate) {
+        return flatMap(element -> fromNullable(predicate.call(element) ? element : null));
+    }
+
+    public <V> Optional<V> flatMap(Func1<T, Optional<V>> func) {
+        return isPresent() ? func.call(data) : Optional.absent();
     }
 
     @Override

--- a/app/src/main/java/net/squanchy/support/lang/Predicate.java
+++ b/app/src/main/java/net/squanchy/support/lang/Predicate.java
@@ -1,0 +1,5 @@
+package net.squanchy.support.lang;
+
+public interface Predicate<T> extends Func1<T, Boolean> {
+    // Just a convenience subclass of Func1
+}

--- a/app/src/main/java/net/squanchy/support/lang/Procedure0.java
+++ b/app/src/main/java/net/squanchy/support/lang/Procedure0.java
@@ -1,7 +1,0 @@
-package net.squanchy.support.lang;
-
-
-public interface Procedure0 {
-
-    void apply();
-}

--- a/app/src/main/java/net/squanchy/support/lang/Procedure1.java
+++ b/app/src/main/java/net/squanchy/support/lang/Procedure1.java
@@ -1,7 +1,0 @@
-package net.squanchy.support.lang;
-
-
-public interface Procedure1<T> {
-
-    void apply(T t);
-}

--- a/app/src/main/java/net/squanchy/support/view/Hotspot.java
+++ b/app/src/main/java/net/squanchy/support/view/Hotspot.java
@@ -8,7 +8,7 @@ import com.google.auto.value.AutoValue;
 @AutoValue
 public abstract class Hotspot {
 
-    public static Hotspot from(MotionEvent motionEvent) {
+    public static Hotspot fromMotionEvent(MotionEvent motionEvent) {
         return new AutoValue_Hotspot(motionEvent.getX(), motionEvent.getY());
     }
 

--- a/app/src/main/java/net/squanchy/support/widget/InterceptingBottomNavigationView.java
+++ b/app/src/main/java/net/squanchy/support/widget/InterceptingBottomNavigationView.java
@@ -58,11 +58,8 @@ public class InterceptingBottomNavigationView extends BottomNavigationView {
     }
 
     private void setBackgroundHotspot(CircularRevealDrawable revealDrawable, MenuItem menuItem) {
-        lastUpEvent.subscribe(motionEvent -> applyHotspot(revealDrawable, Hotspot.from(motionEvent)),
-                () -> applyHotspot(revealDrawable, getHotspotFor(menuItem)));
-    }
-
-    private void applyHotspot(CircularRevealDrawable revealDrawable, Hotspot hotspot) {
+        Hotspot hotspot = lastUpEvent.map(Hotspot::fromMotionEvent)
+                .or(getHotspotFor(menuItem));
         revealDrawable.setHotspot(hotspot.x(), hotspot.y());
     }
 


### PR DESCRIPTION
This PR:
 * Uses more widespread names for `Func`tions, and unifies their method names
 * Drops the `Optional#subscribe` as the same can be achieved with more common functional methods `Optional` usually has, like `map` and `filter`; those methods are implemented here too
 * Uses the aforementioned changes to improve the `setBackgroundHotspot()` method code