### PR TITLE
Setup instructions update

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ Starting your own conference app is easy and requires very little effort. See [`
 
 Please note that this app uses some third party services:
  * Firebase (Realtime DB, Push messages, etc)
- * Fabric/Crashlytics
- * Google Analytics
+ * Fabric: Crashlytics and Twitter
+ * NearIt (proximity/location services)
  
 While not all of them are strictly necessary for the app to work (with the exception of Firebase's RTDB), it is currently not possible for the code to work without them.
 We plan on eventually abstracting away the implementations so that they would simply be disabled if there is no API configured, but we haven't done it yet.
-If you need to use Squanchy without some of those implementations, please contribute back to mainline your changes.  
+If you need to use Squanchy without some of those implementations, please feel free to make them optional and contribute back to mainline your changes.  

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -39,7 +39,7 @@ This file contains a bunch of private configuration details that are not needed 
  * `fabricApiKey` is the API key to use for Fabric (and thus, Crashlytics). To obtain this, enable the app for Fabric from the [Fabric plugin](https://fabric.io/downloads/android-studio), let it change stuff, get the API key it generates, and put it into the properties file. Then revert whatever changes the Fabric wizard might have applied to the code
  * `googleMapsApiKey` is the API key for [Google Maps](https://developers.google.com/maps/documentation/android-api/signup). This is used for the venue map and directions
  * `twitterApiKey` and `twitterSecret` are used by the Twitter SDK. You can obtain them by enabling the Twitter Kit in Fabric; just click the corresponding button in the Fabric plugin UI in Android Studio, grab the keys from wherever it adds them, move them to the properties file, and revert whatever other changes the wizard might have done to the code
- * `baseUrl` is the URL to use as prefix when composing the HTTP requests to the backend
+ * `nearITApiKey` is the API key to use for the NearIT SDK (used for location-awareness and beacons, will be optional in the future but it is mandatory at the time of writing; you can use some dummy value if you don't want NearIT integration)
 
 ### Google Play Store keys
 

--- a/team-props/secrets.properties.sample
+++ b/team-props/secrets.properties.sample
@@ -2,3 +2,4 @@ fabricApiKey=
 twitterApiKey=
 twitterSecret=
 googleMapsApiKey=
+nearITApiKey=


### PR DESCRIPTION
This includes the NearIT key in the setup instructions and removes the now-unused `baseUrl` (leftover from Connfa)