### PR TITLE
SQ-142/Fix circles not being circles sometimes 🔴

### DIFF
--- a/app/src/main/java/net/squanchy/eventdetails/widget/EventDetailsHeaderLayout.java
+++ b/app/src/main/java/net/squanchy/eventdetails/widget/EventDetailsHeaderLayout.java
@@ -7,6 +7,7 @@ import android.widget.TextView;
 
 import net.squanchy.R;
 import net.squanchy.schedule.domain.view.Event;
+import net.squanchy.support.lang.Optional;
 import net.squanchy.support.widget.SpeakerView;
 
 public class EventDetailsHeaderLayout extends AppBarLayout {
@@ -31,6 +32,6 @@ public class EventDetailsHeaderLayout extends AppBarLayout {
         titleView.setVisibility(VISIBLE);
 
         speakerView.setVisibility(event.speakers().isEmpty() ? GONE : VISIBLE);
-        speakerView.updateWith(event.speakers(), listener);
+        speakerView.updateWith(event.speakers(), Optional.of(listener));
     }
 }

--- a/app/src/main/java/net/squanchy/schedule/view/TalkEventItemView.java
+++ b/app/src/main/java/net/squanchy/schedule/view/TalkEventItemView.java
@@ -7,6 +7,7 @@ import android.widget.TextView;
 import net.squanchy.R;
 import net.squanchy.eventdetails.widget.ExperienceLevelIconView;
 import net.squanchy.schedule.domain.view.Event;
+import net.squanchy.support.lang.Optional;
 import net.squanchy.support.widget.SpeakerView;
 
 import org.joda.time.format.DateTimeFormat;
@@ -52,7 +53,7 @@ public class TalkEventItemView extends EventItemView {
         }
 
         speakerView.setVisibility(event.speakers().isEmpty() ? GONE : VISIBLE);
