### PR TITLE
SQ-60/Location icon update

### DIFF
--- a/app/src/main/java/net/squanchy/navigation/Navigator.java
+++ b/app/src/main/java/net/squanchy/navigation/Navigator.java
@@ -28,6 +28,7 @@ import static android.content.Intent.FLAG_ACTIVITY_SINGLE_TOP;
 public class Navigator {
 
     private static final int NO_FLAGS = 0;
+    
     private final Activity activity;
     private final DebugActivityIntentFactory debugActivityIntentFactory;
 

--- a/app/src/main/java/net/squanchy/navigation/Navigator.java
+++ b/app/src/main/java/net/squanchy/navigation/Navigator.java
@@ -161,7 +161,7 @@ public class Navigator {
 
     public void toSignInForResult(int requestCode) {
         Intent intent = new Intent(activity, SignInActivity.class);
-        activity.startActivityForResult(intent, requestCode);
+        startForResult(intent, requestCode);
     }
 
     public void toOnboardingForResult(OnboardingPage page, int requestCode) {

--- a/app/src/main/res/drawable/location_primary.xml
+++ b/app/src/main/res/drawable/location_primary.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+  android:width="98dp"
+  android:height="140dp"
+  android:viewportWidth="98"
+  android:viewportHeight="140">
+
+  <path
+    android:fillColor="?colorPrimary"
+    android:pathData="M49 0C21.91 0 0 21.91 0 49c0 36.75 49 91 49 91s49-54.25 49-91C98 21.91 76.09 0 49 0zm0 66.5c-9.66 0-17.5-7.84-17.5-17.5S39.34 31.5 49 31.5 66.5 39.34 66.5 49 58.66 66.5 49 66.5z" />
+</vector>

--- a/app/src/main/res/layout/activity_location_onboarding.xml
+++ b/app/src/main/res/layout/activity_location_onboarding.xml
@@ -26,7 +26,7 @@
     android:layout_marginTop="@dimen/onboarding_logo_margin_top"
     android:layout_marginEnd="@dimen/onboarding_content_margin_horizontal"
     android:contentDescription="@null"
-    app:srcCompat="@drawable/google_primary" />
+    app:srcCompat="@drawable/location_primary" />
 
   <TextView
     style="@style/Onboarding.Title"


### PR DESCRIPTION
This adds the correct icon for the location onboarding:

 Before | After
 --- | ---
 ![location_onboarding](https://cloud.githubusercontent.com/assets/153802/24528495/a18a109a-159e-11e7-8463-d582529c1f76.png) | ![location_onboarding_icon](https://cloud.githubusercontent.com/assets/153802/24528503/a641ebf8-159e-11e7-9f11-ad0585f48843.png)

TODO:
 * ~Use correct logo~
 * Add check for location services being enabled as step 2 of the opt-in procedure _(next PR)_
 * Extract permissions/BT logic to a collaborator we can use elsewhere (e.g., `HomeActivity`) to check and re-request permissions/BT as needed _(next PR)_
 * Create `ProximityFeature` that enables the proximity stuff (including the onboarding!) IIF:
    * The device has a Bluetooth radio
    * The device can request location updates (is there a way to check this? not sure)
    * The remoteconfig says we can enable it
    * The user has opted in to the location services during the onboarding or from the settings