### PR TITLE
Notifications check

### DIFF
--- a/app/src/main/java/net/squanchy/notification/NotificationCreator.java
+++ b/app/src/main/java/net/squanchy/notification/NotificationCreator.java
@@ -22,6 +22,8 @@ import net.squanchy.schedule.domain.view.Event;
 import net.squanchy.schedule.domain.view.Place;
 import net.squanchy.speaker.domain.view.Speaker;
 
+import static net.squanchy.support.lang.Lists.map;
+
 public class NotificationCreator {
 
     private static final String GROUP_KEY_NOTIFY_SESSION = "group_key_notify_session";
@@ -160,7 +162,7 @@ public class NotificationCreator {
     }
 
     private String getSpeakerNamesFrom(List<Speaker> speakers) {
-        String speakerNames = TextUtils.join(SPEAKER_NAMES_SEPARATOR, speakers);
+        String speakerNames = TextUtils.join(", ", map(speakers, Speaker::name));
         return context.getString(R.string.event_notification_starting_by, speakerNames);
     }
 

--- a/app/src/main/java/net/squanchy/notification/NotificationCreator.java
+++ b/app/src/main/java/net/squanchy/notification/NotificationCreator.java
@@ -57,11 +57,15 @@ public class NotificationCreator {
         notificationBuilder
                 .setContentIntent(createPendingIntentForSingleEvent(event.id()))
                 .setContentTitle(event.title())
-                .setContentText(getPlaceName(event))
                 .setColor(getTrackColor(event))
                 .setWhen(event.startTime().toDateTime().getMillis())
                 .setShowWhen(true)
                 .setGroup(GROUP_KEY_NOTIFY_SESSION);
+
+        String placeName = getPlaceName(event);
+        if (!placeName.isEmpty()) {
+            notificationBuilder.setContentText(placeName);
+        }
 
         NotificationCompat.BigTextStyle richNotification = createBigTextRichNotification(notificationBuilder, event);
 
@@ -141,12 +145,13 @@ public class NotificationCreator {
 
     private NotificationCompat.BigTextStyle createBigTextRichNotification(NotificationCompat.Builder notificationBuilder, Event event) {
         StringBuilder bigTextBuilder = new StringBuilder()
-                .append(getSpeakerNamesFrom(event.speakers()))
-                .append('\n');
+                .append(getSpeakerNamesFrom(event.speakers()));
 
         String placeName = getPlaceName(event);
         if (!placeName.isEmpty()) {
-            bigTextBuilder.append(context.getString(R.string.event_notification_starting_in, placeName));
+            bigTextBuilder
+                    .append('\n')
+                    .append(context.getString(R.string.event_notification_starting_in, placeName));
         }
 
         return new NotificationCompat.BigTextStyle(notificationBuilder)


### PR DESCRIPTION
* We were always adding a newline after the talk title and setting a blank content for notifications if place is missing
* We were concatenating Speaker objects, instead of their names

### Screenshots

| Before | After | 
| --- | --- |
| ![device-2017-04-03-101557](https://cloud.githubusercontent.com/assets/3942812/24600999/7d2de8c8-1857-11e7-97ff-428fd53c5c30.png) | ![device-2017-04-03-101828](https://cloud.githubusercontent.com/assets/3942812/24601000/7d2edbde-1857-11e7-9677-04dbb536f0af.png) |
