### PR TITLE
Lifecycle awareness from the support library 26.1.0

### DIFF
--- a/app/src/main/java/net/squanchy/favorites/FavoritesPageView.java
+++ b/app/src/main/java/net/squanchy/favorites/FavoritesPageView.java
@@ -1,5 +1,8 @@
 package net.squanchy.favorites;
 
+import android.arch.lifecycle.Lifecycle;
+import android.arch.lifecycle.LifecycleObserver;
+import android.arch.lifecycle.OnLifecycleEvent;
 import android.content.Context;
 import android.support.design.widget.CoordinatorLayout;
 import android.support.v7.app.AppCompatActivity;
@@ -12,7 +15,6 @@ import net.squanchy.analytics.Analytics;
 import net.squanchy.analytics.ContentType;
 import net.squanchy.favorites.view.FavoritesListView;
 import net.squanchy.home.HomeActivity;
-import net.squanchy.home.Loadable;
 import net.squanchy.navigation.Navigator;
 import net.squanchy.schedule.ScheduleService;
 import net.squanchy.schedule.domain.view.Event;
@@ -26,7 +28,7 @@ import io.reactivex.functions.BiFunction;
 
 import static net.squanchy.support.ContextUnwrapper.unwrapToActivityContext;
 
-public class FavoritesPageView extends CoordinatorLayout implements Loadable {
+public class FavoritesPageView extends CoordinatorLayout implements LifecycleObserver {
 
     private View progressBar;
     private Disposable subscription;
@@ -93,8 +95,8 @@ public class FavoritesPageView extends CoordinatorLayout implements Loadable {
         });
     }
 
