### PR TITLE
SQ-52/Search results now contain events

### DIFF
--- a/app/src/main/java/net/squanchy/navigation/Navigator.java
+++ b/app/src/main/java/net/squanchy/navigation/Navigator.java
@@ -2,6 +2,8 @@ package net.squanchy.navigation;
 
 import android.content.Context;
 import android.content.Intent;
+import android.text.TextUtils;
+import android.widget.Toast;
 
 import net.squanchy.eventdetails.EventDetailsActivity;
 import net.squanchy.search.SearchActivity;
@@ -21,6 +23,11 @@ public class Navigator {
     public void toEventDetails(String eventId) {
         Intent intent = EventDetailsActivity.createIntent(context, eventId);
         context.startActivity(intent);
+    }
+
+    public void toSpeakerDetails(String... speakerIds) {
+        // TODO open the speaker detail view here
+        Toast.makeText(context, "Speakers clicked: " + TextUtils.join(", ", speakerIds), Toast.LENGTH_SHORT).show();
     }
 
     public void toSearch() {

--- a/app/src/main/java/net/squanchy/schedule/view/EventViewHolder.java
+++ b/app/src/main/java/net/squanchy/schedule/view/EventViewHolder.java
@@ -5,13 +5,13 @@ import android.support.v7.widget.RecyclerView;
 
 import net.squanchy.schedule.domain.view.Event;
 
-class EventViewHolder extends RecyclerView.ViewHolder {
+public class EventViewHolder extends RecyclerView.ViewHolder {
 
-    EventViewHolder(EventItemView itemView) {
+    public EventViewHolder(EventItemView itemView) {
         super(itemView);
     }
 
-    void updateWith(Event event, @Nullable ScheduleViewPagerAdapter.OnEventClickedListener listener) {
+    public void updateWith(Event event, @Nullable ScheduleViewPagerAdapter.OnEventClickedListener listener) {
         ((EventItemView) itemView).updateWith(event);
         itemView.setOnClickListener(v -> {
             if (listener != null) {

--- a/app/src/main/java/net/squanchy/search/SearchActivity.java
+++ b/app/src/main/java/net/squanchy/search/SearchActivity.java
@@ -16,7 +16,6 @@ import android.view.MenuItem;
 import android.view.View;
 import android.view.inputmethod.InputMethodManager;
 import android.widget.EditText;
-import android.widget.Toast;
 
 import java.util.Collections;
 import java.util.List;
@@ -24,6 +23,8 @@ import java.util.concurrent.TimeUnit;
 
 import net.squanchy.R;
 import net.squanchy.fonts.TypefaceStyleableActivity;
+import net.squanchy.navigation.Navigator;
+import net.squanchy.schedule.domain.view.Event;
 import net.squanchy.search.view.SearchRecyclerView;
 import net.squanchy.speaker.domain.view.Speaker;
 
@@ -43,6 +44,8 @@ public class SearchActivity extends TypefaceStyleableActivity implements SearchR
 
     private final CompositeDisposable subscriptions = new CompositeDisposable();
 
+    private Navigator navigator;
+
     private SearchTextWatcher searchTextWatcher;
 
     private EditText searchField;
@@ -61,6 +64,7 @@ public class SearchActivity extends TypefaceStyleableActivity implements SearchR
 
         SearchComponent component = SearchInjector.obtain(this);
         searchService = component.service();
+        navigator = component.navigator();
     }
 
     private void setupToolbar() {
@@ -159,8 +163,16 @@ public class SearchActivity extends TypefaceStyleableActivity implements SearchR
 
     @Override
     public void onSpeakerClicked(Speaker speaker) {
-        // TODO open the speaker detail view here
-        Toast.makeText(this, "Speaker clicked " + speaker, Toast.LENGTH_SHORT).show();
+        navigate().toSpeakerDetails(speaker.id());
+    }
+
+    @Override
+    public void onEventClicked(Event event) {
+        navigate().toEventDetails(event.id());
+    }
+
+    private Navigator navigate() {
+        return navigator;
     }
 
     private static class SearchTextWatcher implements TextWatcher {

--- a/app/src/main/java/net/squanchy/search/SearchActivity.java
+++ b/app/src/main/java/net/squanchy/search/SearchActivity.java
@@ -31,6 +31,7 @@ import io.reactivex.BackpressureStrategy;
 import io.reactivex.android.schedulers.AndroidSchedulers;
 import io.reactivex.disposables.CompositeDisposable;
 import io.reactivex.disposables.Disposable;
+import io.reactivex.schedulers.Schedulers;
 import io.reactivex.subjects.PublishSubject;
 import timber.log.Timber;
 
@@ -81,10 +82,11 @@ public class SearchActivity extends TypefaceStyleableActivity implements SearchR
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(searchResults -> searchRecyclerView.updateWith(searchResults, this), Timber::e);
 
-        Disposable searchSubscription = querySubject.debounce(QUERY_DEBOUNCE_TIMEOUT, TimeUnit.MILLISECONDS)
+        Disposable searchSubscription = querySubject.throttleLast(QUERY_DEBOUNCE_TIMEOUT, TimeUnit.MILLISECONDS)
                 .flatMap(query -> searchService.find(query))
                 .doOnNext(searchResults -> speakersSubscription.dispose())
                 .toFlowable(BackpressureStrategy.LATEST)
+                .subscribeOn(Schedulers.computation())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(searchResults -> searchRecyclerView.updateWith(searchResults, this), Timber::e);
 

--- a/app/src/main/java/net/squanchy/search/SearchComponent.java
+++ b/app/src/main/java/net/squanchy/search/SearchComponent.java
@@ -2,6 +2,7 @@ package net.squanchy.search;
 
 import net.squanchy.injection.ActivityLifecycle;
 import net.squanchy.injection.ApplicationComponent;
+import net.squanchy.navigation.Navigator;
 
 import dagger.Component;
 
@@ -10,4 +11,6 @@ import dagger.Component;
 interface SearchComponent {
 
     SearchService service();
+
+    Navigator navigator();
 }

--- a/app/src/main/java/net/squanchy/search/SearchInjector.java
+++ b/app/src/main/java/net/squanchy/search/SearchInjector.java
@@ -11,7 +11,7 @@ final class SearchInjector {
     public static SearchComponent obtain(SearchActivity activity) {
         return DaggerSearchComponent.builder()
                 .applicationComponent(ApplicationInjector.obtain(activity))
-                .searchModule(new SearchModule())
+                .searchModule(new SearchModule(activity))
                 .build();
     }
 }

--- a/app/src/main/java/net/squanchy/search/SearchModule.java
+++ b/app/src/main/java/net/squanchy/search/SearchModule.java
@@ -1,5 +1,8 @@
 package net.squanchy.search;
 
+import android.content.Context;
+
+import net.squanchy.navigation.Navigator;
 import net.squanchy.search.engines.SearchEngines;
 import net.squanchy.service.repository.EventRepository;
 import net.squanchy.service.repository.SpeakerRepository;
@@ -10,6 +13,12 @@ import dagger.Provides;
 @Module
 class SearchModule {
 
+    private final Context context;
+
+    SearchModule(Context context) {
+        this.context = context;
+    }
+
     @Provides
     SearchEngines searchEngines() {
         return new SearchEngines();
@@ -18,5 +27,15 @@ class SearchModule {
     @Provides
     SearchService searchService(EventRepository eventRepository, SpeakerRepository speakerRepository, SearchEngines searchEngines) {
         return new SearchService(eventRepository, speakerRepository, searchEngines);
+    }
+
+    @Provides
+    Context context() {
+        return context;
+    }
+
+    @Provides
+    Navigator navigator(Context context) {
+        return new Navigator(context);
     }
 }

--- a/app/src/main/java/net/squanchy/search/engines/EventSearchEngine.java
+++ b/app/src/main/java/net/squanchy/search/engines/EventSearchEngine.java
@@ -18,9 +18,7 @@ class EventSearchEngine implements SearchEngine<Event> {
     }
 
     private boolean eventIsSearchable(Event event) {
-        return event.type() != Event.Type.LUNCH
-                && event.type() != Event.Type.COFFEE_BREAK
-                && event.type() != Event.Type.REGISTRATION;
+        return event.type() == Event.Type.TALK || event.type() == Event.Type.KEYNOTE;
     }
 
     private boolean matchesQuery(Event event, String query) {

--- a/app/src/main/java/net/squanchy/search/view/HeaderType.java
+++ b/app/src/main/java/net/squanchy/search/view/HeaderType.java
@@ -6,7 +6,7 @@ import net.squanchy.R;
 
 public enum HeaderType {
     SPEAKERS(R.string.speaker_list_title),
-    EVENTS(R.string.speaker_list_title),
+    EVENTS(R.string.talks_list_title),
     TRACKS(R.string.speaker_list_title);
 
     @StringRes

--- a/app/src/main/java/net/squanchy/search/view/ItemsAdapter.java
+++ b/app/src/main/java/net/squanchy/search/view/ItemsAdapter.java
@@ -3,6 +3,7 @@ package net.squanchy.search.view;
 import java.util.List;
 import java.util.Locale;
 
+import net.squanchy.schedule.domain.view.Event;
 import net.squanchy.search.SearchResults;
 import net.squanchy.search.view.SearchAdapter.ViewTypeId;
 import net.squanchy.speaker.domain.view.Speaker;
@@ -95,6 +96,19 @@ class ItemsAdapter {
         } else {
             throw new IndexOutOfBoundsException("No speaker at position " + position + ", that is supposed to be the speakers header");
         }
+    }
+
+    Event eventAtAbsolutePosition(int position) {
+        ensurePositionExists(position);
+
+        int totalEventItemsCount = totalCountForSectionIncludingHeaders(searchResults.events());
+        if (position == 0) {
+            throw new IndexOutOfBoundsException("No event at position " + position + ", that is supposed to be the events header");
+        } else if (position - 1 >= totalEventItemsCount) {
+            throw new IndexOutOfBoundsException("No event at position " + position + ", that is supposed to be in the speakers sublist");
+        }
+
+        return searchResults.events().get(position - 1);
     }
 
     HeaderType headerTypeAtAbsolutePosition(int position) {

--- a/app/src/main/java/net/squanchy/search/view/SearchAdapter.java
+++ b/app/src/main/java/net/squanchy/search/view/SearchAdapter.java
@@ -16,6 +16,8 @@ import java.util.Collections;
 import net.squanchy.R;
 import net.squanchy.imageloader.ImageLoader;
 import net.squanchy.imageloader.ImageLoaderInjector;
+import net.squanchy.schedule.view.EventItemView;
+import net.squanchy.schedule.view.EventViewHolder;
 import net.squanchy.search.SearchResults;
 
 class SearchAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> {
@@ -63,6 +65,9 @@ class SearchAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> {
         } else if (viewType == ViewTypeId.SPEAKER) {
             View view = LayoutInflater.from(context).inflate(R.layout.item_search_result_small, parent, false);
             return new SpeakerViewHolder(view);
+        } else if (viewType == ViewTypeId.EVENT) {
+            View view = LayoutInflater.from(context).inflate(R.layout.item_schedule_event_talk, parent, false);
+            return new EventViewHolder((EventItemView) view);
         } else {
             throw new IllegalArgumentException("Item type " + viewType + " not supported");
         }
@@ -76,6 +81,8 @@ class SearchAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> {
             ((SpeakerViewHolder) holder).updateWith(itemsAdapter.speakerAtAbsolutePosition(position), imageLoader, listener);
         } else if (viewType == ViewTypeId.HEADER) {
             ((HeaderViewHolder) holder).updateWith(itemsAdapter.headerTypeAtAbsolutePosition(position));
+        } else if (viewType == ViewTypeId.EVENT) {
+            ((EventViewHolder) holder).updateWith(itemsAdapter.eventAtAbsolutePosition(position), listener);
         } else {
             throw new IllegalArgumentException("Item type " + viewType + " not supported");
         }

--- a/app/src/main/java/net/squanchy/search/view/SearchRecyclerView.java
+++ b/app/src/main/java/net/squanchy/search/view/SearchRecyclerView.java
@@ -6,8 +6,7 @@ import android.support.v7.widget.GridLayoutManager;
 import android.support.v7.widget.RecyclerView;
 import android.util.AttributeSet;
 
-import java.util.Collections;
-
+import net.squanchy.schedule.view.ScheduleViewPagerAdapter;
 import net.squanchy.search.SearchResults;
 import net.squanchy.speaker.domain.view.Speaker;
 
@@ -37,21 +36,19 @@ public class SearchRecyclerView extends RecyclerView {
         setClipToPadding(false);
     }
 
-    public void updateWith(SearchResults newData, OnSearchResultClickListener listener) {
+    public void updateWith(SearchResults searchResults, OnSearchResultClickListener listener) {
         if (getAdapter() == null) {
             super.setAdapter(adapter);
         }
 
-        // TODO undo this once we support the events too
-        adapter.updateWith(SearchResults.create(Collections.emptyList(), newData.speakers()), listener);
-        
+        adapter.updateWith(searchResults, listener);
+
         GridLayoutManager layoutManager = (GridLayoutManager) getLayoutManager();
         GridLayoutManager.SpanSizeLookup spanSizeLookup = adapter.createSpanSizeLookup(COLUMNS_COUNT);
         layoutManager.setSpanSizeLookup(spanSizeLookup);
-
     }
 
-    public interface OnSearchResultClickListener {
+    public interface OnSearchResultClickListener extends ScheduleViewPagerAdapter.OnEventClickedListener {
 
         void onSpeakerClicked(Speaker speaker);
     }

--- a/app/src/main/java/net/squanchy/search/view/SearchRecyclerView.java
+++ b/app/src/main/java/net/squanchy/search/view/SearchRecyclerView.java
@@ -1,14 +1,19 @@
 package net.squanchy.search.view;
 
 import android.content.Context;
+import android.graphics.Rect;
 import android.support.annotation.Nullable;
+import android.support.annotation.Px;
 import android.support.v7.widget.GridLayoutManager;
 import android.support.v7.widget.RecyclerView;
 import android.util.AttributeSet;
+import android.view.View;
 
+import net.squanchy.R;
 import net.squanchy.schedule.view.ScheduleViewPagerAdapter;
 import net.squanchy.search.SearchResults;
 import net.squanchy.speaker.domain.view.Speaker;
+import net.squanchy.support.widget.CardLayout;
 
 public class SearchRecyclerView extends RecyclerView {
 
@@ -29,8 +34,14 @@ public class SearchRecyclerView extends RecyclerView {
     @Override
     protected void onFinishInflate() {
         super.onFinishInflate();
+
         GridLayoutManager gridLayoutManager = new GridLayoutManager(getContext(), COLUMNS_COUNT);
         setLayoutManager(gridLayoutManager);
+
+        int horizontalSpacing = getResources().getDimensionPixelSize(R.dimen.card_horizontal_margin);
+        int verticalSpacing = getResources().getDimensionPixelSize(R.dimen.card_vertical_margin);
+        addItemDecoration(new CardOnlySpacingItemDecorator(horizontalSpacing, verticalSpacing));
+
         adapter = new SearchAdapter(getContext());
         setAdapter(adapter);
         setClipToPadding(false);
@@ -51,5 +62,38 @@ public class SearchRecyclerView extends RecyclerView {
     public interface OnSearchResultClickListener extends ScheduleViewPagerAdapter.OnEventClickedListener {
 
         void onSpeakerClicked(Speaker speaker);
+    }
+
+    private static class CardOnlySpacingItemDecorator extends ItemDecoration {
+
+        @Px
+        private final int horizontalSpacing;
+        @Px
+        private final int verticalSpacing;
+
+        private CardOnlySpacingItemDecorator(@Px int horizontalSpacing, @Px int verticalSpacing) {
+            this.horizontalSpacing = horizontalSpacing;
+            this.verticalSpacing = verticalSpacing;
+        }
+
+        @Override
+        public void getItemOffsets(Rect outRect, View view, RecyclerView parent, State state) {
+            if (!(view instanceof CardLayout)) {
+                return;
+            }
+
+            int position = parent.getChildAdapterPosition(view);
+            int count = state.getItemCount();
+
+            int topSpacing = verticalSpacing / 2;
+            int bottomSpacing = topSpacing;
+            if (position == 0) {
+                topSpacing = verticalSpacing;
+            } else if (position == count - 1) {
+                bottomSpacing = verticalSpacing;
+            }
+
+            outRect.set(horizontalSpacing, topSpacing, horizontalSpacing, bottomSpacing);
+        }
     }
 }

--- a/app/src/main/res/layout/activity_search.xml
+++ b/app/src/main/res/layout/activity_search.xml
@@ -12,7 +12,7 @@
     <android.support.v7.widget.Toolbar
       android:id="@+id/search_toolbar"
       style="@style/Search.Toolbar"
-      android:theme="@style/ThemeOverlay.Squanchy.Toolbar"
+      android:theme="@style/ThemeOverlay.Squanchy.Toolbar.Search"
       android:layout_width="match_parent"
       android:layout_height="?attr/actionBarSize">
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -17,6 +17,7 @@
   <string name="bottom_bar_venue_label">Venue Info</string>
   <string name="search_label">Search</string>
   <string name="voice_search">Voice search</string>
-  <string name="speaker_list_title">Droidcon speakers</string>
+  <string name="speaker_list_title">Speakers</string>
+  <string name="talks_list_title">Talks</string>
 
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -81,8 +81,13 @@
     <item name="android:colorControlNormal">?colorAccent</item>
   </style>
 
+  <style name="ThemeOverlay.Squanchy.Toolbar.Search" parent="ThemeOverlay.Squanchy.Toolbar">
+    <item name="colorPrimary">@color/window_background</item>
+    <item name="colorAccent">@color/primary</item>
+  </style>
+
   <style name="Search.SectionHeader" parent="TextAppearance.AppCompat.Body1">
-    <item name="android:textColor">?android:colorAccent</item>
+    <item name="android:textColor">?android:colorPrimary</item>
     <item name="fontPath">?titleTypeface</item>
   </style>
 
@@ -95,6 +100,7 @@
     <item name="android:background">@null</item>
     <item name="android:hint">@string/search_label</item>
     <item name="android:imeOptions">actionSearch</item>
+    <item name="android:inputType">text</item>
     <item name="android:maxLines">1</item>
   </style>
 

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -45,8 +45,6 @@
   <style name="Theme.Squanchy.EventDetails" parent="Theme.Squanchy" />
 
   <style name="Theme.Squanchy.Search" parent="Theme.Squanchy">
-    <item name="colorPrimary">@color/window_background</item>
-    <item name="colorAccent">@color/primary</item>
     <item name="android:statusBarColor">@color/status_bar_primary</item>
   </style>
 

--- a/app/src/test/java/net/squanchy/search/engines/EventSearchEngineTest.java
+++ b/app/src/test/java/net/squanchy/search/engines/EventSearchEngineTest.java
@@ -13,6 +13,7 @@ public class EventSearchEngineTest {
 
     private static final Event MATCHING_EVENT = anEvent()
             .withTitle("Banane")
+            .withType(Event.Type.TALK)
             .build();
 
     private final EventSearchEngine searchEngine = new EventSearchEngine();
@@ -46,7 +47,7 @@ public class EventSearchEngineTest {
 
     @Test
     public void givenEventWithCoffeeBreakType_whenMatching_thenReturnsFalse() {
-        Event event = anEvent().withType(Event.Type.COFFEE_BREAK).build();
+        Event event = anEvent().withTitle("anything").withType(Event.Type.COFFEE_BREAK).build();
 
         boolean matches = searchEngine.matches(event, "anything");
 
@@ -55,7 +56,7 @@ public class EventSearchEngineTest {
 
     @Test
     public void givenEventWithLunchType_whenMatching_thenReturnsFalse() {
-        Event event = anEvent().withType(Event.Type.LUNCH).build();
+        Event event = anEvent().withTitle("anything").withType(Event.Type.LUNCH).build();
 
         boolean matches = searchEngine.matches(event, "anything");
 
@@ -64,7 +65,25 @@ public class EventSearchEngineTest {
 
     @Test
     public void givenEventWithRegistrationType_whenMatching_thenReturnsFalse() {
-        Event event = anEvent().withType(Event.Type.REGISTRATION).build();
+        Event event = anEvent().withTitle("anything").withType(Event.Type.REGISTRATION).build();
+
+        boolean matches = searchEngine.matches(event, "anything");
+
+        assertThat(matches).isFalse();
+    }
+
+    @Test
+    public void givenEventWithSocialType_whenMatching_thenReturnsFalse() {
+        Event event = anEvent().withTitle("anything").withType(Event.Type.SOCIAL).build();
+
+        boolean matches = searchEngine.matches(event, "anything");
+
+        assertThat(matches).isFalse();
+    }
+
+    @Test
+    public void givenEventWithOtherType_whenMatching_thenReturnsFalse() {
+        Event event = anEvent().withTitle("anything").withType(Event.Type.OTHER).build();
 
         boolean matches = searchEngine.matches(event, "anything");
 

--- a/app/src/test/java/net/squanchy/search/view/ItemsAdapterTest.java
+++ b/app/src/test/java/net/squanchy/search/view/ItemsAdapterTest.java
@@ -349,6 +349,99 @@ public class ItemsAdapterTest {
         }
     }
 
+    public static class EventAtPosition extends BaseTest {
+
+        @Test
+        public void givenEmptySearchResults_whenGettingEventAtAnyPosition_thenThrowsIndexOutOfBoundsException() {
+            givenEmptySearchResults();
+            thrown.expect(IndexOutOfBoundsException.class);
+
+            itemsAdapter.eventAtAbsolutePosition(0);
+        }
+
+        @Test
+        public void givenAnySearchResults_whenGettingEventAtNegativePosition_thenThrowsIndexOutOfBoundsException() {
+            givenSearchResultsWith(ANY_THREE_EVENTS, ANY_TWO_SPEAKERS);
+            thrown.expect(IndexOutOfBoundsException.class);
+
+            itemsAdapter.eventAtAbsolutePosition(-1);
+        }
+
+        @Test
+        public void givenAnySearchResults_whenGettingEventPositionEqualOrGreaterThanTotalItemsCount_thenThrowsIndexOutOfBoundsException() {
+            givenSearchResultsWith(ANY_THREE_EVENTS, ANY_TWO_SPEAKERS);
+            thrown.expect(IndexOutOfBoundsException.class);
+
+            itemsAdapter.eventAtAbsolutePosition(7);      // 7 = (1 header + 3 events + 1 header + 2 speakers + 1 off-by-one) - 1 [because zero-based]
+        }
+
+        @Test
+        public void givenSearchResultsWithOnlyEvents_whenGettingEventAtEventsHeaderPosition_thenThrowsIndexOutOfBoundsException() {
+            givenSearchResultsWith(ANY_THREE_EVENTS, NO_SPEAKERS);
+            thrown.expect(IndexOutOfBoundsException.class);
+
+            itemsAdapter.eventAtAbsolutePosition(0);      // 0 = (1 header) - 1 [because zero-based]
+        }
+
+        @Test
+        public void givenSearchResultsWithOnlyEvents_whenGettingEventAtEventPosition_thenReturnsEvent() {
+            givenSearchResultsWith(ANY_THREE_EVENTS, NO_SPEAKERS);
+
+            Event event = itemsAdapter.eventAtAbsolutePosition(1);      // 1 = (1 header + 1 speaker) - 1 [because zero-based]
+
+            assertThat(event).isEqualTo(ANY_THREE_EVENTS.get(0));
+        }
+
+        @Test
+        public void givenSearchResultsWithOnlyEvents_whenGettingEventAtSpeakersHeaderPosition_thenThrowsIndexOutOfBoundsException() {
+            givenSearchResultsWith(ANY_THREE_EVENTS, NO_SPEAKERS);
+            thrown.expect(IndexOutOfBoundsException.class);
+
+            itemsAdapter.eventAtAbsolutePosition(4);      // 4 = (1 header + 3 speaker + 1 header) - 1 [because zero-based]
+        }
+
+        @Test
+        public void givenSearchResultsWithOnlySpeakers_whenGettingEventAtAnyPosition_thenThrowsIndexOutOfBoundsException() {
+            givenSearchResultsWith(NO_EVENTS, ANY_TWO_SPEAKERS);
+            thrown.expect(IndexOutOfBoundsException.class);
+
+            itemsAdapter.eventAtAbsolutePosition(0);
+        }
+
+        @Test
+        public void givenSearchResultsWithEventsAndSpeakers_whenGettingEventAtEventsHeaderPosition_thenThrowsIndexOutOfBoundsException() {
+            givenSearchResultsWith(ANY_THREE_EVENTS, ANY_TWO_SPEAKERS);
+            thrown.expect(IndexOutOfBoundsException.class);
+
+            itemsAdapter.eventAtAbsolutePosition(0);      // 0 = (1 header) - 1 [because zero-based]
+        }
+
+        @Test
+        public void givenSearchResultsWithEventsAndSpeakers_whenGettingEventAtEventPosition_thenReturnsEvent() {
+            givenSearchResultsWith(ANY_THREE_EVENTS, ANY_TWO_SPEAKERS);
+
+            Event event = itemsAdapter.eventAtAbsolutePosition(1);// 1 = (1 header + 1 event) - 1 [because zero-based]
+
+            assertThat(event).isEqualTo(ANY_THREE_EVENTS.get(0));
+        }
+
+        @Test
+        public void givenSearchResultsWithEventsAndSpeakers_whenGettingEventAtSpeakerHeaderPosition_thenThrowsIndexOutOfBoundsException() {
+            givenSearchResultsWith(ANY_THREE_EVENTS, ANY_TWO_SPEAKERS);
+            thrown.expect(IndexOutOfBoundsException.class);
+
+            itemsAdapter.eventAtAbsolutePosition(4);      // 4 = (1 header + 3 events + 1 header) - 1 [because zero-based]
+        }
+
+        @Test
+        public void givenSearchResultsWithEventsAndSpeakers_whenGettingEventAtSpeakerPosition_thenThrowsIndexOutOfBoundsException() {
+            givenSearchResultsWith(ANY_THREE_EVENTS, ANY_TWO_SPEAKERS);
+            thrown.expect(IndexOutOfBoundsException.class);
+
+            itemsAdapter.eventAtAbsolutePosition(5);     // 5 = (1 header + 3 events + 1 header + 1 speaker) - 1 [because zero-based]
+        }
+    }
+
     public static class HeaderTypeAtPosition extends BaseTest {
 
         @Test


### PR DESCRIPTION
In this PR:
 * I changed the query from being `debounce`d to being `throttleLast` because we don't want to drop events (what `debounce` does); rather, we want to keep the last event of any 250ms interval
 * We only allow `TALK` and `KEYNOTE` events to be searchable (simplification to avoid having one additional viewtype)
 * Show event results in search

![events-in-results](https://cloud.githubusercontent.com/assets/153802/23835330/9b40c72a-0765-11e7-9cd1-33aa1289e840.gif)
