### PR TITLE
SQ-60/Fix tweets layout missing behaviour

### DIFF
--- a/app/src/main/res/layout/view_page_favorites.xml
+++ b/app/src/main/res/layout/view_page_favorites.xml
@@ -86,6 +86,7 @@
       android:id="@+id/favorites_list"
       android:layout_width="match_parent"
       android:layout_height="match_parent" />
+
   </FrameLayout>
 
 </net.squanchy.favorites.FavoritesPageView>

--- a/app/src/main/res/layout/view_page_tweets.xml
+++ b/app/src/main/res/layout/view_page_tweets.xml
@@ -23,7 +23,8 @@
 
   <FrameLayout
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    app:layout_behavior="@string/appbar_scrolling_view_behavior">
 
     <TextView
       android:id="@+id/empty_view"


### PR DESCRIPTION
This fixes the top padding missing on 

 Before | After
 --- | ---
 ![tweets-before](https://cloud.githubusercontent.com/assets/153802/24677277/28ffd298-197e-11e7-8f3e-8749cb48a080.png) | ![tweets-after](https://cloud.githubusercontent.com/assets/153802/24677278/2901e894-197e-11e7-9052-d44ad9e89f50.png)

