### PR TITLE
SQ-180/bottom navigation color fix

### DIFF
--- a/app/src/main/java/net/squanchy/home/HomeActivity.java
+++ b/app/src/main/java/net/squanchy/home/HomeActivity.java
@@ -34,6 +34,7 @@ import net.squanchy.support.widget.InterceptingBottomNavigationView;
 
 import io.reactivex.android.schedulers.AndroidSchedulers;
 import io.reactivex.disposables.CompositeDisposable;
+import timber.log.Timber;
 
 public class HomeActivity extends TypefaceStyleableActivity {
 
@@ -141,6 +142,15 @@ public class HomeActivity extends TypefaceStyleableActivity {
         for (LifecycleView lifecycleView : lifecycleViews) {
             lifecycleView.onStart();
         }
+    }
+
+    //TODO fix it properly
+    @Override
+    protected void onResume() {
+        super.onResume();
+
+        Resources.Theme theme = getThemeFor(currentSection);
+        bottomNavigationView.setBackgroundColor(getColorFromTheme(theme, android.support.design.R.attr.colorPrimary));
     }
 
     private void handleProximityEvent(ProximityEvent proximityEvent) {

--- a/app/src/main/java/net/squanchy/home/HomeActivity.java
+++ b/app/src/main/java/net/squanchy/home/HomeActivity.java
@@ -34,7 +34,6 @@ import net.squanchy.support.widget.InterceptingBottomNavigationView;
 
 import io.reactivex.android.schedulers.AndroidSchedulers;
 import io.reactivex.disposables.CompositeDisposable;
-import timber.log.Timber;
 
 public class HomeActivity extends TypefaceStyleableActivity {
 


### PR DESCRIPTION
This is dirty fix for issue #180 
**Note**
*This dirty thing has been made into the `onResume()` method as the `onStart()` and `onRestart()` were not called as we expected them to.*