### PR TITLE
SQ-198/persist tweets

### DIFF
--- a/app/src/main/java/net/squanchy/tweets/TweetsPageView.java
+++ b/app/src/main/java/net/squanchy/tweets/TweetsPageView.java
@@ -117,7 +117,17 @@ public class TweetsPageView extends LinearLayout implements LifecycleView {
         swipeLayout.setRefreshing(true);
         refreshingData = true;
         subscription = twitterService.refresh(query)
-                .subscribe(tweetsAdapter::updateWith, Timber::e, this::onRefreshCompleted);
+                .subscribe(this::onSuccess, this::onError);
+    }
+
+    private void onSuccess(List<Tweet> tweets) {
+        tweetsAdapter.updateWith(tweets);
+        onRefreshCompleted();
+    }
+
+    private void onError(Throwable throwable) {
+        Timber.e(throwable);
+        onRefreshCompleted();
     }
 
     private void onRefreshCompleted() {

--- a/app/src/main/java/net/squanchy/tweets/TweetsPageView.java
+++ b/app/src/main/java/net/squanchy/tweets/TweetsPageView.java
@@ -99,6 +99,7 @@ public class TweetsPageView extends LinearLayout implements LifecycleView {
             }
         });
     }
+
     @Override
     public void onStart() {
         Context context = getContext();
@@ -116,13 +117,17 @@ public class TweetsPageView extends LinearLayout implements LifecycleView {
         swipeLayout.setRefreshing(true);
         refreshingData = true;
         subscription = twitterService.refresh(query)
-                .subscribe(this::onRefreshFinished, this::onError);
+                .subscribe(this::onRefreshSuccess, this::onError);
     }
 
-    private void onRefreshFinished(List<Tweet> tweets) {
+    private void onRefreshSuccess(List<Tweet> tweets) {
+        tweetsAdapter.updateWith(tweets);
+        onRefreshCompleted();
+    }
+
+    private void onRefreshCompleted() {
         refreshingData = false;
         swipeLayout.setRefreshing(false);
-        tweetsAdapter.updateWith(tweets);
 
         if (tweetsAdapter.isEmpty()) {
             emptyView.setVisibility(VISIBLE);
@@ -135,6 +140,6 @@ public class TweetsPageView extends LinearLayout implements LifecycleView {
 
     private void onError(Throwable throwable) {
         Timber.e(throwable);
-        onRefreshFinished(Collections.emptyList());
+        onRefreshCompleted();
     }
 }

--- a/app/src/main/java/net/squanchy/tweets/TweetsPageView.java
+++ b/app/src/main/java/net/squanchy/tweets/TweetsPageView.java
@@ -117,12 +117,7 @@ public class TweetsPageView extends LinearLayout implements LifecycleView {
         swipeLayout.setRefreshing(true);
         refreshingData = true;
         subscription = twitterService.refresh(query)
-                .subscribe(this::onRefreshSuccess, this::onError);
-    }
-
-    private void onRefreshSuccess(List<Tweet> tweets) {
-        tweetsAdapter.updateWith(tweets);
-        onRefreshCompleted();
+                .subscribe(tweetsAdapter::updateWith, Timber::e, this::onRefreshCompleted);
     }
 
     private void onRefreshCompleted() {
@@ -136,10 +131,5 @@ public class TweetsPageView extends LinearLayout implements LifecycleView {
             emptyView.setVisibility(GONE);
             tweetsList.setVisibility(VISIBLE);
         }
-    }
-
-    private void onError(Throwable throwable) {
-        Timber.e(throwable);
-        onRefreshCompleted();
     }
 }


### PR DESCRIPTION
Basically #198 was a bug uncovered by removing the check for the empty list. When the request was failing, we were updating the `TweetsAdapter` with an empty list. This won't happen anymore, since `onRefreshSuccess` has been split in two methods, and only the successful one updates the adapter