### PR TITLE
SQ-SC/Use different clientId for automanaged google api clients

### DIFF
--- a/app/src/main/java/net/squanchy/google/GoogleClientId.java
+++ b/app/src/main/java/net/squanchy/google/GoogleClientId.java
@@ -1,0 +1,13 @@
+package net.squanchy.google;
+
+public enum GoogleClientId {
+
+    HOME_ACTIVITY,
+    LOCATION_ONBOARDING_ACTIVITY,
+    SETTINGS_FRAGMENT,
+    SIGN_IN_ACTIVITY;
+
+    public int clientId() {
+        return ordinal();
+    }
+}

--- a/app/src/main/java/net/squanchy/home/HomeActivity.java
+++ b/app/src/main/java/net/squanchy/home/HomeActivity.java
@@ -48,12 +48,13 @@ import io.reactivex.android.schedulers.AndroidSchedulers;
 import io.reactivex.disposables.CompositeDisposable;
 import timber.log.Timber;
 
+import static net.squanchy.google.GoogleClientId.HOME_ACTIVITY;
+
 public class HomeActivity extends TypefaceStyleableActivity {
 
     private static final String KEY_CONTEST_STAND = "stand";
     private static final String KEY_ROOM_EVENT = "room";
 
-    private static final int REQUEST_SETTINGS = 9375;
     private static final int REQUEST_SIGN_IN_MAY_GOD_HAVE_MERCY_OF_OUR_SOULS = 666;
     private static final String KEY_PROXIMITY_ID = "proximity_id";
 
@@ -144,7 +145,7 @@ public class HomeActivity extends TypefaceStyleableActivity {
 
     private GoogleApiClient getGoogleApiClient() {
         return new GoogleApiClient.Builder(this)
-                .enableAutoManage(this, connectionResult -> Timber.e("Google Client connection failed"))
+                .enableAutoManage(this, HOME_ACTIVITY.clientId(), connectionResult -> Timber.e("Google Client connection failed"))
                 .addApi(LocationServices.API)
                 .build();
     }

--- a/app/src/main/java/net/squanchy/home/HomeActivity.java
+++ b/app/src/main/java/net/squanchy/home/HomeActivity.java
@@ -13,6 +13,7 @@ import android.support.design.widget.BaseTransientBottomBar;
 import android.support.design.widget.Snackbar;
 import android.support.transition.Fade;
 import android.support.transition.TransitionManager;
+import android.support.v4.content.ContextCompat;
 import android.util.TypedValue;
 import android.view.View;
 import android.view.ViewGroup;
@@ -157,7 +158,7 @@ public class HomeActivity extends TypefaceStyleableActivity {
                 BaseTransientBottomBar.LENGTH_INDEFINITE
         );
         snackbar.setAction(R.string.missing_prerequisites_action, view -> proximityPreconditions.startSatisfyingPreconditions());
-        snackbar.setActionTextColor(getResources().getColor(R.color.text_inverse));
+        snackbar.setActionTextColor(ContextCompat.getColor(this, R.color.text_inverse));
         return snackbar;
     }
 
@@ -225,7 +226,7 @@ public class HomeActivity extends TypefaceStyleableActivity {
     public Snackbar toSnackbar(Event event, ProximityEvent proximityEvent) {
         Snackbar snackbar = Snackbar.make(pageViews.get(currentSection), buildString(event), BaseTransientBottomBar.LENGTH_INDEFINITE);
         snackbar.setAction(R.string.event_details, view -> tapOnSnackbarAction(event, proximityEvent));
-        snackbar.setActionTextColor(getResources().getColor(R.color.text_inverse));
+        snackbar.setActionTextColor(ContextCompat.getColor(this, R.color.text_inverse));
         return snackbar;
     }
 

--- a/app/src/main/java/net/squanchy/onboarding/location/LocationOnboardingActivity.java
+++ b/app/src/main/java/net/squanchy/onboarding/location/LocationOnboardingActivity.java
@@ -21,6 +21,8 @@ import net.squanchy.service.proximity.injection.ProximityService;
 
 import timber.log.Timber;
 
+import static net.squanchy.google.GoogleClientId.LOCATION_ONBOARDING_ACTIVITY;
+
 public class LocationOnboardingActivity extends TypefaceStyleableActivity {
 
     private Onboarding onboarding;
@@ -36,7 +38,7 @@ public class LocationOnboardingActivity extends TypefaceStyleableActivity {
         super.onCreate(savedInstanceState);
 
         GoogleApiClient googleApiClient = new GoogleApiClient.Builder(this)
-                .enableAutoManage(this, connectionResult -> onGoogleConnectionFailed())
+                .enableAutoManage(this, LOCATION_ONBOARDING_ACTIVITY.clientId(), connectionResult -> onGoogleConnectionFailed())
                 .addApi(LocationServices.API)
                 .build();
 

--- a/app/src/main/java/net/squanchy/settings/SettingsFragment.java
+++ b/app/src/main/java/net/squanchy/settings/SettingsFragment.java
@@ -32,6 +32,8 @@ import io.reactivex.android.schedulers.AndroidSchedulers;
 import io.reactivex.disposables.CompositeDisposable;
 import timber.log.Timber;
 
+import static net.squanchy.google.GoogleClientId.SETTINGS_FRAGMENT;
+
 public class SettingsFragment extends PreferenceFragment {
 
     private final CompositeDisposable subscriptions = new CompositeDisposable();
@@ -66,7 +68,7 @@ public class SettingsFragment extends PreferenceFragment {
 
         AppCompatActivity activity = (AppCompatActivity) getActivity(); // TODO UNYOLO
         GoogleApiClient googleApiClient = new GoogleApiClient.Builder(activity)
-                .enableAutoManage(activity, connectionResult -> onGoogleConnectionFailed())
+                .enableAutoManage(activity, SETTINGS_FRAGMENT.clientId(), connectionResult -> onGoogleConnectionFailed())
                 .addApi(LocationServices.API)
                 .build();
 

--- a/app/src/main/java/net/squanchy/signin/SignInActivity.java
+++ b/app/src/main/java/net/squanchy/signin/SignInActivity.java
@@ -22,6 +22,8 @@ import net.squanchy.support.config.DialogLayoutParameters;
 import io.reactivex.android.schedulers.AndroidSchedulers;
 import io.reactivex.functions.Action;
 
+import static net.squanchy.google.GoogleClientId.SIGN_IN_ACTIVITY;
+
 public class SignInActivity extends TypefaceStyleableActivity {
 
     private static final int RC_SIGN_IN = 9001;
@@ -66,7 +68,7 @@ public class SignInActivity extends TypefaceStyleableActivity {
                 .build();
 
         return new GoogleApiClient.Builder(this)
-                .enableAutoManage(this, e -> showSignInFailedError())
+                .enableAutoManage(this, SIGN_IN_ACTIVITY.clientId(), e -> showSignInFailedError())
                 .addApi(Auth.GOOGLE_SIGN_IN_API, signInOptions)
                 .build();
     }


### PR DESCRIPTION
https://fabric.io/sebs-apps/android/apps/it.droidconit.dummiladisciassette/issues/58e5ef690aeb16625b4e2f0b?time=last-seven-days
<details>
<summary>java.lang.IllegalStateException: Already managing a GoogleApiClient with id 0</summary>
Fatal Exception: java.lang.RuntimeException: Unable to start activity ComponentInfo{it.droidconit.dummiladisciassette/net.squanchy.settings.SettingsActivity}: java.lang.IllegalStateException: Already managing a GoogleApiClient with id 0
       at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:2444)
       at android.app.ActivityThread.handleLaunchActivity(ActivityThread.java:2504)
       at android.app.ActivityThread.handleRelaunchActivity(ActivityThread.java:4113)
       at android.app.ActivityThread.access$1000(ActivityThread.java:165)
       at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1374)
       at android.os.Handler.dispatchMessage(Handler.java:102)
       at android.os.Looper.loop(Looper.java:150)
       at android.app.ActivityThread.main(ActivityThread.java:5546)
       at java.lang.reflect.Method.invoke(Method.java)
       at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:794)
       at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:684)
Caused by java.lang.IllegalStateException: Already managing a GoogleApiClient with id 0
       at com.google.android.gms.common.internal.zzac.zza(Unknown Source)
       at com.google.android.gms.internal.zzaaa.zza(Unknown Source)
       at com.google.android.gms.common.api.GoogleApiClient$Builder.zzf(Unknown Source)
       at com.google.android.gms.common.api.GoogleApiClient$Builder.build(Unknown Source)
       at net.squanchy.settings.SettingsFragment.onCreate(SettingsFragment.java:71)
       at android.app.Fragment.performCreate(Fragment.java:2202)
       at android.app.FragmentManagerImpl.moveToState(FragmentManager.java:945)
       at android.app.FragmentManagerImpl.moveToState(FragmentManager.java:1157)
       at android.app.BackStackRecord.run(BackStackRecord.java:793)
       at android.app.FragmentManagerImpl.execPendingActions(FragmentManager.java:1544)
       at android.app.FragmentController.execPendingActions(FragmentController.java:325)
       at android.app.Activity.performStart(Activity.java:6386)
       at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:2407)
       at android.app.ActivityThread.handleLaunchActivity(ActivityThread.java:2504)
       at android.app.ActivityThread.handleRelaunchActivity(ActivityThread.java:4113)
       at android.app.ActivityThread.access$1000(ActivityThread.java:165)
       at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1374)
       at android.os.Handler.dispatchMessage(Handler.java:102)
       at android.os.Looper.loop(Looper.java:150)
       at android.app.ActivityThread.main(ActivityThread.java:5546)
       at java.lang.reflect.Method.invoke(Method.java)
       at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:794)
       at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:684)
</details>

---

https://developers.google.com/android/reference/com/google/android/gms/common/api/GoogleApiClient.Builder#enableAutoManage(android.support.v4.app.FragmentActivity,%20int,%20com.google.android.gms.common.api.GoogleApiClient.OnConnectionFailedListener)

> A non-negative identifier for this client. At any given time, only one auto-managed client is allowed per id. To reuse an id you must first call stopAutoManage(FragmentActivity) on the previous client.

The version that doesn't require a clientId is going to set it to 0 every time, which means we will end up in the situation where the app might crash.

https://developers.google.com/android/reference/com/google/android/gms/common/api/GoogleApiClient.Builder.html#enableAutoManage(android.support.v4.app.FragmentActivity, com.google.android.gms.common.api.GoogleApiClient.OnConnectionFailedListener)

>This method can only be used if this GoogleApiClient will be the only auto-managed client in the containing activity. The api client will be assigned a default client id