### PR TITLE
SQ-60/Allow testing contest again and add "can check" to Precondition

### DIFF
--- a/app/src/main/java/net/squanchy/proximity/preconditions/BluetoothPrecondition.java
+++ b/app/src/main/java/net/squanchy/proximity/preconditions/BluetoothPrecondition.java
@@ -27,6 +27,11 @@ class BluetoothPrecondition implements Precondition {
     }
 
     @Override
+    public boolean performsSynchronousSatisfiedCheck() {
+        return CAN_PERFORM_SYNCHRONOUS_CHECK;
+    }
+
+    @Override
     public boolean satisfied() {
         BluetoothAdapter adapter = bluetoothManager.getAdapter();
         return adapter.isEnabled();

--- a/app/src/main/java/net/squanchy/proximity/preconditions/LocationPermissionPrecondition.java
+++ b/app/src/main/java/net/squanchy/proximity/preconditions/LocationPermissionPrecondition.java
@@ -23,7 +23,12 @@ class LocationPermissionPrecondition implements Precondition {
 
     @Override
     public boolean available() {
-        return true;
+        return ALWAYS_AVAILABLE;
+    }
+
+    @Override
+    public boolean performsSynchronousSatisfiedCheck() {
+        return CAN_PERFORM_SYNCHRONOUS_CHECK;
     }
 
     @Override

--- a/app/src/main/java/net/squanchy/proximity/preconditions/LocationProviderPrecondition.java
+++ b/app/src/main/java/net/squanchy/proximity/preconditions/LocationProviderPrecondition.java
@@ -37,7 +37,12 @@ public class LocationProviderPrecondition implements Precondition {
 
     @Override
     public boolean available() {
-        return true;
+        return ALWAYS_AVAILABLE;
+    }
+
+    @Override
+    public boolean performsSynchronousSatisfiedCheck() {
+        return CANNOT_PERFORM_SYNCHRONOUS_CHECK;
     }
 
     @Override

--- a/app/src/main/java/net/squanchy/proximity/preconditions/ModularProximityPreconditions.java
+++ b/app/src/main/java/net/squanchy/proximity/preconditions/ModularProximityPreconditions.java
@@ -89,12 +89,13 @@ public class ModularProximityPreconditions implements ProximityPreconditions {
             return;
         }
 
-        if (precondition.satisfied()) {
+        boolean canCheckIfSatisfied = precondition.performsSynchronousSatisfiedCheck();
+        if (canCheckIfSatisfied && precondition.satisfied()) {
             continueAfterSucceedingCheck(precondition);
         } else {
             precondition.satisfy()
                     .subscribe(() -> {
-                        if (precondition.satisfied()) {
+                        if (canCheckIfSatisfied && precondition.satisfied()) {
                             continueAfterSucceedingCheck(precondition);
                         }
                         // Waiting on some external resource (e.g., onActivityResult) that will

--- a/app/src/main/java/net/squanchy/proximity/preconditions/OptInPrecondition.java
+++ b/app/src/main/java/net/squanchy/proximity/preconditions/OptInPrecondition.java
@@ -8,13 +8,18 @@ public class OptInPrecondition implements Precondition {
 
     private final ProximityOptInPersister preferences_persister;
 
-    public OptInPrecondition(ProximityOptInPersister preferences_persister) {
+    OptInPrecondition(ProximityOptInPersister preferences_persister) {
         this.preferences_persister = preferences_persister;
     }
 
     @Override
     public boolean available() {
-        return true;
+        return ALWAYS_AVAILABLE;
+    }
+
+    @Override
+    public boolean performsSynchronousSatisfiedCheck() {
+        return CAN_PERFORM_SYNCHRONOUS_CHECK;
     }
 
     @Override

--- a/app/src/main/java/net/squanchy/proximity/preconditions/Precondition.java
+++ b/app/src/main/java/net/squanchy/proximity/preconditions/Precondition.java
@@ -15,9 +15,4 @@ interface Precondition {
     Completable satisfy();
 
     Optional<Integer> requestCode();
-
-    enum SatisfactionResult {
-        SUCCESS,
-        RETRY
-    }
 }

--- a/app/src/main/java/net/squanchy/proximity/preconditions/Precondition.java
+++ b/app/src/main/java/net/squanchy/proximity/preconditions/Precondition.java
@@ -6,9 +6,14 @@ import io.reactivex.Completable;
 
 interface Precondition {
 
+    boolean ALWAYS_AVAILABLE = true;
+    boolean CAN_PERFORM_SYNCHRONOUS_CHECK = true;
+    boolean CANNOT_PERFORM_SYNCHRONOUS_CHECK = false;
     boolean ALWAYS_ATTEMPT_SATISFYING = false;
 
     boolean available();
+
+    boolean performsSynchronousSatisfiedCheck();
 
     boolean satisfied();
 

--- a/app/src/main/java/net/squanchy/proximity/preconditions/PreconditionsRegistry.java
+++ b/app/src/main/java/net/squanchy/proximity/preconditions/PreconditionsRegistry.java
@@ -15,7 +15,9 @@ class PreconditionsRegistry {
 
     boolean anyUnsatisfied() {
         for (Precondition precondition : preconditions) {
-            if (!precondition.satisfied()) {
+            boolean canCheck = precondition.performsSynchronousSatisfiedCheck();
+            boolean preconditionNotSatisfied = !precondition.satisfied();
+            if (canCheck && preconditionNotSatisfied) {
                 return true;
             }
         }

--- a/app/src/main/java/net/squanchy/support/debug/DebugPreferences.java
+++ b/app/src/main/java/net/squanchy/support/debug/DebugPreferences.java
@@ -3,10 +3,13 @@ package net.squanchy.support.debug;
 import android.content.Context;
 import android.content.SharedPreferences;
 
+import net.squanchy.BuildConfig;
+
 public class DebugPreferences {
 
     private static final String PREFERENCES_NAME_DEBUG = "debug";
     private static final String KEY_CONTEST_TESTING_ENABLED = "contest.testing_enabled";
+    private static final boolean IS_DEBUG = BuildConfig.DEBUG;
 
     private final SharedPreferences preferences;
 
@@ -15,18 +18,21 @@ public class DebugPreferences {
     }
 
     public boolean contestTestingEnabled() {
-        return preferences.getBoolean(KEY_CONTEST_TESTING_ENABLED, false);
+        return IS_DEBUG && preferences.getBoolean(KEY_CONTEST_TESTING_ENABLED, false);
     }
 
     public void enableContestTesting() {
-        storePreference(KEY_CONTEST_TESTING_ENABLED, true);
+        storeDebugPreference(KEY_CONTEST_TESTING_ENABLED, true);
     }
 
     public void disableContestTesting() {
-        storePreference(KEY_CONTEST_TESTING_ENABLED, false);
+        storeDebugPreference(KEY_CONTEST_TESTING_ENABLED, false);
     }
 
-    private void storePreference(String key, boolean value) {
+    private void storeDebugPreference(String key, boolean value) {
+        if (!IS_DEBUG) {
+            return;
+        }
         preferences.edit()
                 .putBoolean(key, value)
                 .apply();


### PR DESCRIPTION
This PR makes sure the "contest testing" debug setting bypasses the remoteconfig check for the proximity/contest settings, and adds the `performsSynchronousSatisfiedCheck()` method on `Precondition`. This way we can know whether preconditions' `satisfied()` should be taken into account or not.

Yes, this begs for further refactors. Yes, that will eventually happen. Not now.