### PR TITLE
Add Analytics

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -84,6 +84,12 @@ android {
         }
     }
 
+    buildTypes {
+        debug {
+            ext.enableCrashlytics = false
+        }
+    }
+
     lintOptions {
         lintConfig file("$rootProject.projectDir/team-props/lint.xml")
         abortOnError false

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -106,7 +106,6 @@ dependencies {
     compile libraries.app.glide
     compile libraries.app.glideOkHttp3
     compile libraries.app.jodaTimeAndroid
-    compile libraries.app.playAnalytics
     compile libraries.app.rx
     compile libraries.app.rxAndroid
     compile libraries.app.supportAppCompat

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -65,7 +65,6 @@ android {
         resValueProperty 'api_value_twitter_api_key', (buildProperties.secrets['twitterApiKey'] | buildProperties.env['TWITTER_API_KEY'])
         resValueProperty 'api_value_twitter_secret', (buildProperties.secrets['twitterSecret'] | buildProperties.env['TWITTER_SECRET'])
         resValueProperty 'api_value_google_maps_api_key', (buildProperties.secrets['googleMapsApiKey'] | buildProperties.env['GOOGLE_MAPS_API_KEY'])
-        resValueProperty 'api_value_base_url', (buildProperties.secrets['baseUrl'] | buildProperties.env['BASE_URL'])
         resValueProperty 'social_query', (buildProperties.application['socialQuery'] | "#AndroidDev")
     }
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,7 +3,9 @@
   xmlns:tools="http://schemas.android.com/tools"
   package="net.squanchy">
 
+  <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
   <uses-permission android:name="android.permission.INTERNET" />
+  <uses-permission android:name="android.permission.WAKE_LOCK" />
 
   <application
     android:name="net.squanchy.SquanchyApplication"

--- a/app/src/main/java/net/squanchy/SquanchyApplication.java
+++ b/app/src/main/java/net/squanchy/SquanchyApplication.java
@@ -4,6 +4,7 @@ import android.app.Application;
 import android.support.annotation.MainThread;
 
 import com.crashlytics.android.Crashlytics;
+import com.crashlytics.android.core.CrashlyticsCore;
 import com.google.firebase.database.FirebaseDatabase;
 import com.twitter.sdk.android.core.TwitterAuthConfig;
 import com.twitter.sdk.android.core.TwitterCore;
@@ -47,7 +48,13 @@ public class SquanchyApplication extends Application {
                 getString(R.string.api_value_twitter_api_key),
                 getString(R.string.api_value_twitter_secret)
         );
-        Fabric.with(this, new Crashlytics(), new TwitterCore(authConfig), new TweetUi());
+        CrashlyticsCore crashlyticsCore = new CrashlyticsCore.Builder().disabled(BuildConfig.DEBUG).build();
+        Fabric.with(
+                this,
+                new Crashlytics.Builder().core(crashlyticsCore).build(),
+                new TwitterCore(authConfig),
+                new TweetUi()
+        );
     }
 
     @MainThread

--- a/app/src/main/java/net/squanchy/SquanchyApplication.java
+++ b/app/src/main/java/net/squanchy/SquanchyApplication.java
@@ -35,7 +35,7 @@ public class SquanchyApplication extends Application {
     private void setupTracking() {
         setupFabric();
 
-        Analytics analytics = Analytics.from(this);
+        Analytics analytics = applicationComponent().analytics();
         analytics.enableExceptionLogging();
 
         if (BuildConfig.DEBUG) {
@@ -60,7 +60,7 @@ public class SquanchyApplication extends Application {
     @MainThread
     public ApplicationComponent applicationComponent() {
         if (applicationComponent == null) {
-            applicationComponent = ApplicationComponent.Factory.create();
+            applicationComponent = ApplicationComponent.Factory.create(this);
         }
 
         return applicationComponent;

--- a/app/src/main/java/net/squanchy/SquanchyApplication.java
+++ b/app/src/main/java/net/squanchy/SquanchyApplication.java
@@ -35,7 +35,6 @@ public class SquanchyApplication extends Application {
         setupFabric();
 
         Analytics analytics = Analytics.from(this);
-        analytics.enableActivityLifecycleLogging();
         analytics.enableExceptionLogging();
 
         if (BuildConfig.DEBUG) {

--- a/app/src/main/java/net/squanchy/analytics/Analytics.java
+++ b/app/src/main/java/net/squanchy/analytics/Analytics.java
@@ -33,14 +33,14 @@ public class Analytics {
 
     public void trackPageView(Activity activity, String screenName, @Nullable String screenClassOverride) {
         trackPageViewOnFirebaseAnalytics(activity, screenName, screenClassOverride);
-        trackPageViewOnCrashlytics(activity, screenName, screenClassOverride);
+        trackPageViewOnCrashlytics(screenName);
     }
 
     private void trackPageViewOnFirebaseAnalytics(Activity activity, String screenName, String screenClassOverride) {
         firebaseAnalytics.setCurrentScreen(activity, screenName, screenClassOverride);
     }
 
-    private void trackPageViewOnCrashlytics(Activity activity, String screenName, String screenClassOverride) {
+    private void trackPageViewOnCrashlytics(String screenName) {
         ContentViewEvent viewEvent = new ContentViewEvent();
         viewEvent.putContentName(screenName);
         crashlytics.answers.logContentView(viewEvent);

--- a/app/src/main/java/net/squanchy/analytics/Analytics.java
+++ b/app/src/main/java/net/squanchy/analytics/Analytics.java
@@ -7,31 +7,22 @@ import android.support.annotation.Nullable;
 
 import com.crashlytics.android.Crashlytics;
 import com.crashlytics.android.answers.CustomEvent;
-import com.google.android.gms.analytics.GoogleAnalytics;
-import com.google.android.gms.analytics.HitBuilders.EventBuilder;
-import com.google.android.gms.analytics.Tracker;
 import com.google.firebase.analytics.FirebaseAnalytics;
-
-import net.squanchy.R;
 
 import timber.log.Timber;
 
 public class Analytics {
 
-    private final Tracker googleTracker;
     private final FirebaseAnalytics firebaseAnalytics;
     private final Crashlytics crashlytics;
 
     public static Analytics from(Context context) {
         Application application = (Application) context.getApplicationContext();
-        Tracker tracker = GoogleAnalytics.getInstance(application)
-                .newTracker(R.xml.global_tracker);
         FirebaseAnalytics firebaseAnalytics = FirebaseAnalytics.getInstance(context);
-        return new Analytics(tracker, firebaseAnalytics, Crashlytics.getInstance());
+        return new Analytics(firebaseAnalytics, Crashlytics.getInstance());
     }
 
-    private Analytics(Tracker googleTracker, FirebaseAnalytics firebaseAnalytics, Crashlytics crashlytics) {
-        this.googleTracker = googleTracker;
+    private Analytics(FirebaseAnalytics firebaseAnalytics, Crashlytics crashlytics) {
         this.firebaseAnalytics = firebaseAnalytics;
         this.crashlytics = crashlytics;
     }
@@ -41,17 +32,8 @@ public class Analytics {
     }
 
     public void trackEvent(String category, String action, @Nullable String label) {
-        trackOnGoogleAnalytics(category, action, label);
         trackOnFirebaseAnalytics(category, action, label);
         trackOnCrashlytics(action);
-    }
-
-    private void trackOnGoogleAnalytics(String category, String action, @Nullable String label) {
-        EventBuilder eventBuilder = new EventBuilder(category, action);
-        if (label != null) {
-            eventBuilder.setLabel(label);
-        }
-        googleTracker.send(eventBuilder.build());
     }
 
     private void trackOnFirebaseAnalytics(String category, String action, @Nullable String label) {
@@ -68,12 +50,7 @@ public class Analytics {
         crashlytics.answers.logCustom(event);
     }
 
-    public void enableActivityLifecycleLogging() {
-        googleTracker.enableAutoActivityTracking(true);
-    }
-
     public void enableExceptionLogging() {
         Timber.plant(new CrashlyticsErrorsTree());
-        googleTracker.enableExceptionReporting(true);
     }
 }

--- a/app/src/main/java/net/squanchy/analytics/Analytics.java
+++ b/app/src/main/java/net/squanchy/analytics/Analytics.java
@@ -1,7 +1,6 @@
 package net.squanchy.analytics;
 
 import android.app.Activity;
-import android.content.Context;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
 
@@ -17,12 +16,7 @@ public class Analytics {
     private final FirebaseAnalytics firebaseAnalytics;
     private final Crashlytics crashlytics;
 
-    public static Analytics from(Context context) {
-        FirebaseAnalytics firebaseAnalytics = FirebaseAnalytics.getInstance(context);
-        return new Analytics(firebaseAnalytics, Crashlytics.getInstance());
-    }
-
-    private Analytics(FirebaseAnalytics firebaseAnalytics, Crashlytics crashlytics) {
+    Analytics(FirebaseAnalytics firebaseAnalytics, Crashlytics crashlytics) {
         this.firebaseAnalytics = firebaseAnalytics;
         this.crashlytics = crashlytics;
     }

--- a/app/src/main/java/net/squanchy/analytics/AnalyticsModule.java
+++ b/app/src/main/java/net/squanchy/analytics/AnalyticsModule.java
@@ -1,17 +1,34 @@
 package net.squanchy.analytics;
 
-import android.content.Context;
+import android.app.Application;
 
-import net.squanchy.injection.ActivityContextModule;
+import com.crashlytics.android.Crashlytics;
+import com.google.firebase.analytics.FirebaseAnalytics;
 
 import dagger.Module;
 import dagger.Provides;
 
-@Module(includes = {ActivityContextModule.class})
+@Module
 public class AnalyticsModule {
 
+    private final Application application;
+
+    public AnalyticsModule(Application application) {
+        this.application = application;
+    }
+
     @Provides
-    Analytics analytics(Context context) {
-        return Analytics.from(context);
+    FirebaseAnalytics firebaseAnalytics() {
+        return FirebaseAnalytics.getInstance(application);
+    }
+
+    @Provides
+    Crashlytics crashlytics() {
+        return Crashlytics.getInstance();
+    }
+
+    @Provides
+    Analytics analytics(FirebaseAnalytics firebaseAnalytics, Crashlytics crashlytics) {
+        return new Analytics(firebaseAnalytics, crashlytics);
     }
 }

--- a/app/src/main/java/net/squanchy/analytics/AnalyticsModule.java
+++ b/app/src/main/java/net/squanchy/analytics/AnalyticsModule.java
@@ -1,0 +1,17 @@
+package net.squanchy.analytics;
+
+import android.content.Context;
+
+import net.squanchy.injection.ActivityContextModule;
+
+import dagger.Module;
+import dagger.Provides;
+
+@Module(includes = {ActivityContextModule.class})
+public class AnalyticsModule {
+
+    @Provides
+    Analytics analytics(Context context) {
+        return Analytics.from(context);
+    }
+}

--- a/app/src/main/java/net/squanchy/analytics/ContentType.java
+++ b/app/src/main/java/net/squanchy/analytics/ContentType.java
@@ -1,0 +1,17 @@
+package net.squanchy.analytics;
+
+public enum ContentType {
+    NAVIGATION_ITEM("navigation bar item"),
+    SCHEDULE_DAY("schedule day"),
+    SCHEDULE_ITEM("schedule item");
+
+    private final String rawContentType;
+
+    ContentType(String rawContentType) {
+        this.rawContentType = rawContentType;
+    }
+
+    public String rawContentType() {
+        return rawContentType;
+    }
+}

--- a/app/src/main/java/net/squanchy/eventdetails/EventDetailsInjector.java
+++ b/app/src/main/java/net/squanchy/eventdetails/EventDetailsInjector.java
@@ -1,5 +1,6 @@
 package net.squanchy.eventdetails;
 
+import net.squanchy.injection.ActivityContextModule;
 import net.squanchy.injection.ApplicationInjector;
 import net.squanchy.navigation.NavigationModule;
 
@@ -13,7 +14,8 @@ final class EventDetailsInjector {
         return DaggerEventDetailsComponent.builder()
                 .applicationComponent(ApplicationInjector.obtain(activity))
                 .eventDetailsModule(new EventDetailsModule())
-                .navigationModule(new NavigationModule(activity))
+                .activityContextModule(new ActivityContextModule(activity))
+                .navigationModule(new NavigationModule())
                 .build();
     }
 }

--- a/app/src/main/java/net/squanchy/home/HomeInjector.java
+++ b/app/src/main/java/net/squanchy/home/HomeInjector.java
@@ -1,0 +1,24 @@
+package net.squanchy.home;
+
+import android.app.Activity;
+
+import net.squanchy.analytics.AnalyticsModule;
+import net.squanchy.injection.ActivityContextModule;
+import net.squanchy.navigation.DaggerHomeComponent;
+import net.squanchy.navigation.HomeComponent;
+import net.squanchy.navigation.NavigationModule;
+
+public final class HomeInjector {
+
+    private HomeInjector() {
+        // no instances
+    }
+
+    public static HomeComponent obtain(Activity activity) {
+        return DaggerHomeComponent.builder()
+                .activityContextModule(new ActivityContextModule(activity))
+                .analyticsModule(new AnalyticsModule())
+                .navigationModule(new NavigationModule())
+                .build();
+    }
+}

--- a/app/src/main/java/net/squanchy/injection/ActivityContextModule.java
+++ b/app/src/main/java/net/squanchy/injection/ActivityContextModule.java
@@ -1,0 +1,22 @@
+package net.squanchy.injection;
+
+import android.app.Activity;
+import android.content.Context;
+
+import dagger.Module;
+import dagger.Provides;
+
+@Module
+public class ActivityContextModule {
+
+    private final Activity activity;
+
+    public ActivityContextModule(Activity activity) {
+        this.activity = activity;
+    }
+
+    @Provides
+    public Context activityContext() {
+        return activity;
+    }
+}

--- a/app/src/main/java/net/squanchy/injection/ApplicationComponent.java
+++ b/app/src/main/java/net/squanchy/injection/ApplicationComponent.java
@@ -1,5 +1,9 @@
 package net.squanchy.injection;
 
+import android.app.Application;
+
+import net.squanchy.analytics.Analytics;
+import net.squanchy.analytics.AnalyticsModule;
 import net.squanchy.service.firebase.FirebaseDbService;
 import net.squanchy.service.firebase.injection.DbServiceType;
 import net.squanchy.service.firebase.injection.FirebaseModule;
@@ -12,7 +16,7 @@ import net.squanchy.support.lang.Checksum;
 import dagger.Component;
 
 @ApplicationLifecycle
-@Component(modules = {FirebaseModule.class, ChecksumModule.class, RepositoryModule.class})
+@Component(modules = {FirebaseModule.class, ChecksumModule.class, RepositoryModule.class, AnalyticsModule.class})
 public interface ApplicationComponent {
 
     @DbServiceType(DbServiceType.Type.AUTHENTICATED)
@@ -24,17 +28,20 @@ public interface ApplicationComponent {
 
     SpeakerRepository speakerRepository();
 
+    Analytics analytics();
+
     class Factory {
 
         private Factory() {
             // non-instantiable
         }
 
-        public static ApplicationComponent create() {
+        public static ApplicationComponent create(Application application) {
             return DaggerApplicationComponent.builder()
                     .firebaseModule(new FirebaseModule())
                     .repositoryModule(new RepositoryModule())
                     .checksumModule(new ChecksumModule())
+                    .analyticsModule(new AnalyticsModule(application))
                     .build();
         }
     }

--- a/app/src/main/java/net/squanchy/navigation/HomeActivity.java
+++ b/app/src/main/java/net/squanchy/navigation/HomeActivity.java
@@ -13,7 +13,6 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.view.Window;
 
-
 import java.util.HashMap;
 import java.util.Map;
 
@@ -172,6 +171,7 @@ public class HomeActivity extends TypefaceStyleableActivity {
 
     private void trackPageSelection(BottomNavigationSection section) {
         analytics.trackItemSelected(ContentType.NAVIGATION_ITEM, section.name());
+        analytics.trackPageView(this, section.name());
     }
 
     @Override

--- a/app/src/main/java/net/squanchy/navigation/HomeActivity.java
+++ b/app/src/main/java/net/squanchy/navigation/HomeActivity.java
@@ -20,7 +20,6 @@ import net.squanchy.R;
 import net.squanchy.analytics.Analytics;
 import net.squanchy.analytics.ContentType;
 import net.squanchy.fonts.TypefaceStyleableActivity;
-import net.squanchy.home.HomeInjector;
 import net.squanchy.support.lang.Optional;
 import net.squanchy.support.widget.InterceptingBottomNavigationView;
 

--- a/app/src/main/java/net/squanchy/navigation/HomeComponent.java
+++ b/app/src/main/java/net/squanchy/navigation/HomeComponent.java
@@ -1,13 +1,13 @@
 package net.squanchy.navigation;
 
 import net.squanchy.analytics.Analytics;
-import net.squanchy.analytics.AnalyticsModule;
 import net.squanchy.injection.ActivityLifecycle;
+import net.squanchy.injection.ApplicationComponent;
 
 import dagger.Component;
 
 @ActivityLifecycle
-@Component(modules = {NavigationModule.class, AnalyticsModule.class})
+@Component(modules = {NavigationModule.class}, dependencies = {ApplicationComponent.class})
 public interface HomeComponent {
 
     Navigator navigator();

--- a/app/src/main/java/net/squanchy/navigation/HomeComponent.java
+++ b/app/src/main/java/net/squanchy/navigation/HomeComponent.java
@@ -1,0 +1,16 @@
+package net.squanchy.navigation;
+
+import net.squanchy.analytics.Analytics;
+import net.squanchy.analytics.AnalyticsModule;
+import net.squanchy.injection.ActivityLifecycle;
+
+import dagger.Component;
+
+@ActivityLifecycle
+@Component(modules = {NavigationModule.class, AnalyticsModule.class})
+public interface HomeComponent {
+
+    Navigator navigator();
+
+    Analytics analytics();
+}

--- a/app/src/main/java/net/squanchy/navigation/HomeInjector.java
+++ b/app/src/main/java/net/squanchy/navigation/HomeInjector.java
@@ -1,14 +1,11 @@
-package net.squanchy.home;
+package net.squanchy.navigation;
 
 import android.app.Activity;
 
 import net.squanchy.analytics.AnalyticsModule;
 import net.squanchy.injection.ActivityContextModule;
-import net.squanchy.navigation.DaggerHomeComponent;
-import net.squanchy.navigation.HomeComponent;
-import net.squanchy.navigation.NavigationModule;
 
-public final class HomeInjector {
+final class HomeInjector {
 
     private HomeInjector() {
         // no instances

--- a/app/src/main/java/net/squanchy/navigation/HomeInjector.java
+++ b/app/src/main/java/net/squanchy/navigation/HomeInjector.java
@@ -2,8 +2,8 @@ package net.squanchy.navigation;
 
 import android.app.Activity;
 
-import net.squanchy.analytics.AnalyticsModule;
 import net.squanchy.injection.ActivityContextModule;
+import net.squanchy.injection.ApplicationInjector;
 
 final class HomeInjector {
 
@@ -13,8 +13,8 @@ final class HomeInjector {
 
     public static HomeComponent obtain(Activity activity) {
         return DaggerHomeComponent.builder()
+                .applicationComponent(ApplicationInjector.obtain(activity))
                 .activityContextModule(new ActivityContextModule(activity))
-                .analyticsModule(new AnalyticsModule())
                 .navigationModule(new NavigationModule())
                 .build();
     }

--- a/app/src/main/java/net/squanchy/navigation/NavigationModule.java
+++ b/app/src/main/java/net/squanchy/navigation/NavigationModule.java
@@ -2,22 +2,13 @@ package net.squanchy.navigation;
 
 import android.content.Context;
 
+import net.squanchy.injection.ActivityContextModule;
+
 import dagger.Module;
 import dagger.Provides;
 
-@Module
+@Module(includes = {ActivityContextModule.class})
 public class NavigationModule {
-
-    private final Context context;
-
-    public NavigationModule(Context context) {
-        this.context = context;
-    }
-
-    @Provides
-    Context context() {
-        return context;
-    }
 
     @Provides
     Navigator navigator(Context context) {

--- a/app/src/main/java/net/squanchy/schedule/ScheduleComponent.java
+++ b/app/src/main/java/net/squanchy/schedule/ScheduleComponent.java
@@ -2,6 +2,8 @@ package net.squanchy.schedule;
 
 import android.content.Context;
 
+import net.squanchy.analytics.Analytics;
+import net.squanchy.analytics.AnalyticsModule;
 import net.squanchy.injection.ActivityLifecycle;
 import net.squanchy.injection.ApplicationComponent;
 import net.squanchy.navigation.NavigationModule;
@@ -10,7 +12,7 @@ import net.squanchy.navigation.Navigator;
 import dagger.Component;
 
 @ActivityLifecycle
-@Component(modules = {ScheduleModule.class, NavigationModule.class}, dependencies = ApplicationComponent.class)
+@Component(modules = {ScheduleModule.class, NavigationModule.class, AnalyticsModule.class}, dependencies = ApplicationComponent.class)
 public interface ScheduleComponent {
 
     ScheduleService service();
@@ -18,4 +20,6 @@ public interface ScheduleComponent {
     Context context();
 
     Navigator navigator();
+
+    Analytics analytics();
 }

--- a/app/src/main/java/net/squanchy/schedule/ScheduleComponent.java
+++ b/app/src/main/java/net/squanchy/schedule/ScheduleComponent.java
@@ -3,7 +3,6 @@ package net.squanchy.schedule;
 import android.content.Context;
 
 import net.squanchy.analytics.Analytics;
-import net.squanchy.analytics.AnalyticsModule;
 import net.squanchy.injection.ActivityLifecycle;
 import net.squanchy.injection.ApplicationComponent;
 import net.squanchy.navigation.NavigationModule;
@@ -12,7 +11,7 @@ import net.squanchy.navigation.Navigator;
 import dagger.Component;
 
 @ActivityLifecycle
-@Component(modules = {ScheduleModule.class, NavigationModule.class, AnalyticsModule.class}, dependencies = ApplicationComponent.class)
+@Component(modules = {ScheduleModule.class, NavigationModule.class}, dependencies = ApplicationComponent.class)
 public interface ScheduleComponent {
 
     ScheduleService service();

--- a/app/src/main/java/net/squanchy/schedule/ScheduleComponent.java
+++ b/app/src/main/java/net/squanchy/schedule/ScheduleComponent.java
@@ -4,12 +4,13 @@ import android.content.Context;
 
 import net.squanchy.injection.ActivityLifecycle;
 import net.squanchy.injection.ApplicationComponent;
+import net.squanchy.navigation.NavigationModule;
 import net.squanchy.navigation.Navigator;
 
 import dagger.Component;
 
 @ActivityLifecycle
-@Component(modules = {ScheduleModule.class}, dependencies = ApplicationComponent.class)
+@Component(modules = {ScheduleModule.class, NavigationModule.class}, dependencies = ApplicationComponent.class)
 public interface ScheduleComponent {
 
     ScheduleService service();

--- a/app/src/main/java/net/squanchy/schedule/ScheduleInjector.java
+++ b/app/src/main/java/net/squanchy/schedule/ScheduleInjector.java
@@ -2,7 +2,6 @@ package net.squanchy.schedule;
 
 import android.app.Activity;
 
-import net.squanchy.analytics.AnalyticsModule;
 import net.squanchy.injection.ActivityContextModule;
 import net.squanchy.injection.ApplicationInjector;
 import net.squanchy.navigation.NavigationModule;
@@ -18,7 +17,6 @@ public final class ScheduleInjector {
                 .applicationComponent(ApplicationInjector.obtain(activity))
                 .scheduleModule(new ScheduleModule())
                 .navigationModule(new NavigationModule())
-                .analyticsModule(new AnalyticsModule())
                 .activityContextModule(new ActivityContextModule(activity))
                 .build();
     }

--- a/app/src/main/java/net/squanchy/schedule/ScheduleInjector.java
+++ b/app/src/main/java/net/squanchy/schedule/ScheduleInjector.java
@@ -2,6 +2,7 @@ package net.squanchy.schedule;
 
 import android.app.Activity;
 
+import net.squanchy.analytics.AnalyticsModule;
 import net.squanchy.injection.ActivityContextModule;
 import net.squanchy.injection.ApplicationInjector;
 import net.squanchy.navigation.NavigationModule;
@@ -17,6 +18,7 @@ public final class ScheduleInjector {
                 .applicationComponent(ApplicationInjector.obtain(activity))
                 .scheduleModule(new ScheduleModule())
                 .navigationModule(new NavigationModule())
+                .analyticsModule(new AnalyticsModule())
                 .activityContextModule(new ActivityContextModule(activity))
                 .build();
     }

--- a/app/src/main/java/net/squanchy/schedule/ScheduleInjector.java
+++ b/app/src/main/java/net/squanchy/schedule/ScheduleInjector.java
@@ -1,8 +1,10 @@
 package net.squanchy.schedule;
 
-import android.content.Context;
+import android.app.Activity;
 
+import net.squanchy.injection.ActivityContextModule;
 import net.squanchy.injection.ApplicationInjector;
+import net.squanchy.navigation.NavigationModule;
 
 public final class ScheduleInjector {
 
@@ -10,10 +12,12 @@ public final class ScheduleInjector {
         // no instances
     }
 
-    public static ScheduleComponent obtain(Context context) {
+    public static ScheduleComponent obtain(Activity activity) {
         return DaggerScheduleComponent.builder()
-                .applicationComponent(ApplicationInjector.obtain(context))
-                .scheduleModule(new ScheduleModule(context))
+                .applicationComponent(ApplicationInjector.obtain(activity))
+                .scheduleModule(new ScheduleModule())
+                .navigationModule(new NavigationModule())
+                .activityContextModule(new ActivityContextModule(activity))
                 .build();
     }
 }

--- a/app/src/main/java/net/squanchy/schedule/ScheduleModule.java
+++ b/app/src/main/java/net/squanchy/schedule/ScheduleModule.java
@@ -1,8 +1,5 @@
 package net.squanchy.schedule;
 
-import android.content.Context;
-
-import net.squanchy.navigation.Navigator;
 import net.squanchy.service.firebase.FirebaseDbService;
 import net.squanchy.service.firebase.injection.DbServiceType;
 import net.squanchy.service.repository.EventRepository;
@@ -13,24 +10,8 @@ import dagger.Provides;
 @Module
 class ScheduleModule {
 
-    private final Context context;
-
-    ScheduleModule(Context context) {
-        this.context = context;
-    }
-
     @Provides
     ScheduleService scheduleService(@DbServiceType(DbServiceType.Type.AUTHENTICATED) FirebaseDbService dbService, EventRepository eventRepository) {
         return new ScheduleService(dbService, eventRepository);
-    }
-
-    @Provides
-    Context context() {
-        return context;
-    }
-
-    @Provides
-    Navigator navigator(Context context) {
-        return new Navigator(context);
     }
 }

--- a/app/src/main/java/net/squanchy/schedule/SchedulePageView.java
+++ b/app/src/main/java/net/squanchy/schedule/SchedulePageView.java
@@ -3,6 +3,7 @@ package net.squanchy.schedule;
 import android.app.Activity;
 import android.content.Context;
 import android.content.ContextWrapper;
+import android.content.res.TypedArray;
 import android.graphics.Typeface;
 import android.support.design.widget.CoordinatorLayout;
 import android.support.design.widget.TabLayout;
@@ -120,7 +121,10 @@ public class SchedulePageView extends CoordinatorLayout {
         // TextAppearance is applied _after_ inflating the tab views, which means Calligraphy can't
         // intercept that either. Sad panda.
         tabLayout.addOnLayoutChangeListener((v, left, top, right, bottom, oldLeft, oldTop, oldRight, oldBottom) -> {
-            Typeface typeface = TypefaceUtils.load(getContext().getAssets(), "fonts/LeagueSpartan-Bold.otf");
+            Context context = tabLayout.getContext();
+            String fontPath = getFontPathFor(context);
+
+            Typeface typeface = TypefaceUtils.load(context.getAssets(), fontPath);
             int tabCount = tabLayout.getTabCount();
             for (int i = 0; i < tabCount; i++) {
                 TabLayout.Tab tab = tabLayout.getTabAt(i);
@@ -130,6 +134,15 @@ public class SchedulePageView extends CoordinatorLayout {
                 tab.setText(CalligraphyUtils.applyTypefaceSpan(tab.getText(), typeface));
             }
         });
+    }
+
+    private String getFontPathFor(Context context) {
+        TypedArray a = context.obtainStyledAttributes(R.style.TextAppearance_Squanchy_Tab, new int[]{R.attr.fontPath});
+        try {
+            return a.getString(0);
+        } finally {
+            a.recycle();
+        }
     }
 
     private boolean hasSpan(CharSequence text) {

--- a/app/src/main/java/net/squanchy/schedule/SchedulePageView.java
+++ b/app/src/main/java/net/squanchy/schedule/SchedulePageView.java
@@ -1,6 +1,8 @@
 package net.squanchy.schedule;
 
+import android.app.Activity;
 import android.content.Context;
+import android.content.ContextWrapper;
 import android.graphics.Typeface;
 import android.support.design.widget.CoordinatorLayout;
 import android.support.design.widget.TabLayout;
@@ -11,7 +13,10 @@ import android.util.AttributeSet;
 import android.view.View;
 
 import net.squanchy.R;
+import net.squanchy.analytics.Analytics;
+import net.squanchy.analytics.ContentType;
 import net.squanchy.navigation.Navigator;
+import net.squanchy.schedule.domain.view.Event;
 import net.squanchy.schedule.domain.view.Schedule;
 import net.squanchy.schedule.view.ScheduleViewPagerAdapter;
 
@@ -28,6 +33,7 @@ public class SchedulePageView extends CoordinatorLayout {
     private Disposable subscription;
     private ScheduleService service;
     private Navigator navigate;
+    private Analytics analytics;
 
     public SchedulePageView(Context context, AttributeSet attrs) {
         this(context, attrs, 0);
@@ -41,6 +47,12 @@ public class SchedulePageView extends CoordinatorLayout {
     protected void onFinishInflate() {
         super.onFinishInflate();
 
+        Activity activity = unwrapToActivityContext(getContext());
+        ScheduleComponent component = ScheduleInjector.obtain(activity);
+        service = component.service();
+        navigate = component.navigator();
+        analytics = component.analytics();
+
         progressBar = findViewById(R.id.progressbar);
 
         ViewPager viewPager = (ViewPager) findViewById(R.id.viewpager);
@@ -48,14 +60,25 @@ public class SchedulePageView extends CoordinatorLayout {
         tabLayout.setupWithViewPager(viewPager);
         hackToApplyTypefaces(tabLayout);
 
-        viewPagerAdapter = new ScheduleViewPagerAdapter(getContext());
+        viewPagerAdapter = new ScheduleViewPagerAdapter(activity);
         viewPager.setAdapter(viewPagerAdapter);
 
-        ScheduleComponent component = ScheduleInjector.obtain(getContext());
-        service = component.service();
-        navigate = component.navigator();
+        tabLayout.addOnTabSelectedListener(new TrackingOnTabSelectedListener(analytics, viewPagerAdapter));
 
         setupToolbar();
+    }
+
+    private static Activity unwrapToActivityContext(Context context) {
+        if (context == null) {
+            throw new NullPointerException("Context cannot be null");
+        } else if (context instanceof Activity) {
+            return (Activity) context;
+        } else if (context instanceof ContextWrapper) {
+            ContextWrapper contextWrapper = (ContextWrapper) context;
+            return unwrapToActivityContext(contextWrapper.getBaseContext());
+        } else {
+            throw new IllegalStateException("Context type not supported: " + context.getClass().getCanonicalName());
+        }
     }
 
     private void setupToolbar() {
@@ -76,7 +99,12 @@ public class SchedulePageView extends CoordinatorLayout {
         super.onAttachedToWindow();
         subscription = service.schedule()
                 .observeOn(AndroidSchedulers.mainThread())
-                .subscribe(schedule -> updateWith(schedule, event -> navigate.toEventDetails(event.id())));
+                .subscribe(schedule -> updateWith(schedule, this::onEventClicked));
+    }
+
+    private void onEventClicked(Event event) {
+        analytics.trackItemSelected(ContentType.SCHEDULE_ITEM, event.id());
+        navigate.toEventDetails(event.id());
     }
 
     @Override
@@ -116,5 +144,31 @@ public class SchedulePageView extends CoordinatorLayout {
     public void updateWith(Schedule schedule, ScheduleViewPagerAdapter.OnEventClickedListener listener) {
         viewPagerAdapter.updateWith(schedule.pages(), listener);
         progressBar.setVisibility(GONE);
+    }
+
+    private static class TrackingOnTabSelectedListener implements TabLayout.OnTabSelectedListener {
+
+        private final Analytics analytics;
+        private final ScheduleViewPagerAdapter viewPagerAdapter;
+
+        private TrackingOnTabSelectedListener(Analytics analytics, ScheduleViewPagerAdapter viewPagerAdapter) {
+            this.analytics = analytics;
+            this.viewPagerAdapter = viewPagerAdapter;
+        }
+
+        @Override
+        public void onTabSelected(TabLayout.Tab tab) {
+            analytics.trackItemSelected(ContentType.SCHEDULE_DAY, viewPagerAdapter.getPageDayId(tab.getPosition()));
+        }
+
+        @Override
+        public void onTabUnselected(TabLayout.Tab tab) {
+            // No-op
+        }
+
+        @Override
+        public void onTabReselected(TabLayout.Tab tab) {
+            // No-op
+        }
     }
 }

--- a/app/src/main/java/net/squanchy/schedule/ScheduleService.java
+++ b/app/src/main/java/net/squanchy/schedule/ScheduleService.java
@@ -63,7 +63,7 @@ class ScheduleService {
             List<SchedulePage> sortedPages = new ArrayList<>(pages.size());
 
             for (SchedulePage page : pages) {
-                sortedPages.add(SchedulePage.create(page.date(), sortByStartDate(page)));
+                sortedPages.add(SchedulePage.create(page.dayId(), page.date(), sortByStartDate(page)));
             }
 
             return Schedule.create(sortedPages);
@@ -107,7 +107,7 @@ class ScheduleService {
                 Optional<String> rawDate = findDate(apiDays, dayId);
                 if (rawDate.isPresent()) {
                     LocalDateTime date = LocalDateTime.parse(rawDate.get(), DATE_FORMATTER);
-                    pages.add(SchedulePage.create(date, map.get(dayId)));
+                    pages.add(SchedulePage.create(dayId, date, map.get(dayId)));
                 }
             }
 

--- a/app/src/main/java/net/squanchy/schedule/domain/view/SchedulePage.java
+++ b/app/src/main/java/net/squanchy/schedule/domain/view/SchedulePage.java
@@ -9,9 +9,11 @@ import org.joda.time.LocalDateTime;
 @AutoValue
 public abstract class SchedulePage {
 
-    public static SchedulePage create(LocalDateTime date, List<Event> events) {
-        return new AutoValue_SchedulePage(date, events);
+    public static SchedulePage create(String dayId, LocalDateTime date, List<Event> events) {
+        return new AutoValue_SchedulePage(dayId, date, events);
     }
+
+    public abstract String dayId();
 
     public abstract LocalDateTime date();
 

--- a/app/src/main/java/net/squanchy/schedule/view/ScheduleViewPagerAdapter.java
+++ b/app/src/main/java/net/squanchy/schedule/view/ScheduleViewPagerAdapter.java
@@ -61,6 +61,10 @@ public class ScheduleViewPagerAdapter extends ViewPagerAdapter<ScheduleDayPageVi
         return date.toString(TITLE_FORMAT_TEMPLATE);
     }
 
+    public String getPageDayId(int position) {
+        return pages.get(position).dayId();
+    }
+
     @Override
     public boolean isViewFromObject(View view, Object object) {
         return view == object;

--- a/app/src/main/java/net/squanchy/search/SearchActivity.java
+++ b/app/src/main/java/net/squanchy/search/SearchActivity.java
@@ -97,7 +97,7 @@ public class SearchActivity extends TypefaceStyleableActivity implements SearchR
 
         Disposable searchSubscription = querySubject.throttleLast(QUERY_DEBOUNCE_TIMEOUT, TimeUnit.MILLISECONDS)
                 .doOnNext(this::updateSearchActionIcon)
-                .flatMap(query -> searchService.find(query))
+                .flatMap(searchService::find)
                 .doOnNext(searchResults -> speakersSubscription.dispose())
                 .toFlowable(BackpressureStrategy.LATEST)
                 .subscribeOn(Schedulers.computation())

--- a/app/src/main/java/net/squanchy/search/SearchInjector.java
+++ b/app/src/main/java/net/squanchy/search/SearchInjector.java
@@ -1,5 +1,6 @@
 package net.squanchy.search;
 
+import net.squanchy.injection.ActivityContextModule;
 import net.squanchy.injection.ApplicationInjector;
 import net.squanchy.navigation.NavigationModule;
 
@@ -13,7 +14,8 @@ final class SearchInjector {
         return DaggerSearchComponent.builder()
                 .applicationComponent(ApplicationInjector.obtain(activity))
                 .searchModule(new SearchModule())
-                .navigationModule(new NavigationModule(activity))
+                .activityContextModule(new ActivityContextModule(activity))
+                .navigationModule(new NavigationModule())
                 .build();
     }
 }

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,5 +1,5 @@
 ext {
-    supportLibVersion = '25.2.0'
+    supportLibVersion = '25.3.0'
     playServicesVersion = '10.2.0'
     daggerVersion = '2.9'
 

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -24,7 +24,6 @@ ext {
                     glide            : 'com.github.bumptech.glide:glide:3.7.0',
                     glideOkHttp3     : 'com.github.bumptech.glide:okhttp3-integration:1.4.0@aar',
                     jodaTimeAndroid  : 'net.danlew:android.joda:2.9.7',
-                    playAnalytics    : "com.google.android.gms:play-services-analytics:${playServicesVersion}",
                     retrolambda      : 'net.orfjackal.retrolambda:retrolambda:2.5.0',
                     rx               : 'io.reactivex.rxjava2:rxjava:2.0.5',
                     rxAndroid        : 'io.reactivex.rxjava2:rxandroid:2.0.1',

--- a/team-props/secrets.properties.sample
+++ b/team-props/secrets.properties.sample
@@ -2,4 +2,3 @@ fabricApiKey=
 twitterApiKey=
 twitterSecret=
 googleMapsApiKey=
-baseUrl=


### PR DESCRIPTION
This PR:

 * Removes Google Analytics as we don't really care about that
 * Disables Crashlytics for debug builds... for reals, this time
 * Remove the unused `baseUrl` property from the secrets' list
 * Improve Analytics code and the way it's injected
 * Adds missing Firebase Analytics permissions
 * Track section click and view on the homescreen, schedule days and items selection
 * Bonus fix: retrieve tabs' typeface from their TextAppearance instead of hardcoding it