### PR TITLE
Build version and debug navigation in settings

### DIFF
--- a/app/src/debug/AndroidManifest.xml
+++ b/app/src/debug/AndroidManifest.xml
@@ -9,8 +9,8 @@
       android:label="@string/debug_activity_title">
 
       <intent-filter>
-        <action android:name="android.intent.action.MAIN" />
-        <category android:name="android.intent.category.LAUNCHER" />
+        <action android:name="net.squanchy.DebugActivity" />
+        <category android:name="android.intent.category.DEFAULT" />
       </intent-filter>
     </activity>
 

--- a/app/src/main/java/net/squanchy/settings/SettingsFragment.java
+++ b/app/src/main/java/net/squanchy/settings/SettingsFragment.java
@@ -15,6 +15,10 @@ public class SettingsFragment extends PreferenceFragment {
 
         addPreferencesFromResource(R.xml.settings_preferences);
         displayBuildVersion();
+
+        if (!BuildConfig.DEBUG) {
+            removeDebugCategory();
+        }
     }
 
     private void displayBuildVersion() {
@@ -22,5 +26,11 @@ public class SettingsFragment extends PreferenceFragment {
         Preference buildVersionPreference = findPreference(buildVersionKey);
         String buildVersion = String.format(getString(R.string.version_x), BuildConfig.VERSION_NAME);
         buildVersionPreference.setSummary(buildVersion);
+    }
+
+    private void removeDebugCategory() {
+        String debugCategoryKey = getString(R.string.debug_category_preference_key);
+        Preference debugCategory = findPreference(debugCategoryKey);
+        getPreferenceScreen().removePreference(debugCategory);
     }
 }

--- a/app/src/main/java/net/squanchy/settings/SettingsFragment.java
+++ b/app/src/main/java/net/squanchy/settings/SettingsFragment.java
@@ -1,8 +1,10 @@
 package net.squanchy.settings;
 
 import android.os.Bundle;
+import android.preference.Preference;
 import android.preference.PreferenceFragment;
 
+import net.squanchy.BuildConfig;
 import net.squanchy.R;
 
 public class SettingsFragment extends PreferenceFragment {
@@ -12,5 +14,13 @@ public class SettingsFragment extends PreferenceFragment {
         super.onCreate(savedInstanceState);
 
         addPreferencesFromResource(R.xml.settings_preferences);
+        displayBuildVersion();
+    }
+
+    private void displayBuildVersion() {
+        String buildVersionKey = getString(R.string.buid_version_preference_key);
+        Preference buildVersionPreference = findPreference(buildVersionKey);
+        String buildVersion = String.format(getString(R.string.version_x), BuildConfig.VERSION_NAME);
+        buildVersionPreference.setSummary(buildVersion);
     }
 }

--- a/app/src/main/res/values/preference_keys.xml
+++ b/app/src/main/res/values/preference_keys.xml
@@ -3,5 +3,7 @@
 
   <string name="about_to_start_notification_preference_key">about_to_start_notification__preference_key</string>
   <string name="buid_version_preference_key">build_version_preference_key</string>
+  <string name="debug_category_preference_key">debug_category_preference_key</string>
+  <string name="open_debug_preference_key">open_debug_preference_key</string>
 
 </resources>

--- a/app/src/main/res/values/preference_keys.xml
+++ b/app/src/main/res/values/preference_keys.xml
@@ -2,5 +2,6 @@
 <resources>
 
   <string name="about_to_start_notification_preference_key">about_to_start_notification__preference_key</string>
+  <string name="buid_version_preference_key">build_version_preference_key</string>
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -52,5 +52,8 @@
   <string name="settings_notifications_about_to_start_title">Upcoming events notification</string>
   <string name="settings_notifications_about_to_start_summary_on">Show notifications for favourite events starting soon</string>
   <string name="settings_notifications_about_to_start_summary_off">Do not show notifications for favourite events starting soon</string>
+  <string name="settings_about_category">About</string>
+  <string name="settings_about_build_version_title">Build version</string>
+  <string name="version_x">Version: %1$s</string>
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -55,5 +55,7 @@
   <string name="settings_about_category">About</string>
   <string name="settings_about_build_version_title">Build version</string>
   <string name="version_x">Version: %1$s</string>
+  <string name="settings_debug_category">Debug</string>
+  <string name="settings_open_debug_title">Open debug screen</string>
 
 </resources>

--- a/app/src/main/res/xml/settings_preferences.xml
+++ b/app/src/main/res/xml/settings_preferences.xml
@@ -20,4 +20,15 @@
 
   </PreferenceCategory>
 
+  <PreferenceCategory android:title="@string/settings_debug_category"
+    android:key="@string/debug_category_preference_key">
+
+    <Preference
+      android:key="@string/open_debug_preference_key"
+      android:title="@string/settings_open_debug_title">
+      <intent android:action="net.squanchy.DebugActivity" />
+    </Preference>
+
+  </PreferenceCategory>
+
 </PreferenceScreen>

--- a/app/src/main/res/xml/settings_preferences.xml
+++ b/app/src/main/res/xml/settings_preferences.xml
@@ -12,4 +12,12 @@
 
   </PreferenceCategory>
 
+  <PreferenceCategory android:title="@string/settings_about_category">
+
+    <Preference
+      android:key="@string/buid_version_preference_key"
+      android:title="@string/settings_about_build_version_title" />
+
+  </PreferenceCategory>
+
 </PreferenceScreen>


### PR DESCRIPTION
This PR adds the build version display and navigation to debug screen from settings.
The debug screen preference is only available for debug builds.
It also removes the debug screen icon in the launcher.

| Debug | Release|
| --- | --- |
|![device-2017-03-21-095152](https://cloud.githubusercontent.com/assets/3942812/24139944/7fe4aab8-0e1e-11e7-8968-3f019fd6870c.png) | ![device-2017-03-21-100504](https://cloud.githubusercontent.com/assets/3942812/24139945/7fe4c0ac-0e1e-11e7-984b-6900c7bd7bbb.png) |

