### PR TITLE
SQ-172/Use event timezone

### DIFF
--- a/.idea/inspectionProfiles/Squanchy.xml
+++ b/.idea/inspectionProfiles/Squanchy.xml
@@ -119,7 +119,9 @@
     <inspection_tool class="AssignmentUsedAsCondition" enabled="true" level="INFO" enabled_by_default="true" />
     <inspection_tool class="CStyleArrayDeclaration" enabled="true" level="INFO" enabled_by_default="true" />
     <inspection_tool class="CallToStringConcatCanBeReplacedByOperator" enabled="true" level="WARNING" enabled_by_default="true" />
+    <inspection_tool class="ClassMayBeInterface" enabled="false" level="INFORMATION" enabled_by_default="false" />
     <inspection_tool class="ClassNameDiffersFromFileName" enabled="true" level="WARNING" enabled_by_default="true" />
+    <inspection_tool class="ComparatorCombinators" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="DuplicateBooleanBranch" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="DuplicateCondition" enabled="true" level="WARNING" enabled_by_default="true">
       <option name="ignoreMethodCalls" value="false" />
@@ -132,11 +134,15 @@
     <inspection_tool class="GroovyOverlyComplexMethod" enabled="false" level="WEAK WARNING" enabled_by_default="false">
       <option name="m_limit" value="10" />
     </inspection_tool>
+    <inspection_tool class="Guava" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="GwtUiFieldErrors" enabled="false" level="ERROR" enabled_by_default="false" />
     <inspection_tool class="GwtUiHandlerErrors" enabled="false" level="ERROR" enabled_by_default="false" />
     <inspection_tool class="IfMayBeConditional" enabled="true" level="INFO" enabled_by_default="true" />
     <inspection_tool class="IfStatementWithIdenticalBranches" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="InstanceofThis" enabled="true" level="WARNING" enabled_by_default="true" />
+    <inspection_tool class="Java8CollectionRemoveIf" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="Java8ListSort" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="Java8MapApi" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="JavaDoc" enabled="true" level="WARNING" enabled_by_default="true">
       <option name="TOP_LEVEL_CLASS_OPTIONS">
         <value>
@@ -174,6 +180,10 @@
       <option name="REPORT_VARIABLES" value="true" />
       <option name="REPORT_PARAMETERS" value="false" />
     </inspection_tool>
+    <inspection_tool class="LoggerInitializedWithForeignClass" enabled="false" level="WARNING" enabled_by_default="false">
+      <option name="loggerClassName" value="org.apache.log4j.Logger,org.slf4j.LoggerFactory,org.apache.commons.logging.LogFactory,java.util.logging.Logger" />
+      <option name="loggerFactoryMethodName" value="getLogger,getLogger,getLog,getLogger" />
+    </inspection_tool>
     <inspection_tool class="LoopConditionNotUpdatedInsideLoop" enabled="true" level="INFO" enabled_by_default="true">
       <option name="ignoreIterators" value="true" />
     </inspection_tool>
@@ -196,12 +206,14 @@
       <option name="ignoreLazyOperators" value="true" />
       <option name="ignoreObscureOperators" value="true" />
     </inspection_tool>
+    <inspection_tool class="ReplaceInefficientStreamCount" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="SizeReplaceableByIsEmpty" enabled="true" level="INFO" enabled_by_default="true" />
     <inspection_tool class="SpellCheckingInspection" enabled="false" level="TYPO" enabled_by_default="false">
       <option name="processCode" value="true" />
       <option name="processLiterals" value="true" />
       <option name="processComments" value="true" />
     </inspection_tool>
+    <inspection_tool class="StaticPseudoFunctionalStyleMethod" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="SystemOutErr" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="ThreadDumpStack" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="ThrowablePrintStackTrace" enabled="true" level="WARNING" enabled_by_default="true" />

--- a/app/src/debug/java/net.squanchy/DebugActivity.java
+++ b/app/src/debug/java/net.squanchy/DebugActivity.java
@@ -22,6 +22,7 @@ import net.squanchy.schedule.domain.view.Track;
 import net.squanchy.speaker.domain.view.Speaker;
 import net.squanchy.support.lang.Optional;
 
+import org.joda.time.DateTimeZone;
 import org.joda.time.LocalDateTime;
 
 @SuppressWarnings("checkstyle:magicnumber")
