### PR TITLE
SQ-227/Sign-in bottom sheet tablet alignment

### DIFF
--- a/app/src/main/java/net/squanchy/support/widget/MaxSizeFrameLayout.java
+++ b/app/src/main/java/net/squanchy/support/widget/MaxSizeFrameLayout.java
@@ -33,8 +33,13 @@ public class MaxSizeFrameLayout extends FrameLayout {
         super(context, attrs, defStyleAttr, defStyleRes);
 
         TypedArray a = context.obtainStyledAttributes(attrs, R.styleable.MaxSizeFrameLayout, defStyleAttr, defStyleRes);
-        setMaxWidth(a.getDimensionPixelSize(R.styleable.MaxSizeFrameLayout_android_maxWidth, NO_CONSTRAINTS));
-        setMaxHeight(a.getDimensionPixelSize(R.styleable.MaxSizeFrameLayout_android_maxHeight, NO_CONSTRAINTS));
+
+        try {
+            setMaxWidth(a.getDimensionPixelSize(R.styleable.MaxSizeFrameLayout_android_maxWidth, NO_CONSTRAINTS));
+            setMaxHeight(a.getDimensionPixelSize(R.styleable.MaxSizeFrameLayout_android_maxHeight, NO_CONSTRAINTS));
+        } finally {
+            a.recycle();
+        }
     }
 
     @Px

--- a/app/src/main/java/net/squanchy/support/widget/MaxSizeFrameLayout.java
+++ b/app/src/main/java/net/squanchy/support/widget/MaxSizeFrameLayout.java
@@ -1,0 +1,72 @@
+package net.squanchy.support.widget;
+
+import android.content.Context;
+import android.content.res.TypedArray;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.support.annotation.Px;
+import android.util.AttributeSet;
+import android.widget.FrameLayout;
+
+import net.squanchy.R;
+
+public class MaxSizeFrameLayout extends FrameLayout {
+
+    @Px
+    private static final int NO_CONSTRAINTS = Integer.MAX_VALUE;
+
+    @Px
+    private int maxWidth;
+
+    @Px
+    private int maxHeight;
+
+    public MaxSizeFrameLayout(@NonNull Context context, @Nullable AttributeSet attrs) {
+        this(context, attrs, 0);
+    }
+
+    public MaxSizeFrameLayout(@NonNull Context context, @Nullable AttributeSet attrs, int defStyleAttr) {
+        this(context, attrs, defStyleAttr, 0);
+    }
+
+    public MaxSizeFrameLayout(@NonNull Context context, @Nullable AttributeSet attrs, int defStyleAttr, int defStyleRes) {
+        super(context, attrs, defStyleAttr, defStyleRes);
+
+        TypedArray a = context.obtainStyledAttributes(attrs, R.styleable.MaxSizeFrameLayout, defStyleAttr, defStyleRes);
+        setMaxWidth(a.getDimensionPixelSize(R.styleable.MaxSizeFrameLayout_android_maxWidth, NO_CONSTRAINTS));
+        setMaxHeight(a.getDimensionPixelSize(R.styleable.MaxSizeFrameLayout_android_maxHeight, NO_CONSTRAINTS));
+    }
+
+    @Px
+    public int maxWidth() {
+        return maxWidth;
+    }
+
+    public void setMaxWidth(@Px int maxWidth) {
+        this.maxWidth = maxWidth <= 0 ? NO_CONSTRAINTS : maxWidth;
+    }
+
+    @Px
+    public int getMaxHeight() {
+        return maxHeight;
+    }
+
+    public void setMaxHeight(@Px int maxHeight) {
+        this.maxHeight = maxHeight <= 0 ? NO_CONSTRAINTS : maxHeight;
+    }
+
+    @Override
+    protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
+        int constrainedWidthSpec = widthMeasureSpec;
+        int constrainedHeightSpec = heightMeasureSpec;
+
+        if (MeasureSpec.getSize(widthMeasureSpec) > maxWidth) {
+            constrainedWidthSpec = MeasureSpec.makeMeasureSpec(maxWidth, MeasureSpec.EXACTLY);
+        }
+        if (MeasureSpec.getSize(heightMeasureSpec) > maxHeight) {
+            constrainedHeightSpec = MeasureSpec.makeMeasureSpec(maxHeight, MeasureSpec.EXACTLY);
+        }
+
+        super.onMeasure(constrainedWidthSpec, constrainedHeightSpec);
+    }
+}

--- a/app/src/main/res/layout/activity_signin.xml
+++ b/app/src/main/res/layout/activity_signin.xml
@@ -16,6 +16,7 @@
     android:layout_height="wrap_content"
     android:clickable="true"
     android:focusable="true"
