### PR TITLE
SQ-269/remove photo url left in the tweet text

### DIFF
--- a/app/src/main/java/net/squanchy/tweets/service/TweetModelConverter.java
+++ b/app/src/main/java/net/squanchy/tweets/service/TweetModelConverter.java
@@ -123,12 +123,13 @@ public class TweetModelConverter {
     }
 
     private String removeLastPhotoUrl(String content, List<String> photoUrls) {
-        if (photoUrls.isEmpty()){
+        if (photoUrls.isEmpty()) {
             return content;
         }
         String lastUrl = photoUrls.get(photoUrls.size() - 1);
         if (content.endsWith(lastUrl)) {
-            content = content.replace(lastUrl, "");
+            content = content.replace(lastUrl, "")
+                    .trim();
         }
         return content;
     }

--- a/app/src/main/java/net/squanchy/tweets/service/TweetModelConverter.java
+++ b/app/src/main/java/net/squanchy/tweets/service/TweetModelConverter.java
@@ -118,19 +118,19 @@ public class TweetModelConverter {
         Integer beginIndex = displayTextRange.start();
         Integer endIndex = displayTextRange.end();
         String displayableText = tweet.text.substring(beginIndex, endIndex);
-        return removePhotoUrl(displayableText, photoUrls);
+        if (photoUrls != null) {
+            displayableText = removePhotoUrl(displayableText, photoUrls);
+        }
+        return displayableText;
     }
 
-    private String removePhotoUrl(String text, List<MediaEntity> photoUrls) {
-        if (photoUrls == null) {
-            return text;
-        }
+    private String removePhotoUrl(String content, List<MediaEntity> photoUrls) {
         for (MediaEntity url : photoUrls) {
-            if (text.contains(url.url)) {
-                text = text.replace(url.url, "");
+            if (content.contains(url.url)) {
+                content = content.replace(url.url, "");
             }
         }
-        return text;
+        return content;
     }
 
     private Optional<String> photoUrlMaybeFrom(List<String> urls) {

--- a/app/src/main/java/net/squanchy/tweets/service/TweetModelConverter.java
+++ b/app/src/main/java/net/squanchy/tweets/service/TweetModelConverter.java
@@ -35,7 +35,7 @@ public class TweetModelConverter {
         List<MentionEntity> mentions = adjustMentions(onlyMentionsInRange(tweet.entities.userMentions, displayTextRange), emojiIndices);
         List<UrlEntity> urls = adjustUrls(onlyUrlsInRange(tweet.entities.urls, displayTextRange), emojiIndices);
         List<String> photoUrls = onlyPhotoUrls(tweet.entities.media);
-        String displayableText = displayableTextFor(tweet, displayTextRange);
+        String displayableText = displayableTextFor(tweet, displayTextRange, tweet.entities.media);
 
         return TweetViewModel.builder()
                 .id(tweet.id)
@@ -56,12 +56,6 @@ public class TweetModelConverter {
             }
         }
         return emojiIndices;
-    }
-
-    private String displayableTextFor(Tweet tweet, Range displayTextRange) {
-        Integer beginIndex = displayTextRange.start();
-        Integer endIndex = displayTextRange.end();
-        return tweet.text.substring(beginIndex, endIndex);
     }
 
     private List<HashtagEntity> onlyHashtagsInRange(List<HashtagEntity> entities, Range displayTextRange) {
@@ -118,6 +112,25 @@ public class TweetModelConverter {
     private List<String> onlyPhotoUrls(List<MediaEntity> media) {
         List<MediaEntity> photos = Lists.filter(media, mediaEntity -> MEDIA_TYPE_PHOTO.equals(mediaEntity.type));
         return Lists.map(photos, mediaEntity -> mediaEntity.mediaUrlHttps);
+    }
+
+    private String displayableTextFor(Tweet tweet, Range displayTextRange, List<MediaEntity> photoUrls) {
+        Integer beginIndex = displayTextRange.start();
+        Integer endIndex = displayTextRange.end();
+        String displayableText = tweet.text.substring(beginIndex, endIndex);
+        return removePhotoUrl(displayableText, photoUrls);
+    }
+
+    private String removePhotoUrl(String text, List<MediaEntity> photoUrls) {
+        if (photoUrls == null) {
+            return text;
+        }
+        for (MediaEntity url : photoUrls) {
+            if (text.contains(url.url)) {
+                text = text.replace(url.url, "");
+            }
+        }
+        return text;
     }
 
     private Optional<String> photoUrlMaybeFrom(List<String> urls) {


### PR DESCRIPTION
 Before | After
 --- | ---
 ![tweet-before](https://cloud.githubusercontent.com/assets/1331440/24701326/4db0407e-19fa-11e7-9c13-459785b63a3f.png) | ![tweet-after](https://cloud.githubusercontent.com/assets/1331440/24701341/5cb435b2-19fa-11e7-99b0-95ed5beea551.png)



This PR removes some Photo URLs left in the Tweet text even if they shouldn't be part of it