### PR TITLE
SQ-57/Update venue info UI

### DIFF
--- a/app/src/main/java/net/squanchy/venue/VenueInfoPageView.java
+++ b/app/src/main/java/net/squanchy/venue/VenueInfoPageView.java
@@ -1,8 +1,12 @@
 package net.squanchy.venue;
 
+import android.annotation.TargetApi;
 import android.app.Activity;
 import android.content.Context;
+import android.os.Build;
 import android.support.v7.widget.Toolbar;
+import android.text.Html;
+import android.text.Spanned;
 import android.util.AttributeSet;
 import android.widget.ImageView;
 import android.widget.LinearLayout;
@@ -100,9 +104,20 @@ public class VenueInfoPageView extends LinearLayout implements Loadable {
     private void updateWith(Venue venue) {
         nameText.setText(venue.name());
         addressText.setText(venue.address());
-        descriptionText.setText(venue.description());
+        descriptionText.setText(parseHtml(venue.description()));
         loadMap(mapView, venue.mapUrl(), imageLoader);
         updateMapClickListenerWith(venue);
+    }
+
+    @TargetApi(Build.VERSION_CODES.N)
+    @SuppressWarnings("deprecation")        // The older fromHtml() is only called pre-24
+    private Spanned parseHtml(String description) {
+        // TODO handle this properly
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+            return Html.fromHtml(description, Html.FROM_HTML_MODE_LEGACY);
+        } else {
+            return Html.fromHtml(description);
+        }
     }
 
     private void loadMap(ImageView imageView, String mapUrl, ImageLoader imageLoader) {

--- a/app/src/main/res/layout/merge_venue_info_layout.xml
+++ b/app/src/main/res/layout/merge_venue_info_layout.xml
@@ -8,40 +8,46 @@
 
   <TextView
     android:id="@+id/venue_name"
-    style="@style/VenueInfo.Name.Text"
+    style="@style/VenueInfo.Name"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
-    android:layout_marginTop="@dimen/venue_info_padding_top" />
+    android:layout_marginStart="@dimen/venue_info_content_padding_horizontal"
+    android:layout_marginTop="@dimen/venue_info_name_margin_top"
+    android:layout_marginEnd="@dimen/venue_info_content_padding_horizontal" />
 
   <TextView
     android:id="@+id/venue_address"
-    style="@style/VenueInfo.Address.Text"
+    style="@style/VenueInfo.Address"
     android:layout_width="wrap_content"
-    android:layout_height="wrap_content" />
-
-  <TextView
-    style="@style/VenueInfo.Label"
-    android:layout_width="match_parent"
-    android:layout_height="@dimen/venue_info_label_height"
-    android:text="@string/venue_about_label" />
-
-  <TextView
-    android:id="@+id/venue_description"
-    style="@style/VenueInfo.Description.Text"
-    android:layout_width="wrap_content"
-    android:layout_height="wrap_content" />
-
-  <TextView
-    style="@style/VenueInfo.Label"
-    android:layout_width="match_parent"
-    android:layout_height="@dimen/venue_info_label_height"
-    android:text="@string/venue_location_label" />
+    android:layout_height="wrap_content"
+    android:layout_marginStart="@dimen/venue_info_content_padding_horizontal"
+    android:layout_marginTop="@dimen/venue_info_address_margin_top"
+    android:layout_marginEnd="@dimen/venue_info_content_padding_horizontal" />
 
   <net.squanchy.support.widget.ImageViewWithForeground
     android:id="@+id/venue_map"
     style="@style/VenueInfo.Description.Map"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
+    android:layout_marginTop="@dimen/venue_info_map_margin_top"
+    android:layout_marginBottom="@dimen/venue_info_map_margin_bottom"
     android:contentDescription="@string/venue_map_content_description" />
+
+  <TextView
+    style="@style/VenueInfo.Label"
+    android:layout_width="match_parent"
+    android:layout_height="@dimen/venue_info_label_height"
+    android:layout_marginStart="@dimen/venue_info_content_padding_horizontal"
+    android:layout_marginEnd="@dimen/venue_info_content_padding_horizontal"
+    android:text="@string/venue_about_label" />
+
+  <TextView
+    android:id="@+id/venue_description"
+    style="@style/VenueInfo.Description.Text"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:layout_marginStart="@dimen/venue_info_content_padding_horizontal"
+    android:layout_marginEnd="@dimen/venue_info_content_padding_horizontal"
+    android:layout_marginBottom="@dimen/venue_info_description_margin_bottom" />
 
 </merge>

--- a/app/src/main/res/layout/merge_venue_info_layout.xml
+++ b/app/src/main/res/layout/merge_venue_info_layout.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
-<merge xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
   xmlns:tools="http://schemas.android.com/tools"
-  tools:layout_width="match_parent"
-  tools:layout_height="match_parent"
-  tools:parentTag="LinearLayout"
-  tools:orientation="vertical">
+  android:layout_width="match_parent"
+  android:layout_height="wrap_content"
+  android:orientation="vertical"
+  tools:showIn="@layout/view_page_venue">
 
   <TextView
     android:id="@+id/venue_name"
@@ -50,4 +50,4 @@
     android:layout_marginEnd="@dimen/venue_info_content_padding_horizontal"
     android:layout_marginBottom="@dimen/venue_info_description_margin_bottom" />
 
-</merge>
+</LinearLayout>

--- a/app/src/main/res/layout/view_page_venue.xml
+++ b/app/src/main/res/layout/view_page_venue.xml
@@ -20,16 +20,17 @@
 
   <ScrollView
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:paddingBottom="@dimen/venue_info_content_padding_bottom"
+    android:clipToPadding="false">
 
-    <LinearLayout
+    <net.squanchy.support.widget.CardLayout
       android:layout_width="match_parent"
-      android:layout_height="wrap_content"
-      android:orientation="vertical">
+      android:layout_height="wrap_content">
 
       <include layout="@layout/merge_venue_info_layout" />
 
-    </LinearLayout>
+    </net.squanchy.support.widget.CardLayout>
 
   </ScrollView>
 

--- a/app/src/main/res/values/color.xml
+++ b/app/src/main/res/values/color.xml
@@ -4,5 +4,8 @@
   <color name="card_background">@color/white</color>
   <color name="licenses_notice_background">#e0e0e0</color>
   <color name="notification_led_color">@color/accent</color>
+  <color name="venue_info_name">#2e676e</color>
+  <color name="venue_info_address">#38828a</color>
+  <color name="venue_info_label">#38828a</color>
 
 </resources>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -89,6 +89,7 @@
   <dimen name="speaker_details_bio_line_spacing_extra">4sp</dimen>
 
   <dimen name="venue_info_content_padding_horizontal">16dp</dimen>
+  <dimen name="venue_info_content_padding_bottom">16dp</dimen>
   <dimen name="venue_info_name_margin_top">16dp</dimen>
   <dimen name="venue_info_name_text">20sp</dimen>
   <dimen name="venue_info_address_margin_top">4dp</dimen>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -88,13 +88,17 @@
   <dimen name="speaker_details_bio_padding">32dp</dimen>
   <dimen name="speaker_details_bio_line_spacing_extra">4sp</dimen>
 
-  <dimen name="venue_info_padding_top">16dp</dimen>
-  <dimen name="venue_info_horizontal_padding">16dp</dimen>
+  <dimen name="venue_info_content_padding_horizontal">16dp</dimen>
+  <dimen name="venue_info_name_margin_top">16dp</dimen>
+  <dimen name="venue_info_name_text">20sp</dimen>
+  <dimen name="venue_info_address_margin_top">4dp</dimen>
+  <dimen name="venue_info_address_line_spacing_extra">4sp</dimen>
+  <dimen name="venue_info_address_text">14sp</dimen>
+  <dimen name="venue_info_map_margin_top">16dp</dimen>
+  <dimen name="venue_info_map_margin_bottom">16dp</dimen>
   <dimen name="venue_info_label_height">56dp</dimen>
   <dimen name="venue_info_label_text">14sp</dimen>
-  <dimen name="venue_info_name_text">20sp</dimen>
-  <dimen name="venue_info_address_text">14sp</dimen>
-  <dimen name="venue_info_address_line_spacing_extra">4sp</dimen>
+  <dimen name="venue_info_description_margin_bottom">16dp</dimen>
   <dimen name="venue_info_description_line_spacing_extra">4sp</dimen>
   <dimen name="venue_info_description_text">14sp</dimen>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -67,7 +67,6 @@
 
   <string name="venue_info_label">Information</string>
   <string name="venue_about_label">About the venue</string>
-  <string name="venue_location_label">Location</string>
   <string name="venue_map_content_description">Map to the venue</string>
 
   <string name="favorites_empty_state_signed_out_blurb">Pick your favorite talks, synced across devices, and get notifications when they’re about to start.</string>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -271,38 +271,33 @@
 
   <style name="VenueInfo.Label" parent="None">
     <item name="android:gravity">start|center_vertical</item>
-    <item name="android:paddingStart">@dimen/venue_info_horizontal_padding</item>
     <item name="android:textAppearance">@style/TextAppearance.Squanchy.VenueInfo.Label</item>
   </style>
 
   <style name="TextAppearance.Squanchy.VenueInfo.Label" parent="None">
-    <item name="android:textColor">?colorPrimary</item>
+    <item name="android:textColor">@color/venue_info_label</item>
     <item name="android:textSize">@dimen/venue_info_label_text</item>
     <item name="fontPath">?titleTypeface</item>
   </style>
 
-  <style name="VenueInfo.Name.Text" parent="None">
-    <item name="android:paddingStart">@dimen/venue_info_horizontal_padding</item>
-    <item name="android:paddingEnd">@dimen/venue_info_horizontal_padding</item>
+  <style name="VenueInfo.Name" parent="None">
     <item name="android:textAppearance">@style/TextAppearance.Squanchy.VenueInfo.Name</item>
   </style>
 
   <style name="TextAppearance.Squanchy.VenueInfo.Name" parent="None">
-    <item name="android:textColor">?android:textColorPrimary</item>
+    <item name="android:textColor">@color/venue_info_name</item>
     <item name="android:textSize">@dimen/venue_info_name_text</item>
     <item name="fontPath">?titleTypeface</item>
   </style>
 
-  <style name="VenueInfo.Address.Text" parent="None">
+  <style name="VenueInfo.Address" parent="None">
     <item name="android:lineSpacingExtra">@dimen/venue_info_address_line_spacing_extra</item>
     <item name="android:lineSpacingMultiplier">1</item>
-    <item name="android:paddingStart">@dimen/venue_info_horizontal_padding</item>
-    <item name="android:paddingEnd">@dimen/venue_info_horizontal_padding</item>
     <item name="android:textAppearance">@style/TextAppearance.Squanchy.VenueInfo.Address</item>
   </style>
 
   <style name="TextAppearance.Squanchy.VenueInfo.Address" parent="None">
-    <item name="android:textColor">?android:textColorSecondary</item>
+    <item name="android:textColor">@color/venue_info_address</item>
     <item name="android:textSize">@dimen/venue_info_address_text</item>
     <item name="fontPath">?defaultMediumTypeface</item>
   </style>
@@ -310,8 +305,6 @@
   <style name="VenueInfo.Description.Text" parent="None">
     <item name="android:lineSpacingExtra">@dimen/venue_info_description_line_spacing_extra</item>
     <item name="android:lineSpacingMultiplier">1</item>
-    <item name="android:paddingStart">@dimen/venue_info_horizontal_padding</item>
-    <item name="android:paddingEnd">@dimen/venue_info_horizontal_padding</item>
     <item name="android:textAppearance">@style/TextAppearance.Squanchy.VenueInfo.Description</item>
   </style>
 


### PR DESCRIPTION
This PR rearranges the content on the venue info page to align with the designs. The venue description now also supports (some) HTML content. This closes #57.

 Before | After
 --- | ---
 ![venue_info_before_top](https://cloud.githubusercontent.com/assets/153802/24592344/7960de4e-180c-11e7-988b-1d383c5907d5.png) | ![venue_info_after_top](https://cloud.githubusercontent.com/assets/153802/24592342/795b325a-180c-11e7-8d8a-1275f929e6d9.png)
 ![venue_info_before_bottom](https://cloud.githubusercontent.com/assets/153802/24592343/795e5b56-180c-11e7-952f-54060b4f1daa.png) | ![venue_info_after_bottom](https://cloud.githubusercontent.com/assets/153802/24592341/795906c4-180c-11e7-842e-028be52e69c1.png)



