### PR TITLE
SQ-184/BottomNavigationView-Theme-Fix

### DIFF
--- a/app/src/main/java/net/squanchy/home/HomeActivity.java
+++ b/app/src/main/java/net/squanchy/home/HomeActivity.java
@@ -131,7 +131,6 @@ public class HomeActivity extends TypefaceStyleableActivity {
     @Override
     protected void onStart() {
         super.onStart();
-        selectInitialPage(currentSection);
 
         remoteConfig.proximityServicesEnabled()
                 .observeOn(AndroidSchedulers.mainThread())
@@ -187,13 +186,11 @@ public class HomeActivity extends TypefaceStyleableActivity {
                 grantResults[0] == PackageManager.PERMISSION_GRANTED;
     }
 
-    //TODO fix it properly
     @Override
     protected void onResume() {
         super.onResume();
 
-        Resources.Theme theme = getThemeFor(currentSection);
-        bottomNavigationView.setBackgroundColor(getColorFromTheme(theme, android.support.design.R.attr.colorPrimary));
+        selectInitialPage(currentSection);
     }
 
     private void handleProximityEvent(ProximityEvent proximityEvent) {


### PR DESCRIPTION
For some reason there's a significant lag between the activity pause and stop: stop is not called when the activity the new Google Maps activity is launched but few seconds after. This causes the `BottomNavigationView` 's theme not to be restored. To fix it we just call `selectInitialPage` in the `onResume` instead of `onStart`. By doing so we avoid to set the background color to the `BottomNavigationView` twice when `onStart` does get called. 

This will work perfectly fine for our MVP, but I'd keep the issue opened #184 and further investigate it at a later time