### PR TITLE
SQ-217/make search great again

### DIFF
--- a/app/src/main/java/net/squanchy/search/engines/EventSearchEngine.java
+++ b/app/src/main/java/net/squanchy/search/engines/EventSearchEngine.java
@@ -5,6 +5,14 @@ import net.squanchy.schedule.domain.view.Event;
 class EventSearchEngine implements SearchEngine<Event> {
 
     private static final int MIN_QUERY_LENGTH = 2;
+    private final Query queryEngine;
+
+    EventSearchEngine() {
+        queryEngine = new QueryEngine.Builder()
+                .withQuery(new TitleQuery())
+                .withQuery(new TextQuery())
+                .build();
+    }
 
     @Override
     public boolean matches(Event event, String query) {
@@ -22,9 +30,7 @@ class EventSearchEngine implements SearchEngine<Event> {
     }
 
     private boolean matchesQuery(Event event, String query) {
-        String normalizedQuery = StringNormalizer.normalize(query);
-        String normalizedTitle = StringNormalizer.normalize(event.title());
 
-        return normalizedTitle.contains(normalizedQuery);
+        return queryEngine.matches(event, query);
     }
 }

--- a/app/src/main/java/net/squanchy/search/engines/Query.java
+++ b/app/src/main/java/net/squanchy/search/engines/Query.java
@@ -1,0 +1,8 @@
+package net.squanchy.search.engines;
+
+import net.squanchy.schedule.domain.view.Event;
+
+interface Query {
+
+    boolean matches(Event event, String query);
+}

--- a/app/src/main/java/net/squanchy/search/engines/QueryEngine.java
+++ b/app/src/main/java/net/squanchy/search/engines/QueryEngine.java
@@ -1,0 +1,18 @@
+package net.squanchy.search.engines;
+
+import java.util.List;
+
+import net.squanchy.schedule.domain.view.Event;
+
+public class QueryEngine implements Query{
+    private final List<Query> queries;
+
+    public QueryEngine(List<Query> queries) {
+        this.queries = queries;
+    }
+
+    @Override
+    public boolean matches(Event event, String query) {
+        return false;
+    }
+}

--- a/app/src/main/java/net/squanchy/search/engines/QueryEngine.java
+++ b/app/src/main/java/net/squanchy/search/engines/QueryEngine.java
@@ -1,18 +1,38 @@
 package net.squanchy.search.engines;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import net.squanchy.schedule.domain.view.Event;
+import net.squanchy.support.lang.Lists;
+import net.squanchy.support.lang.Predicate;
 
-public class QueryEngine implements Query{
+class QueryEngine implements Query {
+
     private final List<Query> queries;
 
-    public QueryEngine(List<Query> queries) {
+    private QueryEngine(List<Query> queries) {
         this.queries = queries;
     }
 
     @Override
-    public boolean matches(Event event, String query) {
-        return false;
+    public boolean matches(Event event, String queryParameter) {
+        return Lists.any(queries, query -> query.matches(event, queryParameter));
+    }
+
+    public static class Builder {
+
+        private final List<Query> queries = new ArrayList<>();
+
+        Builder withQuery(Query query) {
+            if (!queries.contains(query)) {
+                queries.add(query);
+            }
+            return this;
+        }
+
+        public QueryEngine build() {
+            return new QueryEngine(queries);
+        }
     }
 }

--- a/app/src/main/java/net/squanchy/search/engines/SearchEngine.java
+++ b/app/src/main/java/net/squanchy/search/engines/SearchEngine.java
@@ -1,6 +1,6 @@
 package net.squanchy.search.engines;
 
-interface SearchEngine<T> {
+public interface SearchEngine<T> {
 
     boolean matches(T element, String query);
 }

--- a/app/src/main/java/net/squanchy/search/engines/SearchEngine.java
+++ b/app/src/main/java/net/squanchy/search/engines/SearchEngine.java
@@ -1,6 +1,6 @@
 package net.squanchy.search.engines;
 
-public interface SearchEngine<T> {
+interface SearchEngine<T> {
 
     boolean matches(T element, String query);
 }

--- a/app/src/main/java/net/squanchy/search/engines/TextQuery.java
+++ b/app/src/main/java/net/squanchy/search/engines/TextQuery.java
@@ -1,5 +1,7 @@
 package net.squanchy.search.engines;
 
+import java.util.Arrays;
+
 import net.squanchy.schedule.domain.view.Event;
 import net.squanchy.support.lang.Lists;
 
@@ -14,6 +16,6 @@ class TextQuery implements Query {
         String[] normalizedQueries = StringNormalizer.normalize(query).split("\\s");
         String normalizedText = StringNormalizer.normalize(event.description().get());
 
-        return Lists.all(normalizedQueries, normalizedText::contains);
+        return Lists.all(Arrays.asList(normalizedQueries), normalizedText::contains);
     }
 }

--- a/app/src/main/java/net/squanchy/search/engines/TextQuery.java
+++ b/app/src/main/java/net/squanchy/search/engines/TextQuery.java
@@ -14,6 +14,6 @@ class TextQuery implements Query{
         String[] normalizedQueries = StringNormalizer.normalize(query).split("\\s");
         String normalizedText = StringNormalizer.normalize(event.description().get());
 
-        return Lists.any(normalizedQueries, normalizedText::contains);
+        return Lists.all(normalizedQueries, normalizedText::contains);
     }
 }

--- a/app/src/main/java/net/squanchy/search/engines/TextQuery.java
+++ b/app/src/main/java/net/squanchy/search/engines/TextQuery.java
@@ -3,7 +3,7 @@ package net.squanchy.search.engines;
 import net.squanchy.schedule.domain.view.Event;
 import net.squanchy.support.lang.Lists;
 
-class TextQuery implements Query{
+class TextQuery implements Query {
 
     @Override
     public boolean matches(Event event, String query) {

--- a/app/src/main/java/net/squanchy/search/engines/TextQuery.java
+++ b/app/src/main/java/net/squanchy/search/engines/TextQuery.java
@@ -1,0 +1,19 @@
+package net.squanchy.search.engines;
+
+import net.squanchy.schedule.domain.view.Event;
+import net.squanchy.support.lang.Lists;
+
+class TextQuery implements Query{
+
+    @Override
+    public boolean matches(Event event, String query) {
+        if (!event.description().isPresent()) {
+            return false;
+        }
+
+        String[] normalizedQueries = StringNormalizer.normalize(query).split("\\s");
+        String normalizedText = StringNormalizer.normalize(event.description().get());
+
+        return Lists.any(normalizedQueries, normalizedText::contains);
+    }
+}

--- a/app/src/main/java/net/squanchy/search/engines/TitleQuery.java
+++ b/app/src/main/java/net/squanchy/search/engines/TitleQuery.java
@@ -2,7 +2,7 @@ package net.squanchy.search.engines;
 
 import net.squanchy.schedule.domain.view.Event;
 
-public class TitleQuery implements Query {
+class TitleQuery implements Query {
 
     @Override
     public boolean matches(Event event, String query) {

--- a/app/src/main/java/net/squanchy/search/engines/TitleQuery.java
+++ b/app/src/main/java/net/squanchy/search/engines/TitleQuery.java
@@ -1,0 +1,14 @@
+package net.squanchy.search.engines;
+
+import net.squanchy.schedule.domain.view.Event;
+
+public class TitleQuery implements Query {
+
+    @Override
+    public boolean matches(Event event, String query) {
+        String normalizedQuery = StringNormalizer.normalize(query);
+        String normalizedTitle = StringNormalizer.normalize(event.title());
+
+        return normalizedTitle.contains(normalizedQuery);
+    }
+}

--- a/app/src/main/java/net/squanchy/support/lang/Lists.java
+++ b/app/src/main/java/net/squanchy/support/lang/Lists.java
@@ -67,4 +67,14 @@ public final class Lists {
 
         return false;
     }
+
+    public static <T> boolean all(T[] array, Predicate<T> predicate) {
+        for (T t : array){
+            if (!predicate.call(t)){
+                return false;
+            }
+        }
+
+        return true;
+    }
 }

--- a/app/src/main/java/net/squanchy/support/lang/Lists.java
+++ b/app/src/main/java/net/squanchy/support/lang/Lists.java
@@ -1,6 +1,7 @@
 package net.squanchy.support.lang;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -51,6 +52,13 @@ public final class Lists {
         }
 
         return reducedValue;
+    }
+
+    public static <T> boolean any(T[] array, Predicate<T> predicate) {
+        if (array == null) {
+            return false;
+        }
+        return any(Arrays.asList(array), predicate);
     }
 
     public static <T> boolean any(List<T> list, Predicate<T> predicate) {

--- a/app/src/main/java/net/squanchy/support/lang/Lists.java
+++ b/app/src/main/java/net/squanchy/support/lang/Lists.java
@@ -52,4 +52,17 @@ public final class Lists {
 
         return reducedValue;
     }
+
+    public static <T> boolean any(List<T> list, Predicate<T> predicate) {
+        if (list == null) {
+            return false;
+        }
+        for (T t : list) {
+            if (predicate.call(t)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
 }

--- a/app/src/main/java/net/squanchy/support/lang/Lists.java
+++ b/app/src/main/java/net/squanchy/support/lang/Lists.java
@@ -54,10 +54,6 @@ public final class Lists {
         return reducedValue;
     }
 
-    public static <T> boolean any(T[] array, Predicate<T> predicate) {
-        return any(Arrays.asList(array), predicate);
-    }
-
     public static <T> boolean any(List<T> list, Predicate<T> predicate) {
         for (T t : list) {
             if (predicate.call(t)) {
@@ -68,8 +64,8 @@ public final class Lists {
         return false;
     }
 
-    public static <T> boolean all(T[] array, Predicate<T> predicate) {
-        for (T t : array){
+    public static <T> boolean all(List<T> list, Predicate<T> predicate) {
+        for (T t : list){
             if (!predicate.call(t)){
                 return false;
             }

--- a/app/src/main/java/net/squanchy/support/lang/Lists.java
+++ b/app/src/main/java/net/squanchy/support/lang/Lists.java
@@ -55,16 +55,10 @@ public final class Lists {
     }
 
     public static <T> boolean any(T[] array, Predicate<T> predicate) {
-        if (array == null) {
-            return false;
-        }
         return any(Arrays.asList(array), predicate);
     }
 
     public static <T> boolean any(List<T> list, Predicate<T> predicate) {
-        if (list == null) {
-            return false;
-        }
         for (T t : list) {
             if (predicate.call(t)) {
                 return true;


### PR DESCRIPTION
The idea behind this PR is to make the search look inside the title *and* the text.

The search in the title didn't change, but we added some logic so that we can search in the text as well, using an `AND` logic.

<details>

For `AND` logic, we mean that if the user types more than one word, we look for **all** the words, in any order. Another approach would be to check if at least **one** of them is present (we discarded this option as it gave way too many results). The third approach we could think of would be to do as we do for the title and treat the query as a full String, so that we just run the check on the text as we do against the title and that's it.

We went for the first approach as it seemed the best in terms of UX