-    @Override
-    public void startLoading() {
+    @OnLifecycleEvent(Lifecycle.Event.ON_START)
+    protected void startLoading() {
         subscription = Observable.combineLatest(service.schedule(true), service.currentUserIsSignedIn(), toScheduleAndLoggedIn())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(schedule -> updateWith(schedule, this::onEventClicked));
@@ -109,8 +111,8 @@ public class FavoritesPageView extends CoordinatorLayout implements Loadable {
         navigate.toEventDetails(event.getId());
     }
 
-    @Override
-    public void stopLoading() {
+    @OnLifecycleEvent(Lifecycle.Event.ON_STOP)
+    protected void stopLoading() {
         subscription.dispose();
     }
 

--- a/app/src/main/java/net/squanchy/home/Loadable.java
+++ b/app/src/main/java/net/squanchy/home/Loadable.java
@@ -1,8 +1,0 @@
-package net.squanchy.home;
-
-public interface Loadable {
-
-    void startLoading();
-
-    void stopLoading();
-}

--- a/app/src/main/java/net/squanchy/schedule/SchedulePageView.java
+++ b/app/src/main/java/net/squanchy/schedule/SchedulePageView.java
@@ -1,5 +1,8 @@
 package net.squanchy.schedule;
 
+import android.arch.lifecycle.Lifecycle;
+import android.arch.lifecycle.LifecycleObserver;
+import android.arch.lifecycle.OnLifecycleEvent;
 import android.content.Context;
 import android.content.res.TypedArray;
 import android.graphics.Typeface;
@@ -15,7 +18,6 @@ import android.view.View;
 import net.squanchy.R;
 import net.squanchy.analytics.Analytics;
 import net.squanchy.analytics.ContentType;
-import net.squanchy.home.Loadable;
 import net.squanchy.navigation.Navigator;
 import net.squanchy.schedule.domain.view.Event;
 import net.squanchy.schedule.domain.view.Schedule;
@@ -30,7 +32,7 @@ import uk.co.chrisjenx.calligraphy.TypefaceUtils;
 
 import static net.squanchy.support.ContextUnwrapper.unwrapToActivityContext;
 
-public class SchedulePageView extends CoordinatorLayout implements Loadable {
+public class SchedulePageView extends CoordinatorLayout implements LifecycleObserver {
 
     private ScheduleViewPagerAdapter viewPagerAdapter;
     private View progressBar;
@@ -61,8 +63,8 @@ public class SchedulePageView extends CoordinatorLayout implements Loadable {
 
         progressBar = findViewById(R.id.progressbar);
 
-        ViewPager viewPager = (ViewPager) findViewById(R.id.viewpager);
-        TabLayout tabLayout = (TabLayout) findViewById(R.id.tabstrip);
+        ViewPager viewPager = findViewById(R.id.viewpager);
+        TabLayout tabLayout = findViewById(R.id.tabstrip);
         tabLayout.setupWithViewPager(viewPager);
         hackToApplyTypefaces(tabLayout);
 
@@ -74,7 +76,7 @@ public class SchedulePageView extends CoordinatorLayout implements Loadable {
     }
 
     private void setupToolbar() {
-        Toolbar toolbar = (Toolbar) findViewById(R.id.toolbar);
+        Toolbar toolbar = findViewById(R.id.toolbar);
         toolbar.setTitle(R.string.activity_schedule);
         toolbar.inflateMenu(R.menu.homepage);
         toolbar.setOnMenuItemClickListener(item -> {
@@ -91,8 +93,8 @@ public class SchedulePageView extends CoordinatorLayout implements Loadable {
         });
     }
 
-    @Override
-    public void startLoading() {
+    @OnLifecycleEvent(Lifecycle.Event.ON_START)
+    protected void startLoading() {
         subscription = service.schedule(false)
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(schedule -> updateWith(schedule, this::onEventClicked), Timber::e);
@@ -103,8 +105,8 @@ public class SchedulePageView extends CoordinatorLayout implements Loadable {
         navigate.toEventDetails(event.getId());
     }
 
-    @Override
-    public void stopLoading() {
+    @OnLifecycleEvent(Lifecycle.Event.ON_STOP)
+    protected void stopLoading() {
         subscription.dispose();
     }
 

--- a/app/src/main/java/net/squanchy/tweets/TweetsPageView.java
+++ b/app/src/main/java/net/squanchy/tweets/TweetsPageView.java
@@ -1,5 +1,8 @@
 package net.squanchy.tweets;
 
+import android.arch.lifecycle.Lifecycle;
+import android.arch.lifecycle.LifecycleObserver;
+import android.arch.lifecycle.OnLifecycleEvent;
 import android.content.Context;
 import android.support.design.widget.CoordinatorLayout;
 import android.support.v4.widget.SwipeRefreshLayout;
@@ -12,7 +15,6 @@ import android.widget.TextView;
 import java.util.List;
 
 import net.squanchy.R;
-import net.squanchy.home.Loadable;
 import net.squanchy.navigation.Navigator;
 import net.squanchy.tweets.domain.view.TweetViewModel;
 import net.squanchy.tweets.service.TwitterService;
@@ -24,7 +26,7 @@ import timber.log.Timber;
 
 import static net.squanchy.support.ContextUnwrapper.unwrapToActivityContext;
 
-public class TweetsPageView extends CoordinatorLayout implements Loadable {
+public class TweetsPageView extends CoordinatorLayout implements LifecycleObserver {
 
     private final TwitterService twitterService;
     private final Navigator navigator;
@@ -87,16 +89,16 @@ public class TweetsPageView extends CoordinatorLayout implements Loadable {
         });
     }
 
-    @Override
-    public void startLoading() {
+    @OnLifecycleEvent(Lifecycle.Event.ON_START)
+    protected void startLoading() {
         Context context = getContext();
         query = context.getString(R.string.social_query);
         emptyView.setText(context.getString(R.string.no_tweets_for_query, query));
         refreshTimeline();
     }
 
-    @Override
-    public void stopLoading() {
+    @OnLifecycleEvent(Lifecycle.Event.ON_STOP)
+    protected void stopLoading() {
         subscription.dispose();
     }
 

--- a/app/src/main/java/net/squanchy/venue/VenueInfoPageView.java
+++ b/app/src/main/java/net/squanchy/venue/VenueInfoPageView.java
@@ -1,6 +1,9 @@
 package net.squanchy.venue;
 
 import android.annotation.TargetApi;
+import android.arch.lifecycle.Lifecycle;
+import android.arch.lifecycle.LifecycleObserver;
+import android.arch.lifecycle.OnLifecycleEvent;
 import android.content.Context;
 import android.os.Build;
 import android.support.design.widget.CoordinatorLayout;
@@ -13,7 +16,6 @@ import android.widget.ImageView;
 import android.widget.TextView;
 
 import net.squanchy.R;
-import net.squanchy.home.Loadable;
 import net.squanchy.imageloader.ImageLoader;
 import net.squanchy.imageloader.ImageLoaderInjector;
 import net.squanchy.navigation.Navigator;
@@ -24,7 +26,7 @@ import io.reactivex.disposables.Disposable;
 
 import static net.squanchy.support.ContextUnwrapper.unwrapToActivityContext;
 
-public class VenueInfoPageView extends CoordinatorLayout implements Loadable {
+public class VenueInfoPageView extends CoordinatorLayout implements LifecycleObserver {
 
     private Disposable subscription;
     private final Navigator navigate;
@@ -81,7 +83,7 @@ public class VenueInfoPageView extends CoordinatorLayout implements Loadable {
         });
     }
 
-    @Override
+    @OnLifecycleEvent(Lifecycle.Event.ON_START)
     public void startLoading() {
         subscription = service.venue()
                 .observeOn(AndroidSchedulers.mainThread())
@@ -117,7 +119,7 @@ public class VenueInfoPageView extends CoordinatorLayout implements Loadable {
         });
     }
 
-    @Override
+    @OnLifecycleEvent(Lifecycle.Event.ON_STOP)
     public void stopLoading() {
         subscription.dispose();
     }


### PR DESCRIPTION
Instead of using the `Loadables` interface, this PR takes advantage of the new lifecycle component introduced in support library 26.1.0 to make the bottom bar views lifecycle aware without having to manually dispatch callbacks to them