### PR TITLE
SQ-176/Search bug

### DIFF
--- a/app/src/main/java/net/squanchy/search/SearchActivity.java
+++ b/app/src/main/java/net/squanchy/search/SearchActivity.java
@@ -30,7 +30,6 @@ import net.squanchy.schedule.domain.view.Event;
 import net.squanchy.search.view.SearchRecyclerView;
 import net.squanchy.speaker.domain.view.Speaker;
 
-import io.reactivex.BackpressureStrategy;
 import io.reactivex.android.schedulers.AndroidSchedulers;
 import io.reactivex.disposables.CompositeDisposable;
 import io.reactivex.disposables.Disposable;
@@ -99,7 +98,6 @@ public class SearchActivity extends TypefaceStyleableActivity implements SearchR
                 .doOnNext(this::updateSearchActionIcon)
                 .flatMap(searchService::find)
                 .doOnNext(searchResults -> speakersSubscription.dispose())
-                .toFlowable(BackpressureStrategy.LATEST)
                 .subscribeOn(Schedulers.computation())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(this::onReceivedSearchResults, Timber::e);
@@ -153,7 +151,7 @@ public class SearchActivity extends TypefaceStyleableActivity implements SearchR
     protected void onStop() {
         super.onStop();
 
-        subscriptions.dispose();
+        subscriptions.clear();
 
         if (searchTextWatcher != null) {
             searchField.removeTextChangedListener(searchTextWatcher);


### PR DESCRIPTION
Removing `toFlowable` did the trick, I didn't see the point in using it and @rock3r doesn't remember the reason so yolo.

Fixes #176 

The "problem" now is that the search state is restored to the empty state every time we go back into it.