### PR TITLE
Make events a map of events

### DIFF
--- a/app/src/main/java/net/squanchy/service/firebase/model/FirebaseEvents.java
+++ b/app/src/main/java/net/squanchy/service/firebase/model/FirebaseEvents.java
@@ -1,14 +1,15 @@
 package net.squanchy.service.firebase.model;
 
-import java.util.List;
+import java.util.Map;
 
 public class FirebaseEvents {
 
-    public FirebaseEvents() {}
+    public FirebaseEvents() {
+    }
 
-    public FirebaseEvents(List<FirebaseEvent> events) {
+    public FirebaseEvents(Map<String, FirebaseEvent> events) {
         this.events = events;
     }
 
-    public List<FirebaseEvent> events;
+    public Map<String, FirebaseEvent> events;
 }

--- a/app/src/main/java/net/squanchy/service/repository/EventRepository.java
+++ b/app/src/main/java/net/squanchy/service/repository/EventRepository.java
@@ -1,5 +1,6 @@
 package net.squanchy.service.repository;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
@@ -68,7 +69,7 @@ public class EventRepository {
     }
 
     private BiFunction<FirebaseEvents, List<Speaker>, List<Event>> combineSessionsAndSpeakers() {
-        return (apiSchedule, speakers) -> Lists.map(apiSchedule.events, combineEventWith(speakers));
+        return (apiSchedule, speakers) -> Lists.map(new ArrayList<>(apiSchedule.events.values()), combineEventWith(speakers));
     }
 
     private Func1<FirebaseEvent, Event> combineEventWith(List<Speaker> speakers) {


### PR DESCRIPTION
:warning: This is a breaking change due to a change in the DB data:

I made the events a `Map<String, FirebaseEvent>` because the keys aren't integers anymore, thus they're now represented (and retrieved) as a map. This will fix the favorites (which can't be added if the event id is an integer, since the list will change between a list and a map depending whether there's a sequence of id or they're random:

```
favorites ids: 0, 1, 2 = retrieved as a list
favorites ids: 2, 3, 4 = retrieved as a map
```
Either of these will break the app in some way (thanks firebase for trying to be """smart""" here :man_shrugging: )