@@ -82,10 +83,10 @@ public class DebugActivity extends Activity {
                 Event.Type.TALK,
                 true,
                 Optional.absent(),
-                Optional.of(createTrack())
+                Optional.of(createTrack()),
+                DateTimeZone.forID("Europe/Rome")
         );
     }
-
 
     private Optional<Place> createPlace() {
         Place place = Place.create("1", "That room over there", Optional.absent());
@@ -116,7 +117,7 @@ public class DebugActivity extends Activity {
                 Optional.of(generateColor()),
                 Optional.of(generateColor()),
                 Optional.of("gs://droidcon-italy-2017.appspot.com/tracks/0.webp")
-                );
+        );
     }
 
     public int getRandomColor() {

--- a/app/src/main/java/net/squanchy/eventdetails/widget/EventDetailsLayout.java
+++ b/app/src/main/java/net/squanchy/eventdetails/widget/EventDetailsLayout.java
@@ -22,6 +22,9 @@ import net.squanchy.schedule.domain.view.Event;
 import net.squanchy.schedule.domain.view.Place;
 import net.squanchy.support.lang.Optional;
 
+import org.joda.time.format.DateTimeFormat;
+import org.joda.time.format.DateTimeFormatter;
+
 public class EventDetailsLayout extends LinearLayout {
 
     private static final String WHEN_DATE_TIME_FORMAT = "EEEE, d MMMM 'at' HH:mm";
@@ -60,9 +63,15 @@ public class EventDetailsLayout extends LinearLayout {
     }
 
     public void updateWith(Event event) {
-        whenTextView.setText(event.startTime().toString(WHEN_DATE_TIME_FORMAT));
+        updateWhen(event);
         updateWhere(event);
         updateDescription(event.description());
+    }
+
+    private void updateWhen(Event event) {
+        DateTimeFormatter formatter = DateTimeFormat.forPattern(WHEN_DATE_TIME_FORMAT)
+                .withZone(event.timeZone());
+        whenTextView.setText(formatter.print(event.startTime().toDateTime()));
     }
 
     private void updateWhere(Event event) {

--- a/app/src/main/java/net/squanchy/schedule/domain/view/Event.java
+++ b/app/src/main/java/net/squanchy/schedule/domain/view/Event.java
@@ -8,6 +8,7 @@ import net.squanchy.eventdetails.domain.view.ExperienceLevel;
 import net.squanchy.speaker.domain.view.Speaker;
 import net.squanchy.support.lang.Optional;
 
+import org.joda.time.DateTimeZone;
 import org.joda.time.LocalDateTime;
 
 @AutoValue
@@ -26,7 +27,8 @@ public abstract class Event {
             Type type,
             boolean favorited,
             Optional<String> description,
-            Optional<Track> track) {
+            Optional<Track> track,
+            DateTimeZone timeZone) {
         return new AutoValue_Event.Builder()
                 .id(eventId)
                 .numericId(numericEventId)
@@ -41,6 +43,7 @@ public abstract class Event {
                 .type(type)
                 .favorited(favorited)
                 .description(description)
+                .timeZone(timeZone)
                 .build();
     }
 
@@ -69,6 +72,8 @@ public abstract class Event {
     public abstract boolean favorited();
 
     public abstract Optional<String> description();
+
+    public abstract DateTimeZone timeZone();
 
     public String speakersNames() {
         StringBuilder speakersBuilder = new StringBuilder();
@@ -111,6 +116,8 @@ public abstract class Event {
         public abstract Builder favorited(boolean favorited);
 
         public abstract Builder description(Optional<String> description);
+
+        public abstract Builder timeZone(DateTimeZone timeZone);
 
         public abstract Event build();
     }

--- a/app/src/main/java/net/squanchy/schedule/view/OtherEventItemView.java
+++ b/app/src/main/java/net/squanchy/schedule/view/OtherEventItemView.java
@@ -14,8 +14,6 @@ import org.joda.time.format.DateTimeFormatter;
 
 public class OtherEventItemView extends EventItemView {
 
-    private final DateTimeFormatter dateTimeFormatter;
-
     private TextView titleView;
     private TextView timestampView;
     private ImageView illustrationView;
@@ -26,7 +24,6 @@ public class OtherEventItemView extends EventItemView {
 
     public OtherEventItemView(Context context, AttributeSet attrs, int defStyleAttr) {
         super(context, attrs, defStyleAttr);
-        this.dateTimeFormatter = DateTimeFormat.shortTime();
     }
 
     @Override
@@ -42,10 +39,28 @@ public class OtherEventItemView extends EventItemView {
     public void updateWith(Event event) {
         ensureSupportedType(event.type());
 
-        timestampView.setText(dateTimeFormatter.print(event.startTime()));
+        timestampView.setText(startTimeAsFormattedString(event));
         titleView.setText(event.title());
 
         illustrationView.setImageResource(illustrationFor(event.type()));
+    }
+
+    private void ensureSupportedType(Event.Type type) {
+        if (type == Event.Type.COFFEE_BREAK
+                || type == Event.Type.LUNCH
+                || type == Event.Type.OTHER
+                || type == Event.Type.REGISTRATION
+                || type == Event.Type.SOCIAL) {
+            return;
+        }
+        throw new IllegalArgumentException("Event with type " + type.name() + " is not supported by this view");
+    }
+
+    private String startTimeAsFormattedString(Event event) {
+        DateTimeFormatter formatter = DateTimeFormat.shortTime()
+                .withZone(event.timeZone());
+
+        return formatter.print(event.startTime().toDateTime());
     }
 
     @DrawableRes
@@ -60,16 +75,5 @@ public class OtherEventItemView extends EventItemView {
             default:
                 throw new IllegalArgumentException("Type not supported: " + type.name());
         }
-    }
-
-    private void ensureSupportedType(Event.Type type) {
-        if (type == Event.Type.COFFEE_BREAK
-                || type == Event.Type.LUNCH
-                || type == Event.Type.OTHER
-                || type == Event.Type.REGISTRATION
-                || type == Event.Type.SOCIAL) {
-            return;
-        }
-        throw new IllegalArgumentException("Event with type " + type.name() + " is not supported by this view");
     }
 }

--- a/app/src/main/java/net/squanchy/schedule/view/TalkEventItemView.java
+++ b/app/src/main/java/net/squanchy/schedule/view/TalkEventItemView.java
@@ -14,8 +14,6 @@ import org.joda.time.format.DateTimeFormatter;
 
 public class TalkEventItemView extends EventItemView {
 
-    private final DateTimeFormatter dateTimeFormatter;
-
     private TextView titleView;
     private TextView timestampView;
     private ExperienceLevelIconView experienceLevelIconView;
@@ -27,7 +25,6 @@ public class TalkEventItemView extends EventItemView {
 
     public TalkEventItemView(Context context, AttributeSet attrs, int defStyleAttr) {
         super(context, attrs, defStyleAttr);
-        this.dateTimeFormatter = DateTimeFormat.shortTime();
     }
 
     @Override
@@ -44,7 +41,7 @@ public class TalkEventItemView extends EventItemView {
     public void updateWith(Event event) {
         ensureSupportedType(event.type());
 
-        timestampView.setText(dateTimeFormatter.print(event.startTime()));
+        timestampView.setText(startTimeAsFormattedString(event));
         titleView.setText(event.title());
 
         if (event.experienceLevel().isPresent()) {
@@ -56,6 +53,13 @@ public class TalkEventItemView extends EventItemView {
 
         speakerView.setVisibility(event.speakers().isEmpty() ? GONE : VISIBLE);
         speakerView.updateWith(event.speakers(), speaker -> { });
+    }
+
+    private String startTimeAsFormattedString(Event event) {
+        DateTimeFormatter formatter = DateTimeFormat.shortTime()
+                .withZone(event.timeZone());
+
+        return formatter.print(event.startTime().toDateTime());
     }
 
     private void ensureSupportedType(Event.Type type) {

--- a/app/src/main/java/net/squanchy/service/firebase/model/FirebaseVenue.java
+++ b/app/src/main/java/net/squanchy/service/firebase/model/FirebaseVenue.java
@@ -13,4 +13,6 @@ public class FirebaseVenue {
     public String description;
 
     public String map_url;
+
+    public String timezone;
 }

--- a/app/src/main/java/net/squanchy/service/repository/VenueRepository.java
+++ b/app/src/main/java/net/squanchy/service/repository/VenueRepository.java
@@ -1,7 +1,7 @@
 package net.squanchy.service.repository;
 
-import net.squanchy.venue.domain.view.Venue;
 import net.squanchy.service.firebase.FirebaseDbService;
+import net.squanchy.venue.domain.view.Venue;
 
 import io.reactivex.Observable;
 
@@ -21,7 +21,8 @@ public class VenueRepository {
                         firebaseVenue.lat,
                         firebaseVenue.lon,
                         firebaseVenue.description,
-                        firebaseVenue.map_url
+                        firebaseVenue.map_url,
+                        firebaseVenue.timezone
                 ));
     }
 }

--- a/app/src/main/java/net/squanchy/venue/domain/view/Venue.java
+++ b/app/src/main/java/net/squanchy/venue/domain/view/Venue.java
@@ -2,10 +2,12 @@ package net.squanchy.venue.domain.view;
 
 import com.google.auto.value.AutoValue;
 
+import org.joda.time.DateTimeZone;
+
 @AutoValue
 public abstract class Venue {
 
-    public static Venue create(String name, String address, double latitude, double longitude, String description, String mapUrl) {
+    public static Venue create(String name, String address, double latitude, double longitude, String description, String mapUrl, String timezoneId) {
         return new AutoValue_Venue.Builder()
                 .name(name)
                 .address(address)
@@ -13,6 +15,7 @@ public abstract class Venue {
                 .longitude(longitude)
                 .description(description)
                 .mapUrl(mapUrl)
+                .timeZone(DateTimeZone.forID(timezoneId))
                 .build();
     }
 
@@ -28,6 +31,8 @@ public abstract class Venue {
 
     public abstract String mapUrl();
 
+    public abstract DateTimeZone timeZone();
+
     @AutoValue.Builder
     public abstract static class Builder {
 
@@ -42,6 +47,8 @@ public abstract class Venue {
         public abstract Builder description(String description);
 
         public abstract Builder mapUrl(String mapUrl);
+
+        public abstract Builder timeZone(DateTimeZone timeZone);
 
         public abstract Venue build();
     }

--- a/app/src/test/java/net/squanchy/schedule/domain/view/EventFixtures.java
+++ b/app/src/test/java/net/squanchy/schedule/domain/view/EventFixtures.java
@@ -7,6 +7,7 @@ import net.squanchy.eventdetails.domain.view.ExperienceLevel;
 import net.squanchy.speaker.domain.view.Speaker;
 import net.squanchy.support.lang.Optional;
 
+import org.joda.time.DateTimeZone;
 import org.joda.time.LocalDateTime;
 
 import static net.squanchy.schedule.domain.view.PlaceFixtures.aPlace;
@@ -26,6 +27,7 @@ public final class EventFixtures {
     private Event.Type type = Event.Type.OTHER;
     private Optional<String> description = Optional.of("Now this is the story all about how\nMy life got flipped, turned upside down");
     private Optional<Track> track = Optional.of(aTrack().build());
+    private DateTimeZone timeZone = DateTimeZone.forID("Europe/Rome");
 
     public static EventFixtures anEvent() {
         return new EventFixtures();
@@ -95,6 +97,11 @@ public final class EventFixtures {
         return this;
     }
 
+    public EventFixtures withTimeZone(DateTimeZone timeZone) {
+        this.timeZone = timeZone;
+        return this;
+    }
+
     public Event build() {
         return Event.create(
                 eventId,
@@ -109,7 +116,8 @@ public final class EventFixtures {
                 type,
                 false,
                 description,
-                track
+                track,
+                timeZone
         );
     }
 }


### PR DESCRIPTION
This PR makes sure we use the local timezone to the event rather than the device timezone when formatting dates and times. It also disables a few Java 8-only inspections for APIs we can't use on Android.

This fixes #172.

 Before* | After*
 --- | ---
 ![timezone-before](https://cloud.githubusercontent.com/assets/153802/24361725/8d1fe75e-1302-11e7-8d0e-09bd7c84171e.png) | ![timezone-after](https://cloud.githubusercontent.com/assets/153802/24361724/8d0e5b24-1302-11e7-9651-3b9d0d86fbcc.png)

\* taken in the UK with a UK timezone on the device