### PR TITLE
SQ-154/fix notification crash

### DIFF
--- a/app/src/main/java/net/squanchy/notification/NotificationCreator.java
+++ b/app/src/main/java/net/squanchy/notification/NotificationCreator.java
@@ -54,7 +54,6 @@ public class NotificationCreator {
                 .setContentTitle(event.title())
                 .setContentText(getPlaceName(event))
                 .setColor(getTrackColor(event))
-                .setUsesChronometer(true)
                 .setWhen(event.startTime().toDateTime().getMillis())
                 .setShowWhen(true)
                 .setGroup(GROUP_KEY_NOTIFY_SESSION);

--- a/app/src/main/java/net/squanchy/notification/NotificationCreator.java
+++ b/app/src/main/java/net/squanchy/notification/NotificationCreator.java
@@ -9,6 +9,7 @@ import android.graphics.BitmapFactory;
 import android.graphics.Color;
 import android.support.v4.app.NotificationCompat;
 import android.support.v4.app.TaskStackBuilder;
+import android.support.v4.content.ContextCompat;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -94,7 +95,7 @@ public class NotificationCreator {
                 )
                 .setDefaults(Notification.DEFAULT_SOUND | Notification.DEFAULT_VIBRATE)
                 .setLights(
-                        resources.getColor(R.color.notification_led_color, context.getTheme()),
+                        ContextCompat.getColor(context, R.color.notification_led_color),
                         NOTIFICATION_LED_ON_MS,
                         NOTIFICATION_LED_OFF_MS
                 )


### PR DESCRIPTION
Fixes the notification on Lollipop, that were crashing due to method not being found (as per Issue #154 ) and removes the chronometer, as it was behaving strangely on HTC devices.

| Before | After |
|--------|------|
|![htc_rompe_le_cose](https://cloud.githubusercontent.com/assets/2534841/24145655/76ecdcfa-0e32-11e7-8f75-398e844880e1.png)|![e_roby_le_aggiusta](https://cloud.githubusercontent.com/assets/2534841/24145669/8111bcd2-0e32-11e7-846a-43a7c60542e0.png)|