+    android:layout_gravity="center_horizontal"
     app:layout_behavior="android.support.design.widget.BottomSheetBehavior"
     tools:layout_width="match_parent">
 

--- a/app/src/main/res/layout/activity_signin.xml
+++ b/app/src/main/res/layout/activity_signin.xml
@@ -9,13 +9,11 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent" />
 
-  <FrameLayout
+  <net.squanchy.support.widget.MaxSizeFrameLayout
     android:id="@+id/bottom_sheet"
     style="@style/SignIn.BottomSheet"
-    android:layout_width="@dimen/sign_in_bottom_sheet_width"
+    android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:clickable="true"
-    android:focusable="true"
     android:layout_gravity="center_horizontal"
     app:layout_behavior="android.support.design.widget.BottomSheetBehavior"
     tools:layout_width="match_parent">
@@ -64,6 +62,6 @@
       android:visibility="gone"
       tools:visibility="visible" />
 
-  </FrameLayout>
+  </net.squanchy.support.widget.MaxSizeFrameLayout>
 
 </android.support.design.widget.CoordinatorLayout>

--- a/app/src/main/res/values-w450dp/dimens.xml
+++ b/app/src/main/res/values-w450dp/dimens.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
-  <dimen name="sign_in_bottom_sheet_width">400dp</dimen>
+  <dimen name="sign_in_bottom_sheet_max_width">450dp</dimen>
 
 </resources>

--- a/app/src/main/res/values/attrs.xml
+++ b/app/src/main/res/values/attrs.xml
@@ -35,4 +35,9 @@
     <attr name="android:foregroundGravity" />
   </declare-styleable>
 
+  <declare-styleable name="MaxSizeFrameLayout">
+    <attr name="android:maxWidth" />
+    <attr name="android:maxHeight" />
+  </declare-styleable>
+
 </resources>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -130,7 +130,7 @@
   <dimen name="licenses_notice_padding">8dp</dimen>
   <dimen name="licenses_notice_text">12sp</dimen>
 
-  <dimen name="sign_in_bottom_sheet_width">-1px</dimen>   <!-- match_parent -->
+  <dimen name="sign_in_bottom_sheet_max_width">400dp</dimen>
   <dimen name="sign_in_bottom_sheet_content_padding">32dp</dimen>
   <dimen name="sign_in_logo_size">64dp</dimen>
   <dimen name="sign_in_logo_margin_bottom">24dp</dimen>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -130,7 +130,7 @@
   <dimen name="licenses_notice_padding">8dp</dimen>
   <dimen name="licenses_notice_text">12sp</dimen>
 
-  <dimen name="sign_in_bottom_sheet_max_width">400dp</dimen>
+  <dimen name="sign_in_bottom_sheet_max_width">0dp</dimen>
   <dimen name="sign_in_bottom_sheet_content_padding">32dp</dimen>
   <dimen name="sign_in_logo_size">64dp</dimen>
   <dimen name="sign_in_logo_margin_bottom">24dp</dimen>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -483,7 +483,11 @@
 
   <style name="Favorite.Empty.Fab" parent="EventDetails.Fab" />
 
-  <style name="SignIn.BottomSheet" parent="Widget.Design.BottomSheet.Modal" />
+  <style name="SignIn.BottomSheet" parent="Widget.Design.BottomSheet.Modal">
+    <item name="android:maxWidth">@dimen/sign_in_bottom_sheet_max_width</item>
+    <item name="android:clickable">true</item>
+    <item name="android:focusable">true</item>
+  </style>
 
   <style name="SignIn.BottomSheet.Label" parent="None">
     <item name="android:gravity">start|center_vertical</item>


### PR DESCRIPTION
This PR fixes the alignment of the bottom sheet on tablets, and uses a new view that enforces a max width of 450dp if the screen width is larger than that (this covers all tablets, and phones in landscape). This fixes #227.

 Phone landscape | Phone portrait
 --- | ---
 ![bottom-sheet-phone-land-after](https://cloud.githubusercontent.com/assets/153802/24591979/daef157e-1805-11e7-9d10-d2e3f8ddf4d8.png) | ![bottom-sheet-phone-port-after](https://cloud.githubusercontent.com/assets/153802/24591980/daf440d0-1805-11e7-9aef-b61f30112280.png)


 Tablet landscape | Tablet portrait
 --- | ---
![bottom-sheet-tablet-land-after](https://cloud.githubusercontent.com/assets/153802/24591981/daf5bd5c-1805-11e7-8bfc-9439fcbd9b7e.png) | ![bottom-sheet-tablet-port-after](https://cloud.githubusercontent.com/assets/153802/24591982/daf8b4b2-1805-11e7-8afb-659636e24a61.png)