-        speakerView.updateWith(event.speakers(), speaker -> { });
+        speakerView.updateWith(event.speakers(), Optional.absent());
     }
 
     private String startTimeAsFormattedString(Event event) {

--- a/app/src/main/java/net/squanchy/support/widget/CircleImageView.java
+++ b/app/src/main/java/net/squanchy/support/widget/CircleImageView.java
@@ -20,14 +20,34 @@
 package net.squanchy.support.widget;
 
 import android.content.Context;
+import android.graphics.Bitmap;
+import android.graphics.BitmapShader;
+import android.graphics.Canvas;
+import android.graphics.Matrix;
 import android.graphics.Outline;
+import android.graphics.Paint;
+import android.graphics.RectF;
+import android.graphics.Shader;
+import android.graphics.drawable.BitmapDrawable;
+import android.graphics.drawable.ColorDrawable;
+import android.graphics.drawable.Drawable;
+import android.net.Uri;
+import android.support.annotation.DrawableRes;
 import android.util.AttributeSet;
 import android.view.View;
 import android.view.ViewOutlineProvider;
 
+import com.google.auto.value.AutoValue;
+
+import net.squanchy.support.lang.Optional;
+
+import timber.log.Timber;
+
 public class CircleImageView extends ImageViewWithForeground {
 
     private static final CircularOutlineProvider CIRCULAR_OUTLINE_PROVIDER = new CircularOutlineProvider();
+
+    private Optional<Necessaire> necessaireOptional = Optional.absent();
 
     public CircleImageView(Context context, AttributeSet attrs) {
         this(context, attrs, 0);
@@ -62,6 +82,158 @@ public class CircleImageView extends ImageViewWithForeground {
     }
 
     @Override
+    public void setImageBitmap(Bitmap bm) {
+        super.setImageBitmap(bm);
+        updateFor(getDrawable());
+    }
+
+    @Override
+    public void setImageDrawable(Drawable drawable) {
+        super.setImageDrawable(drawable);
+        updateFor(drawable);
+    }
+
+    @Override
+    public void setImageResource(@DrawableRes int resId) {
+        super.setImageResource(resId);
+        updateFor(getDrawable());
+    }
+
+    @Override
+    public void setImageURI(Uri uri) {
+        super.setImageURI(uri);
+        updateFor(getDrawable());
+    }
+
+    private void updateFor(Drawable drawable) {
+        Optional<Bitmap> bitmap = extractBitmapFrom(drawable);
+        necessaireOptional = necessaireFor(bitmap);
+        invalidate();
+    }
+
+    private Optional<Bitmap> extractBitmapFrom(Drawable drawable) {
+        if (drawable == null) {
+            return Optional.absent();
+        } else if (drawable instanceof BitmapDrawable) {
+            BitmapDrawable bitmapDrawable = (BitmapDrawable) drawable;
+            return Optional.of(bitmapDrawable.getBitmap());
+        } else {
+            return tryCreatingBitmapFrom(drawable);
+        }
+    }
+
+    private Optional<Bitmap> tryCreatingBitmapFrom(Drawable drawable) {
+        try {
+            Bitmap bitmap = createBitmapFor(drawable);
+            Canvas canvas = new Canvas(bitmap);
+            drawable.setBounds(0, 0, canvas.getWidth(), canvas.getHeight());
+            drawable.draw(canvas);
+            return Optional.of(bitmap);
+        } catch (Exception e) {
+            Timber.e(e);
+            return Optional.absent();
+        }
+    }
+
+    private Bitmap createBitmapFor(Drawable drawable) {
+        if (drawable instanceof ColorDrawable) {
+            return Bitmap.createBitmap(1, 1, Bitmap.Config.ARGB_8888);
+        } else {
+            return Bitmap.createBitmap(drawable.getIntrinsicWidth(), drawable.getIntrinsicHeight(), Bitmap.Config.ARGB_8888);
+        }
+    }
+
+    private Optional<Necessaire> necessaireFor(Optional<Bitmap> bitmapOptional) {
+        if (isZeroSize()) {
+            return null;
+        }
+
+        return bitmapOptional.map(this::toNecessaireOptional);
+    }
+
+    private boolean isZeroSize() {
+        return getWidth() == 0 || getHeight() == 0;
+    }
+
+    private Necessaire toNecessaireOptional(Bitmap bitmap) {
+        RectF bounds = calculateBounds();
+        Paint paint = createPaintFor(bitmap, bounds);
+
+        float radius = Math.min(bounds.height() / 2.0f, bounds.width() / 2.0f);
+
+        return Necessaire.builder()
+                .bounds(bounds)
+                .paint(paint)
+                .radius(radius)
+                .build();
+    }
+
+    private Paint createPaintFor(Bitmap bitmap, RectF bounds) {
+        Shader shader = new BitmapShader(bitmap, Shader.TileMode.CLAMP, Shader.TileMode.CLAMP);
+        int bitmapWidth = bitmap.getHeight();
+        int bitmapHeight = bitmap.getWidth();
+        updateShaderMatrix(shader, bounds, bitmapWidth, bitmapHeight);
+
+        Paint paint = new Paint();
+        paint.setAntiAlias(true);
+        paint.setShader(shader);
+        return paint;
+    }
+
+    private RectF calculateBounds() {
+        int availableWidth = getWidth() - getPaddingLeft() - getPaddingRight();
+        int availableHeight = getHeight() - getPaddingTop() - getPaddingBottom();
+
+        int sideLength = Math.min(availableWidth, availableHeight);
+
+        float left = getPaddingLeft() + (availableWidth - sideLength) / 2f;
+        float top = getPaddingTop() + (availableHeight - sideLength) / 2f;
+
+        return new RectF(left, top, left + sideLength, top + sideLength);
+    }
+
+    private void updateShaderMatrix(Shader shader, RectF bounds, int bitmapWidth, int bitmapHeight) {
+        float scale;
+        float dx = 0;
+        float dy = 0;
+        Matrix matrix = new Matrix();
+
+        if (bitmapWidth * bounds.height() > bounds.width() * bitmapHeight) {
+            scale = bounds.height() / (float) bitmapHeight;
+            dx = (bounds.width() - bitmapWidth * scale) * 0.5f;
+        } else {
+            scale = bounds.width() / (float) bitmapWidth;
+            dy = (bounds.height() - bitmapHeight * scale) * 0.5f;
+        }
+
+        matrix.setScale(scale, scale);
+        matrix.postTranslate((int) (dx + 0.5f) + bounds.left, (int) (dy + 0.5f) + bounds.top);
+
+        shader.setLocalMatrix(matrix);
+    }
+
+    @Override
+    protected void onDraw(Canvas canvas) {
+        super.onDraw(canvas);
+
+        if (necessaireOptional == null) {
+            // This is needed because on the first init, the super sometimes is causing a draw
+            // to happen even before our static initialisation can set the value to absent.
+            necessaireOptional = Optional.absent();
+        }
+
+        if (necessaireOptional.isPresent()) {
+            Necessaire necessaire = necessaireOptional.get();
+
+            RectF bounds = necessaire.bounds();
+            float radius = necessaire.radius();
+            Paint paint = necessaire.paint();
+
+            canvas.drawCircle(bounds.centerX(), bounds.centerY(), radius, paint);
+        }
+    }
+
+    @Override
     protected final void onSizeChanged(int w, int h, int oldw, int oldh) {
         if (w != h) {
             throw new IllegalArgumentException("The width and height of this view must be identical");
@@ -74,6 +246,32 @@ public class CircleImageView extends ImageViewWithForeground {
         @Override
         public void getOutline(View view, Outline outline) {
             outline.setOval(0, 0, view.getWidth(), view.getHeight());
+        }
+    }
+
+    @AutoValue
+    abstract static class Necessaire {
+
+        static Builder builder() {
+            return new AutoValue_CircleImageView_Necessaire.Builder();
+        }
+
+        abstract RectF bounds();
+
+        abstract float radius();
+
+        abstract Paint paint();
+
+        @AutoValue.Builder
+        abstract static class Builder {
+
+            abstract Builder bounds(RectF bounds);
+
+            abstract Builder radius(float radius);
+
+            abstract Builder paint(Paint paint);
+
+            abstract Necessaire build();
         }
     }
 }

--- a/app/src/main/java/net/squanchy/support/widget/CircleImageView.java
+++ b/app/src/main/java/net/squanchy/support/widget/CircleImageView.java
@@ -34,14 +34,11 @@ public class CircleImageView extends ImageViewWithForeground {
     }
 
     public CircleImageView(Context context, AttributeSet attrs, int defStyleAttr) {
-        this(context, attrs, defStyleAttr, 0);
-    }
-
-    public CircleImageView(Context context, AttributeSet attrs, int defStyleAttr, int defStyleRes) {
-        super(context, attrs, defStyleAttr, defStyleRes);
+        super(context, attrs, defStyleAttr);
 
         super.setOutlineProvider(CIRCULAR_OUTLINE_PROVIDER);
         super.setClipToOutline(true);
+        super.setScaleType(ScaleType.CENTER_CROP);
     }
 
     @Override
@@ -52,6 +49,11 @@ public class CircleImageView extends ImageViewWithForeground {
     @Override
     public final void setClipToOutline(boolean clipToOutline) {
         throw new UnsupportedOperationException("Cannot set clipping to outline on a CircleImageView");
+    }
+
+    @Override
+    public final void setScaleType(ScaleType scaleType) {
+        throw new UnsupportedOperationException("Cannot set scale type on a CircleImageView");
     }
 
     @Override

--- a/app/src/main/java/net/squanchy/support/widget/ImageViewWithForeground.java
+++ b/app/src/main/java/net/squanchy/support/widget/ImageViewWithForeground.java
@@ -27,13 +27,13 @@ import android.graphics.Rect;
 import android.graphics.drawable.Drawable;
 import android.os.Build;
 import android.support.annotation.Nullable;
+import android.support.v7.widget.AppCompatImageView;
 import android.util.AttributeSet;
 import android.view.Gravity;
-import android.widget.ImageView;
 
 import net.squanchy.R;
 
-public class ImageViewWithForeground extends ImageView implements ViewWithForeground {
+public class ImageViewWithForeground extends AppCompatImageView implements ViewWithForeground {
 
     @Nullable
     private Drawable foregroundDrawable;
@@ -51,25 +51,21 @@ public class ImageViewWithForeground extends ImageView implements ViewWithForegr
     }
 
     public ImageViewWithForeground(Context context, AttributeSet attrs, int defStyleAttr) {
-        this(context, attrs, defStyleAttr, 0);
-    }
+        super(context, attrs, defStyleAttr);
 
-    public ImageViewWithForeground(Context context, AttributeSet attrs, int defStyleAttr, int defStyleRes) {
-        super(context, attrs, defStyleAttr, defStyleRes);
-
-        TypedArray a = context.obtainStyledAttributes(attrs, R.styleable.ForegroundLinearLayout,
+        TypedArray a = context.obtainStyledAttributes(attrs, R.styleable.ImageViewWithForeground,
                 defStyleAttr, 0);
 
         foregroundGravity = a.getInt(
-                R.styleable.CircleImageView_android_foregroundGravity, foregroundGravity);
+                R.styleable.ImageViewWithForeground_android_foregroundGravity, foregroundGravity);
 
-        final Drawable d = a.getDrawable(R.styleable.CircleImageView_android_foreground);
+        final Drawable d = a.getDrawable(R.styleable.ImageViewWithForeground_android_foreground);
         if (d != null) {
             setForeground(d);
         }
 
         foregroundInPadding = a.getBoolean(
-                R.styleable.CircleImageView_android_foregroundInsidePadding, true);
+                R.styleable.ImageViewWithForeground_android_foregroundInsidePadding, true);
 
         a.recycle();
     }

--- a/app/src/main/java/net/squanchy/support/widget/SpeakerView.java
+++ b/app/src/main/java/net/squanchy/support/widget/SpeakerView.java
@@ -20,6 +20,7 @@ import net.squanchy.R;
 import net.squanchy.imageloader.ImageLoader;
 import net.squanchy.imageloader.ImageLoaderInjector;
 import net.squanchy.speaker.domain.view.Speaker;
+import net.squanchy.support.lang.Optional;
 
 import static net.squanchy.support.ContextUnwrapper.unwrapToActivityContext;
 import static net.squanchy.support.lang.Lists.map;
@@ -67,7 +68,7 @@ public abstract class SpeakerView extends LinearLayout {
         speakerNameView = (TextView) findViewById(R.id.speaker_name);
     }
 
-    public void updateWith(List<Speaker> speakers, OnSpeakerClickListener listener) {
+    public void updateWith(List<Speaker> speakers, Optional<OnSpeakerClickListener> listener) {
         speakerNameView.setText(toCommaSeparatedNames(speakers));
         updateSpeakerPhotos(speakers, listener);
     }
@@ -76,7 +77,7 @@ public abstract class SpeakerView extends LinearLayout {
         return TextUtils.join(", ", map(speakers, Speaker::name));
     }
 
-    private void updateSpeakerPhotos(List<Speaker> speakers, OnSpeakerClickListener listener) {
+    private void updateSpeakerPhotos(List<Speaker> speakers, Optional<OnSpeakerClickListener> listener) {
         if (imageLoader == null) {
             throw new IllegalStateException("Unable to access the ImageLoader, it hasn't been initialized yet");
         }
@@ -93,9 +94,19 @@ public abstract class SpeakerView extends LinearLayout {
             if (speaker.photoUrl().isPresent()) {
                 ImageView photoView = recycleOrInflatePhotoView(photoViews);
                 speakerPhotoContainer.addView(photoView);
-                photoView.setOnClickListener(v -> listener.onSpeakerClicked(speaker));
+                setClickListenerOrNotClickable(photoView, listener, speaker);
                 loadSpeakerPhoto(photoView, speaker.photoUrl().get(), imageLoader);
             }
+        }
+    }
+
+    private void setClickListenerOrNotClickable(ImageView photoView, Optional<OnSpeakerClickListener> listener, Speaker speaker) {
+        if (listener.isPresent()) {
+            photoView.setOnClickListener(v -> listener.get().onSpeakerClicked(speaker));
+            photoView.setClickable(true);
+        } else {
+            photoView.setOnClickListener(null);
+            photoView.setClickable(false);
         }
     }
 

--- a/app/src/main/java/net/squanchy/support/widget/SpeakerView.java
+++ b/app/src/main/java/net/squanchy/support/widget/SpeakerView.java
@@ -90,9 +90,9 @@ public abstract class SpeakerView extends LinearLayout {
         }
 
         for (Speaker speaker : speakers) {
-            ImageView photoView = recycleOrInflatePhotoView(photoViews);
-            speakerPhotoContainer.addView(photoView);
             if (speaker.photoUrl().isPresent()) {
+                ImageView photoView = recycleOrInflatePhotoView(photoViews);
+                speakerPhotoContainer.addView(photoView);
                 photoView.setOnClickListener(v -> listener.onSpeakerClicked(speaker));
                 loadSpeakerPhoto(photoView, speaker.photoUrl().get(), imageLoader);
             }
@@ -110,7 +110,9 @@ public abstract class SpeakerView extends LinearLayout {
     protected abstract ImageView inflatePhotoView(ViewGroup speakerPhotoContainer);
 
     private void loadSpeakerPhoto(ImageView photoView, String photoUrl, ImageLoader imageLoader) {
-        imageLoader.load(photoUrl).into(photoView);
+        photoView.setImageDrawable(null);
+        imageLoader.load(photoUrl)
+                .into(photoView);
     }
 
     private List<ImageView> getAllImageViewsContainedIn(ViewGroup container) {

--- a/app/src/main/res/values/attrs.xml
+++ b/app/src/main/res/values/attrs.xml
@@ -27,7 +27,7 @@
     <item name="cardInsetBottom">@dimen/card_inset_bottom</item>
   </style>
 
-  <declare-styleable name="CircleImageView">
+  <declare-styleable name="ImageViewWithForeground">
     <attr name="android:foreground" />
     <attr name="android:foregroundInsidePadding" />
     <attr name="android:foregroundGravity" />


### PR DESCRIPTION
Our initial implementation for the `CircleImageView` was to only use the `Outline` to do the clipping. That is clever and I'm still patting myself on the back for thinking of it. BUT. As usual we cannot have nice things, so _sometimes_ (more often than I'd like, too often to ignore) those circles actually were missing their circular clipping. Now, since that's a thing the OS does, we cannot fix it on our side.

So, the approach now is a "best of both worlds" where we still use the outline (which allows us to, for example, have an elevation if we wanted to), plus the battle-tested `drawCircle` approach. The latter is basically preventing the drawable from being drawn outside the circle. I have adopted a smart trick from [hdodenhof's CircleImageView](https://github.com/hdodenhof/CircleImageView) to allow having solid colours and arbitrary drawables in there, besides bitmaps. It's a hacky thing in a sense, but it's not too bad and it only affects the cases where we don't have a bitmap.

Bonus fix: the speaker images in the cards were being set a click listener which made them clickable; now that logic has been improved to avoid doing it so that the images are not clickable if they're not supposed to be.