### PR TITLE
SQ-162/Fix schedule tabs text wrapping in landscape

### DIFF
--- a/app/src/main/java/net/squanchy/schedule/view/ScheduleViewPagerAdapter.java
+++ b/app/src/main/java/net/squanchy/schedule/view/ScheduleViewPagerAdapter.java
@@ -58,7 +58,7 @@ public class ScheduleViewPagerAdapter extends ViewPagerAdapter<ScheduleDayPageVi
     @Override
     public CharSequence getPageTitle(int position) {
         LocalDateTime date = pages.get(position).date();
-        return date.toString(TITLE_FORMAT_TEMPLATE);
+        return date.toString(TITLE_FORMAT_TEMPLATE).toUpperCase();
     }
 
     public String getPageDayId(int position) {

--- a/app/src/main/res/layout/view_page_schedule.xml
+++ b/app/src/main/res/layout/view_page_schedule.xml
@@ -6,7 +6,7 @@
   android:theme="@style/Theme.Squanchy.Schedule"
   android:layout_width="match_parent"
   android:layout_height="match_parent"
-  tools:context="net.squanchy.schedule.ScheduleActivity">
+  tools:context="net.squanchy.home.HomeActivity">
 
   <android.support.design.widget.AppBarLayout
     style="@style/Squanchy.Appbar"

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -22,8 +22,9 @@
 
   <style name="Squanchy.Tabs.Schedule" parent="None">
     <item name="tabIndicatorColor">?colorControlNormal</item>
-    <item name="tabTextAppearance">@style/TextAppearance.Squanchy.Tab</item>
+    <item name="tabGravity">fill</item>
     <item name="tabSelectedTextColor">?android:textColorPrimary</item>
+    <item name="tabTextAppearance">@style/TextAppearance.Squanchy.Tab</item>
   </style>
 
   <style name="TextAppearance.Squanchy.Tab" parent="TextAppearance.AppCompat.Button">


### PR DESCRIPTION
This PR fixes #162. In addition it makes the tab text uppercase as per latest designs.

![tabs-land](https://cloud.githubusercontent.com/assets/153802/24463090/ae3acc00-149d-11e7-9cb2-9f30a546f588.png)
