### PR TITLE
Disable Crashlytics for debug builds

### DIFF
--- a/app/src/main/java/net/squanchy/analytics/CrashlyticsErrorsTree.java
+++ b/app/src/main/java/net/squanchy/analytics/CrashlyticsErrorsTree.java
@@ -2,9 +2,13 @@ package net.squanchy.analytics;
 
 import com.crashlytics.android.Crashlytics;
 
+import net.squanchy.BuildConfig;
+
 import timber.log.Timber;
 
 public class CrashlyticsErrorsTree extends Timber.Tree {
+
+    private static final boolean CAN_LOG = !BuildConfig.DEBUG;
 
     @Override
     protected boolean isLoggable(String tag, int priority) {
@@ -13,7 +17,7 @@ public class CrashlyticsErrorsTree extends Timber.Tree {
 
     @Override
     protected void log(int priority, String tag, String message, Throwable t) {
-        if (t != null) {
+        if (t != null && CAN_LOG) {
             Crashlytics.logException(t);
         }
     }


### PR DESCRIPTION
This PR disables Crashlytics for debug builds to keep the noise down to a minimum.