### PR TITLE
Add padding to favourites CTA button

### DIFF
--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -47,6 +47,7 @@
   <dimen name="favorites_empty_blurb_margin_bottom">24dp</dimen>
   <dimen name="favorites_empty_blurb_text">16sp</dimen>
   <dimen name="favorites_empty_cta_height">56dp</dimen>
+  <dimen name="favorites_empty_cta_padding_horizontal">24dp</dimen>
 
   <dimen name="search_title_margin">16dp</dimen>
   <dimen name="search_card_item_padding">8dp</dimen>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -476,6 +476,8 @@
 
   <style name="Favorite.Empty.Cta" parent="Button.Colored">
     <item name="android:backgroundTint">?colorPrimary</item>
+    <item name="android:paddingStart">@dimen/favorites_empty_cta_padding_horizontal</item>
+    <item name="android:paddingEnd">@dimen/favorites_empty_cta_padding_horizontal</item>
     <item name="android:textAppearance">@style/TextAppearance.Squanchy.Favorite.Empty.Cta</item>
   </style>
 


### PR DESCRIPTION
Just add some padding to the CTA button 'coz it looks better.

 Before | After
 --- | ---
 ![favotires-before](https://cloud.githubusercontent.com/assets/153802/24598925/de830020-1845-11e7-941b-e6a256268e65.png) | ![favorites-after](https://cloud.githubusercontent.com/assets/153802/24598924/de828578-1845-11e7-9305-77517ecee5f5.png)

