### PR TITLE
Extract buildscript dependencies to dependencies.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,17 +6,15 @@ buildscript {
         google()
     }
 
-    ext {
-        jaCoCoVersion = '0.7.9'
-    }
+    apply from: 'dependencies.gradle'
 
     dependencies {
-        classpath "org.jacoco:org.jacoco.core:$jaCoCoVersion"
-        classpath 'com.novoda:gradle-static-analysis-plugin:0.4.1'
-        classpath 'com.github.ben-manes:gradle-versions-plugin:0.15.0'
-        classpath 'com.google.gms:google-services:3.1.0'
-        classpath 'com.github.triplet.gradle:play-publisher:1.1.5'
-        classpath 'com.android.tools.build:gradle:3.0.0-alpha9'
+        classpath buildScript.jaCoCo
+        classpath buildScript.gradleStaticAnalysisPlugin
+        classpath buildScript.gradleVersionsPlugin
+        classpath buildScript.googleServices
+        classpath buildScript.playPublisher
+        classpath buildScript.android
     }
 }
 

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -53,4 +53,13 @@ ext {
                     mockito : 'org.mockito:mockito-core:2.8.47'
             ]
     ]
+
+    buildScript = [
+            jaCoCo                      : 'org.jacoco:org.jacoco.core:0.7.9',
+            gradleStaticAnalysisPlugin  : 'com.novoda:gradle-static-analysis-plugin:0.4.1',
+            gradleVersionsPlugin        : 'com.github.ben-manes:gradle-versions-plugin:0.15.0',
+            googleServices              : 'com.google.gms:google-services:3.1.0',
+            playPublisher               : 'com.github.triplet.gradle:play-publisher:1.1.5',
+            android                     : 'com.android.tools.build:gradle:3.0.0-alpha9'
+    ]
 }


### PR DESCRIPTION
As per title.

One note: I named the map `buildScript` instead of `buildscript` intentionally, as the latter would shadow the already present symbol, can change to something else if there's a better alternative.