### PR TITLE
Image loader API refactor

### DIFF
--- a/app/src/main/java/net/squanchy/imageloader/GlideImageLoader.java
+++ b/app/src/main/java/net/squanchy/imageloader/GlideImageLoader.java
@@ -6,6 +6,7 @@ import android.widget.ImageView;
 import com.bumptech.glide.DrawableTypeRequest;
 import com.bumptech.glide.RequestManager;
 import com.firebase.ui.storage.images.FirebaseImageLoader;
+import com.google.firebase.storage.FirebaseStorage;
 import com.google.firebase.storage.StorageReference;
 
 final class GlideImageLoader implements ImageLoader {
@@ -23,13 +24,18 @@ final class GlideImageLoader implements ImageLoader {
     @Override
     public ImageRequest load(String url) {
         if (url.startsWith(FIREBASE_STORAGE_URL_SCHEMA)) {
-            throw new IllegalArgumentException("To load images from Firebase Storage please obtain the StorageReference first and use that one.");
+            StorageReference reference = FirebaseStorage.getInstance().getReferenceFromUrl(url);
+            return loadFromFirebase(reference);
+        } else {
+            return loadFromWeb(url);
         }
+    }
+
+    private ImageRequest loadFromWeb(String url) {
         return new GlideUrlImageRequest(requestManager, url);
     }
 
-    @Override
-    public ImageRequest load(StorageReference storageReference) {
+    private ImageRequest loadFromFirebase(StorageReference storageReference) {
         return new GlideFirebaseImageRequest(requestManager, storageReference, firebaseImageLoader);
     }
 

--- a/app/src/main/java/net/squanchy/imageloader/ImageLoader.java
+++ b/app/src/main/java/net/squanchy/imageloader/ImageLoader.java
@@ -1,10 +1,7 @@
 package net.squanchy.imageloader;
 
-import com.google.firebase.storage.StorageReference;
-
 public interface ImageLoader {
 
     ImageRequest load(String url);
 
-    ImageRequest load(StorageReference storageReference);
 }

--- a/app/src/main/java/net/squanchy/search/SearchItemView.java
+++ b/app/src/main/java/net/squanchy/search/SearchItemView.java
@@ -6,9 +6,6 @@ import android.widget.ImageView;
 import android.widget.LinearLayout;
 import android.widget.TextView;
 
-import com.google.firebase.storage.FirebaseStorage;
-import com.google.firebase.storage.StorageReference;
-
 import net.squanchy.R;
 import net.squanchy.imageloader.ImageLoader;
 import net.squanchy.search.view.SearchRecyclerView.OnSearchResultClickListener;
@@ -59,20 +56,7 @@ public class SearchItemView extends LinearLayout {
 
         Optional<String> avatarImageURL = speaker.photoUrl();
         if (avatarImageURL.isPresent()) {
-            loadPhoto(image, avatarImageURL.get(), imageLoader);
+            imageLoader.load(avatarImageURL.get()).into(image);
         }
-    }
-
-    private void loadPhoto(ImageView photoView, String photoUrl, ImageLoader imageLoader) {
-        if (isFirebaseStorageUrl(photoUrl)) {
-            StorageReference photoReference = FirebaseStorage.getInstance().getReference(photoUrl);
-            imageLoader.load(photoReference).into(photoView);
-        } else {
-            imageLoader.load(photoUrl).into(photoView);
-        }
-    }
-
-    private boolean isFirebaseStorageUrl(String url) {
-        return url.startsWith("gs://");            // TODO move elsewhere
     }
 }

--- a/app/src/main/java/net/squanchy/support/widget/SpeakerView.java
+++ b/app/src/main/java/net/squanchy/support/widget/SpeakerView.java
@@ -11,9 +11,6 @@ import android.widget.ImageView;
 import android.widget.LinearLayout;
 import android.widget.TextView;
 
-import com.google.firebase.storage.FirebaseStorage;
-import com.google.firebase.storage.StorageReference;
-
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -110,16 +107,7 @@ public abstract class SpeakerView extends LinearLayout {
     protected abstract ImageView inflatePhotoView(ViewGroup speakerPhotoContainer);
 
     private void loadSpeakerPhoto(ImageView photoView, String photoUrl, ImageLoader imageLoader) {
-        if (isFirebaseStorageUrl(photoUrl)) {
-            StorageReference photoReference = FirebaseStorage.getInstance().getReference(photoUrl);
-            imageLoader.load(photoReference).into(photoView);
-        } else {
-            imageLoader.load(photoUrl).into(photoView);
-        }
-    }
-
-    private boolean isFirebaseStorageUrl(String url) {
-        return url.startsWith("gs://");            // TODO move elsewhere
+        imageLoader.load(photoUrl).into(photoView);
     }
 
     private List<ImageView> getAllImageViewsContainedIn(ViewGroup container) {


### PR DESCRIPTION
We were duplicating (triplicating with https://github.com/rock3r/squanchy/pull/158 ) the image URL prefix check.
In this PR I moved the check inside `GlideImageLoader` (which was already aware of the existence of the Firebase Storage URL schema), leaving only one exposed `load` API.

Also, before we were using the wrong method to get the Storage reference (`FirebaseStorage.getInstance().getReference(url)`) => updated with `FirebaseStorage.getInstance(). getReferenceFromUrl(url)`