### PR TITLE
SQ-SC/Fix IndexOutOfBounds error while matching entities

### DIFF
--- a/app/src/main/java/net/squanchy/tweets/TweetsPageView.java
+++ b/app/src/main/java/net/squanchy/tweets/TweetsPageView.java
@@ -105,7 +105,7 @@ public class TweetsPageView extends CoordinatorLayout implements Loadable {
         refreshingData = true;
         subscription = twitterService.refresh(query)
                 .observeOn(AndroidSchedulers.mainThread())
-                .subscribe(this::onSuccess, e -> onError());
+                .subscribe(this::onSuccess, this::onError);
     }
 
     private void onSuccess(List<TweetViewModel> tweet) {
@@ -113,8 +113,8 @@ public class TweetsPageView extends CoordinatorLayout implements Loadable {
         onRefreshCompleted();
     }
 
-    private void onError() {
-        Timber.e("Error refreshing the Twitter timeline");
+    private void onError(Throwable e) {
+        Timber.e(e, "Error refreshing the Twitter timeline");
         onRefreshCompleted();
     }
 

--- a/app/src/main/java/net/squanchy/tweets/service/TweetSpannedTextBuilder.java
+++ b/app/src/main/java/net/squanchy/tweets/service/TweetSpannedTextBuilder.java
@@ -8,7 +8,6 @@ import com.twitter.sdk.android.core.models.HashtagEntity;
 import com.twitter.sdk.android.core.models.MentionEntity;
 import com.twitter.sdk.android.core.models.UrlEntity;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.MatchResult;
 import java.util.regex.Matcher;
@@ -99,10 +98,11 @@ public class TweetSpannedTextBuilder {
         String string = builder.toString();
         Matcher matcher = HTML_ENTITY_PATTERN.matcher(string);
 
-        while (matcher.find()) {
+        if (matcher.find()) {
             MatchResult matchResult = matcher.toMatchResult();
             Spanned unescapedEntity = Html.fromHtml(matchResult.group());
             builder.replace(matchResult.start(), matchResult.end(), unescapedEntity);
+            unescapeEntities(builder);
         }
     }
 }


### PR DESCRIPTION
https://fabric.io/sebs-apps/android/apps/it.droidconit.dummiladisciassette/issues/58e6a3140aeb16625b5502aa?time=last-seven-days
<details>
<summary>Non-fatal Exception: java.lang.IndexOutOfBoundsException: replace (102 ... 106) ends beyond length 103</summary>
Non-fatal Exception: java.lang.IndexOutOfBoundsException: replace (102 ... 106) ends beyond length 103
       at android.text.SpannableStringBuilder.checkRange(SpannableStringBuilder.java:1090)
       at android.text.SpannableStringBuilder.replace(SpannableStringBuilder.java:498)
       at android.text.SpannableStringBuilder.replace(SpannableStringBuilder.java:492)
       at net.squanchy.tweets.service.TweetSpannedTextBuilder.unescapeEntities(TweetSpannedTextBuilder.java:103)
       at net.squanchy.tweets.service.TweetSpannedTextBuilder.applySpans(TweetSpannedTextBuilder.java:47)
       at net.squanchy.tweets.service.TweetModelConverter.toViewModel(TweetModelConverter.java:40)
       at net.squanchy.tweets.service.TwitterService$$Lambda$4.call(Unknown Source)
       at net.squanchy.support.lang.Lists.map(Lists.java:16)
       at net.squanchy.tweets.service.TwitterService.lambda$refresh$3(TwitterService.java:26)
       at net.squanchy.tweets.service.TwitterService$$Lambda$3.apply(Unknown Source)
       at io.reactivex.internal.operators.observable.ObservableMap$MapObserver.onNext(ObservableMap.java:58)
       at io.reactivex.internal.operators.observable.ObservableMap$MapObserver.onNext(ObservableMap.java:63)
       at io.reactivex.internal.operators.observable.ObservableMap$MapObserver.onNext(ObservableMap.java:63)
       at io.reactivex.internal.operators.observable.ObservableCreate$CreateEmitter.onNext(ObservableCreate.java:67)
       at net.squanchy.tweets.service.TwitterRepository$SearchCallback.success(TwitterRepository.java:41)
       at com.twitter.sdk.android.core.Callback.onResponse(Callback.java:40)
       at retrofit2.ExecutorCallAdapterFactory$ExecutorCallbackCall$1$1.run(ExecutorCallAdapterFactory.java:68)
       at android.os.Handler.handleCallback(Handler.java:739)
       at android.os.Handler.dispatchMessage(Handler.java:95)
       at android.os.Looper.loop(Looper.java:148)
       at android.app.ActivityThread.main(ActivityThread.java:5417)
       at java.lang.reflect.Method.invoke(Method.java)
       at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:726)
       at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:616)
</details>

---

I noticed we were cycling through the entity matches while substituting them. This is what caused the `IndexOutOfBoundException`, if there were more than one match, and the last was at the end of the tweet, the last match would have been done to a now adjusted text which would be shorter than the initial one.

Solution: rematch every time we substitute. Recursion to the rescue!