### PR TITLE
SQ-218/update-tweet-design

### DIFF
--- a/app/src/main/java/net/squanchy/tweets/TweetsPageView.java
+++ b/app/src/main/java/net/squanchy/tweets/TweetsPageView.java
@@ -83,7 +83,6 @@ public class TweetsPageView extends LinearLayout implements Loadable {
 
     private void setupToolbar() {
         Toolbar toolbar = (Toolbar) findViewById(R.id.toolbar);
-        toolbar.setTitle(R.string.activity_favorites);
         toolbar.inflateMenu(R.menu.homepage);
         toolbar.setOnMenuItemClickListener(item -> {
             switch (item.getItemId()) {

--- a/app/src/main/java/net/squanchy/tweets/domain/view/Tweet.java
+++ b/app/src/main/java/net/squanchy/tweets/domain/view/Tweet.java
@@ -11,6 +11,8 @@ public abstract class Tweet {
 
     public abstract String text();
 
+    public abstract User user();
+
     public abstract String createdAt();
 
     public abstract List<HashtagEntity> hashtags();
@@ -29,6 +31,8 @@ public abstract class Tweet {
         public abstract Builder id(long id);
 
         public abstract Builder text(String text);
+
+        public abstract Builder user(User user);
 
         public abstract Builder createdAt(String createdAt);
 

--- a/app/src/main/java/net/squanchy/tweets/domain/view/User.java
+++ b/app/src/main/java/net/squanchy/tweets/domain/view/User.java
@@ -1,0 +1,17 @@
+package net.squanchy.tweets.domain.view;
+
+import com.google.auto.value.AutoValue;
+
+@AutoValue
+public abstract class User {
+
+    public static User create(String name, String screenName, String photoUrl) {
+        return new AutoValue_User(name, screenName, photoUrl);
+    }
+
+    public abstract String name();
+
+    public abstract String screenName();
+
+    public abstract String photoUrl();
+}

--- a/app/src/main/java/net/squanchy/tweets/service/TwitterService.java
+++ b/app/src/main/java/net/squanchy/tweets/service/TwitterService.java
@@ -6,6 +6,7 @@ import net.squanchy.tweets.domain.view.HashtagEntity;
 import net.squanchy.tweets.domain.view.MentionEntity;
 import net.squanchy.tweets.domain.view.Tweet;
 import net.squanchy.tweets.domain.view.UrlEntity;
+import net.squanchy.tweets.domain.view.User;
 
 import io.reactivex.Observable;
 
@@ -32,6 +33,7 @@ public class TwitterService {
                 .id(tweet.id)
                 .text(tweet.text)
                 .createdAt(tweet.createdAt)
+                .user(User.create(tweet.user.name, tweet.user.screenName, tweet.user.profileImageUrl))
                 .hashtags(parseHashtags(tweet.entities.hashtags))
                 .mentions(parseMentions(tweet.entities.userMentions))
                 .urls(parseUrls(tweet.entities.urls))

--- a/app/src/main/java/net/squanchy/tweets/util/TwitterDateFormatter.java
+++ b/app/src/main/java/net/squanchy/tweets/util/TwitterDateFormatter.java
@@ -16,11 +16,22 @@ public class TwitterDateFormatter {
 
     // Sat Mar 14 02:34:20 +0000 2009
     private static final String DATE_PATTERN = "EEE MMM dd HH:mm:ss Z yyyy";
+    private static final String AT = "@";
+    private static final String SPACED_EM_DASH = " — ";
 
     private TwitterDateFormatter() {
     }
 
-    public static String getTimestampFrom(Tweet tweet, Context context) {
+    public static String recapFrom(Tweet tweet, Context context){
+        return new StringBuilder()
+                .append(AT)
+                .append(tweet.user().screenName())
+                .append(SPACED_EM_DASH)
+                .append(timestampFrom(tweet, context))
+                .toString();
+    }
+
+    private static String timestampFrom(Tweet tweet, Context context) {
 
         DateTime dateTime = DateTimeFormat.forPattern(DATE_PATTERN).withLocale(Locale.US).parseDateTime(tweet.createdAt());
         String time = DateTimeFormat.shortTime().print(dateTime);

--- a/app/src/main/java/net/squanchy/tweets/util/TwitterDateFormatter.java
+++ b/app/src/main/java/net/squanchy/tweets/util/TwitterDateFormatter.java
@@ -17,7 +17,7 @@ public class TwitterDateFormatter {
     // Sat Mar 14 02:34:20 +0000 2009
     private static final String DATE_PATTERN = "EEE MMM dd HH:mm:ss Z yyyy";
     private static final String AT = "@";
-    private static final String SPACED_EM_DASH = " — ";
+    private static final String EM_DASH = "—";
 
     private TwitterDateFormatter() {
     }
@@ -26,7 +26,7 @@ public class TwitterDateFormatter {
         return new StringBuilder()
                 .append(AT)
                 .append(tweet.user().screenName())
-                .append(SPACED_EM_DASH)
+                .append(EM_DASH)
                 .append(timestampFrom(tweet, context))
                 .toString();
     }

--- a/app/src/main/java/net/squanchy/tweets/util/TwitterFooterFormatter.java
+++ b/app/src/main/java/net/squanchy/tweets/util/TwitterFooterFormatter.java
@@ -12,14 +12,14 @@ import org.joda.time.DateTime;
 import org.joda.time.format.DateTimeFormat;
 import org.joda.time.format.DateTimeFormatter;
 
-public class TwitterDateFormatter {
+public class TwitterFooterFormatter {
 
     // Sat Mar 14 02:34:20 +0000 2009
     private static final String DATE_PATTERN = "EEE MMM dd HH:mm:ss Z yyyy";
     private static final String AT = "@";
     private static final String EM_DASH = "—";
 
-    private TwitterDateFormatter() {
+    private TwitterFooterFormatter() {
     }
 
     public static String recapFrom(Tweet tweet, Context context){

--- a/app/src/main/java/net/squanchy/tweets/view/TweetFooterView.java
+++ b/app/src/main/java/net/squanchy/tweets/view/TweetFooterView.java
@@ -1,0 +1,65 @@
+package net.squanchy.tweets.view;
+
+import android.app.Activity;
+import android.content.Context;
+import android.support.annotation.Nullable;
+import android.util.AttributeSet;
+import android.widget.ImageView;
+import android.widget.LinearLayout;
+import android.widget.TextView;
+
+import net.squanchy.R;
+import net.squanchy.imageloader.ImageLoader;
+import net.squanchy.imageloader.ImageLoaderInjector;
+
+import static net.squanchy.support.ContextUnwrapper.unwrapToActivityContext;
+
+public class TweetFooterView extends LinearLayout {
+
+    private ImageView photoView;
+    private TextView recapView;
+
+    @Nullable
+    private ImageLoader imageLoader;
+
+    public TweetFooterView(Context context, @Nullable AttributeSet attrs) {
+        this(context, attrs, 0);
+    }
+
+    public TweetFooterView(Context context, @Nullable AttributeSet attrs, int defStyleAttr) {
+        this(context, attrs, defStyleAttr, 0);
+    }
+
+    public TweetFooterView(Context context, AttributeSet attrs, int defStyleAttr, int defStyleRes) {
+        super(context, attrs, defStyleAttr, defStyleRes);
+
+        if (!isInEditMode()) {
+            Activity activity = unwrapToActivityContext(context);
+            imageLoader = ImageLoaderInjector.obtain(activity).imageLoader();
+        }
+
+        super.setOrientation(HORIZONTAL);
+    }
+
+    @Override
+    public void setOrientation(int orientation) {
+        throw new UnsupportedOperationException("Changing orientation is not supported for TweetFooterView");
+    }
+
+    @Override
+    protected void onFinishInflate() {
+        super.onFinishInflate();
+
+        photoView = (ImageView) findViewById(R.id.author_photo);
+        recapView = (TextView) findViewById(R.id.recap_footer);
+    }
+
+    public void updateWith(String url, String formattedRecap) {
+        recapView.setText(formattedRecap);
+        if (imageLoader == null) {
+            throw new IllegalStateException("Unable to access the ImageLoader, it hasn't been initialized yet");
+        }
+
+        imageLoader.load(url).into(photoView);
+    }
+}

--- a/app/src/main/java/net/squanchy/tweets/view/TweetItemView.java
+++ b/app/src/main/java/net/squanchy/tweets/view/TweetItemView.java
@@ -36,6 +36,6 @@ public class TweetItemView extends CardLayout {
 
     public void updateWith(Tweet tweet) {
         tweetText.setText(TweetFormatter.format(tweet));
-        tweetFooter.updateWith(tweet.user().photoUrl(), TwitterDateFormatter.getTimestampFrom(tweet, getContext()));
+        tweetFooter.updateWith(tweet.user().photoUrl(), TwitterDateFormatter.recapFrom(tweet, getContext()));
     }
 }

--- a/app/src/main/java/net/squanchy/tweets/view/TweetItemView.java
+++ b/app/src/main/java/net/squanchy/tweets/view/TweetItemView.java
@@ -9,7 +9,7 @@ import net.squanchy.R;
 import net.squanchy.support.widget.CardLayout;
 import net.squanchy.tweets.domain.view.Tweet;
 import net.squanchy.tweets.util.TweetFormatter;
-import net.squanchy.tweets.util.TwitterDateFormatter;
+import net.squanchy.tweets.util.TwitterFooterFormatter;
 
 public class TweetItemView extends CardLayout {
 
@@ -36,6 +36,6 @@ public class TweetItemView extends CardLayout {
 
     public void updateWith(Tweet tweet) {
         tweetText.setText(TweetFormatter.format(tweet));
-        tweetFooter.updateWith(tweet.user().photoUrl(), TwitterDateFormatter.recapFrom(tweet, getContext()));
+        tweetFooter.updateWith(tweet.user().photoUrl(), TwitterFooterFormatter.recapFrom(tweet, getContext()));
     }
 }

--- a/app/src/main/java/net/squanchy/tweets/view/TweetItemView.java
+++ b/app/src/main/java/net/squanchy/tweets/view/TweetItemView.java
@@ -14,7 +14,7 @@ import net.squanchy.tweets.util.TwitterDateFormatter;
 public class TweetItemView extends CardLayout {
 
     private TextView tweetText;
-    private TextView tweetTimestamp;
+    private TweetFooterView tweetFooter;
 
     public TweetItemView(Context context, AttributeSet attrs) {
         this(context, attrs, R.attr.cardViewDefaultStyle);
@@ -29,13 +29,13 @@ public class TweetItemView extends CardLayout {
         super.onFinishInflate();
 
         tweetText = (TextView) findViewById(R.id.tweet_text);
-        tweetTimestamp = (TextView) findViewById(R.id.tweet_timestamp);
+        tweetFooter = (TweetFooterView) findViewById(R.id.tweet_footer);
 
         tweetText.setMovementMethod(LinkMovementMethod.getInstance());
     }
 
     public void updateWith(Tweet tweet) {
         tweetText.setText(TweetFormatter.format(tweet));
-        tweetTimestamp.setText(TwitterDateFormatter.getTimestampFrom(tweet, getContext()));
+        tweetFooter.updateWith(tweet.user().photoUrl(), TwitterDateFormatter.getTimestampFrom(tweet, getContext()));
     }
 }

--- a/app/src/main/res/layout/item_tweet.xml
+++ b/app/src/main/res/layout/item_tweet.xml
@@ -22,12 +22,26 @@
       android:bufferType="spannable"
       tools:text="This is a tweet I wrote to show how it looks" />
 
-    <TextView
-      android:id="@+id/tweet_timestamp"
-      style="@style/Tweet.Card.Timestamp"
+    <net.squanchy.tweets.view.TweetFooterView
+      android:id="@+id/tweet_footer"
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
-      tools:text="Posted last night" />
+      android:paddingTop="8dp"
+      android:layout_gravity="center"
+      android:gravity="center">
+
+      <net.squanchy.support.widget.CircleImageView
+        android:id="@+id/author_photo"
+        android:layout_width="@dimen/twitter_user_photo"
+        android:layout_height="@dimen/twitter_user_photo"
+        android:layout_margin="4dp"/>
+
+      <TextView
+        android:id="@+id/recap_footer"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content" />
+
+    </net.squanchy.tweets.view.TweetFooterView>
 
   </LinearLayout>
 </net.squanchy.tweets.view.TweetItemView>

--- a/app/src/main/res/layout/item_tweet.xml
+++ b/app/src/main/res/layout/item_tweet.xml
@@ -26,18 +26,19 @@
       android:id="@+id/tweet_footer"
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
-      android:paddingTop="8dp"
       android:layout_gravity="center"
+      android:paddingTop="@dimen/twitter_footer_top_padding"
       android:gravity="center">
 
       <net.squanchy.support.widget.CircleImageView
         android:id="@+id/author_photo"
         android:layout_width="@dimen/twitter_user_photo"
         android:layout_height="@dimen/twitter_user_photo"
-        android:layout_margin="4dp"/>
+        android:layout_margin="@dimen/twitter_user_photo_margin" />
 
       <TextView
         android:id="@+id/recap_footer"
+        style="@style/Tweet.Card.Timestamp"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content" />
 

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -110,6 +110,8 @@
   <dimen name="about_opensource_blurb_text">16sp</dimen>
   <dimen name="about_button_margin_bottom">16dp</dimen>
 
+  <dimen name="twitter_user_photo">24dp</dimen>
+
   <dimen name="licenses_library_name_margin_bottom">8dp</dimen>
   <dimen name="licenses_license_label_margin_bottom">16dp</dimen>
   <dimen name="licenses_notice_padding">8dp</dimen>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -111,6 +111,8 @@
   <dimen name="about_button_margin_bottom">16dp</dimen>
 
   <dimen name="twitter_user_photo">24dp</dimen>
+  <dimen name="twitter_user_photo_margin">4dp</dimen>
+  <dimen name="twitter_footer_top_padding">8dp</dimen>
 
   <dimen name="licenses_library_name_margin_bottom">8dp</dimen>
   <dimen name="licenses_license_label_margin_bottom">16dp</dimen>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -34,8 +34,8 @@
   <string name="talks_list_title">Talks</string>
 
   <string name="tweet_date_not_available">Unknown date</string>
-  <string name="tweet_date_recent_format">Posted %1$s at %2$s</string>
-  <string name="tweet_date_normal_format">Posted on %1$s at %2$s</string>
+  <string name="tweet_date_recent_format">%1$s at %2$s</string>
+  <string name="tweet_date_normal_format">%1$s at %2$s</string>
   <string name="tweet_date_today">Today</string>
   <string name="tweet_date_yesterday">Yesterday</string>
 


### PR DESCRIPTION
This PR changes the layout of the timestamp of the tweet, which is now a footer with the circular image of the user, his twitter handle and the timestamp. This PR also fixes the wrong title in the Twitter page

|Before|After|
|-------|-----|
|![before](https://cloud.githubusercontent.com/assets/1331440/24549343/1e8e4370-1619-11e7-9329-681c60deb09b.png)|![after](https://cloud.githubusercontent.com/assets/1331440/24549315/0512364a-1619-11e7-8c5b-66a107f1da52.png)|
