### PR TITLE
SQ-226/Twitter-SDK-Crash

### DIFF
--- a/app/src/main/java/net/squanchy/tweets/TweetsPageView.java
+++ b/app/src/main/java/net/squanchy/tweets/TweetsPageView.java
@@ -115,7 +115,7 @@ public class TweetsPageView extends LinearLayout implements Loadable {
         swipeLayout.setRefreshing(true);
         refreshingData = true;
         subscription = twitterService.refresh(query)
-                .subscribe(this::onSuccess, this::onError);
+                .subscribe(this::onSuccess, e -> onError());
     }
 
     private void onSuccess(List<TweetViewModel> tweet) {
@@ -123,7 +123,7 @@ public class TweetsPageView extends LinearLayout implements Loadable {
         onRefreshCompleted();
     }
 
-    private void onError(Throwable throwable) {
+    private void onError() {
         Timber.e("Error refreshing the Twitter timeline");
         onRefreshCompleted();
     }

--- a/app/src/main/java/net/squanchy/tweets/TweetsPageView.java
+++ b/app/src/main/java/net/squanchy/tweets/TweetsPageView.java
@@ -124,7 +124,7 @@ public class TweetsPageView extends LinearLayout implements Loadable {
     }
 
     private void onError(Throwable throwable) {
-        Timber.e(throwable, "Error refreshing the Twitter timeline");
+        Timber.e("Error refreshing the Twitter timeline");
         onRefreshCompleted();
     }
 

--- a/app/src/main/java/net/squanchy/tweets/service/TwitterRepository.java
+++ b/app/src/main/java/net/squanchy/tweets/service/TwitterRepository.java
@@ -1,15 +1,16 @@
 package net.squanchy.tweets.service;
 
-import com.twitter.sdk.android.core.Callback;
-import com.twitter.sdk.android.core.Result;
+import android.support.annotation.Nullable;
+
 import com.twitter.sdk.android.core.TwitterCore;
-import com.twitter.sdk.android.core.TwitterException;
 import com.twitter.sdk.android.core.models.Search;
 import com.twitter.sdk.android.core.services.SearchService;
 
 import io.reactivex.Observable;
 import io.reactivex.ObservableEmitter;
 import retrofit2.Call;
+import retrofit2.Callback;
+import retrofit2.Response;
 
 public class TwitterRepository {
 
@@ -26,7 +27,7 @@ public class TwitterRepository {
         return searchService.tweets(query, null, null, null, "recent", MAX_ITEM_PER_REQUEST, null, null, null, true);
     }
 
-    private static class SearchCallback extends Callback<Search> {
+    private static class SearchCallback implements Callback<Search> {
 
         private final ObservableEmitter<Search> searchEmitter;
 
@@ -35,14 +36,18 @@ public class TwitterRepository {
         }
 
         @Override
-        public void success(Result<Search> result) {
-            searchEmitter.onNext(result.data);
-            searchEmitter.onComplete();
+        public void onResponse(Call<Search> call, Response<Search> response) {
+            if (response.isSuccessful()) {
+                searchEmitter.onNext(response.body());
+                searchEmitter.onComplete();
+            } else {
+                onFailure(null, new RuntimeException("Unable to load tweets"));
+            }
         }
 
         @Override
-        public void failure(TwitterException e) {
-            searchEmitter.onError(e);
+        public void onFailure(@Nullable Call<Search> call, Throwable throwable) {
+            searchEmitter.onError(throwable);
         }
     }
 }

--- a/app/src/main/java/net/squanchy/tweets/service/TwitterRepository.java
+++ b/app/src/main/java/net/squanchy/tweets/service/TwitterRepository.java
@@ -7,8 +7,6 @@ import com.twitter.sdk.android.core.TwitterException;
 import com.twitter.sdk.android.core.models.Search;
 import com.twitter.sdk.android.core.services.SearchService;
 
-import java.net.SocketTimeoutException;
-
 import io.reactivex.Observable;
 import io.reactivex.ObservableEmitter;
 import retrofit2.Call;
@@ -24,7 +22,7 @@ public class TwitterRepository {
                 .enqueue(new SearchCallback(e)));
     }
 
-    private Call<Search> createSearchRequest(String query) throws Exception{
+    private Call<Search> createSearchRequest(String query) throws Exception {
         return searchService.tweets(query, null, null, null, "recent", MAX_ITEM_PER_REQUEST, null, null, null, true);
     }
 

--- a/app/src/main/java/net/squanchy/tweets/service/TwitterRepository.java
+++ b/app/src/main/java/net/squanchy/tweets/service/TwitterRepository.java
@@ -1,7 +1,5 @@
 package net.squanchy.tweets.service;
 
-import android.support.annotation.Nullable;
-
 import com.twitter.sdk.android.core.TwitterCore;
 import com.twitter.sdk.android.core.models.Search;
 import com.twitter.sdk.android.core.services.SearchService;
@@ -46,7 +44,7 @@ public class TwitterRepository {
         }
 
         @Override
-        public void onFailure(@Nullable Call<Search> call, Throwable throwable) {
+        public void onFailure(Call<Search> call, Throwable throwable) {
             searchEmitter.onError(throwable);
         }
     }


### PR DESCRIPTION
In order to avoid any crash to Twitter ( #226 ) we regain control by getting rid of another part of the Twitter SDK: their callback. We now implement the `retrofit2.Callback` and manually check if the call was successful. If it was, we emit the tweets list, else an exception.

Also we don't log the throwable in case of refresh failed on Crashlytics anymore, since that's a non-fatal exception and when we reach that point it means we have already handled that