### PR TITLE
Tweak search transition and some minor UI stuff

### DIFF
--- a/app/src/main/java/net/squanchy/home/HomeActivity.java
+++ b/app/src/main/java/net/squanchy/home/HomeActivity.java
@@ -82,11 +82,11 @@ public class HomeActivity extends TypefaceStyleableActivity {
 
         pageFadeDurationMillis = getResources().getInteger(android.R.integer.config_shortAnimTime);
 
-        pageContainer = (ViewGroup) findViewById(R.id.page_container);
+        pageContainer = findViewById(R.id.page_container);
         collectPageViewsInto(pageViews);
         collectLoadablesInto(loadables);
 
-        bottomNavigationView = (InterceptingBottomNavigationView) findViewById(R.id.bottom_navigation);
+        bottomNavigationView = findViewById(R.id.bottom_navigation);
         setupBottomNavigation(bottomNavigationView);
 
         Intent intent = getIntent();
@@ -121,10 +121,10 @@ public class HomeActivity extends TypefaceStyleableActivity {
     }
 
     private void collectLoadablesInto(List<Loadable> loadables) {
-        loadables.add((Loadable) pageContainer.findViewById(R.id.schedule_content_root));
-        loadables.add((Loadable) pageContainer.findViewById(R.id.favorites_content_root));
-        loadables.add((Loadable) pageContainer.findViewById(R.id.tweets_content_root));
-        loadables.add((Loadable) pageContainer.findViewById(R.id.venueContentRoot));
+        loadables.add(pageContainer.findViewById(R.id.schedule_content_root));
+        loadables.add(pageContainer.findViewById(R.id.favorites_content_root));
+        loadables.add(pageContainer.findViewById(R.id.tweets_content_root));
+        loadables.add(pageContainer.findViewById(R.id.venueContentRoot));
     }
 
     private void setupBottomNavigation(InterceptingBottomNavigationView bottomNavigationView) {

--- a/app/src/main/java/net/squanchy/navigation/Navigator.kt
+++ b/app/src/main/java/net/squanchy/navigation/Navigator.kt
@@ -38,6 +38,7 @@ internal class Navigator(private val activity: Activity, private val debugActivi
 
     fun toSearch() {
         start(Intent(activity, SearchActivity::class.java))
+        activity.overridePendingTransition(android.R.anim.fade_in, android.R.anim.fade_out)
     }
 
     fun toSettings() {

--- a/app/src/main/java/net/squanchy/onboarding/account/AccountOnboardingActivity.kt
+++ b/app/src/main/java/net/squanchy/onboarding/account/AccountOnboardingActivity.kt
@@ -13,6 +13,7 @@ import net.squanchy.navigation.Navigator
 import net.squanchy.onboarding.Onboarding
 import net.squanchy.onboarding.OnboardingPage
 import net.squanchy.signin.SignInService
+import net.squanchy.support.view.enableLightNavigationBar
 import java.util.concurrent.TimeUnit
 
 class AccountOnboardingActivity : TypefaceStyleableActivity() {
@@ -30,6 +31,7 @@ class AccountOnboardingActivity : TypefaceStyleableActivity() {
         signInService = component.signInService()
 
         setContentView(R.layout.activity_onboarding_account)
+        enableLightNavigationBar(this)
 
         onboardingSkip.setOnClickListener { markPageAsSeenAndFinish() }
         onboardingSignInButton.setOnClickListener { signInToGoogle() }

--- a/app/src/main/java/net/squanchy/search/SearchActivity.java
+++ b/app/src/main/java/net/squanchy/search/SearchActivity.java
@@ -37,6 +37,8 @@ import io.reactivex.schedulers.Schedulers;
 import io.reactivex.subjects.PublishSubject;
 import timber.log.Timber;
 
+import static net.squanchy.support.view.SystemUiKt.enableLightNavigationBar;
+
 @SuppressWarnings("PMD.ExcessiveImports")           // Might use some refactoring later on to extract some collaborator
 public class SearchActivity extends TypefaceStyleableActivity implements SearchRecyclerView.OnSearchResultClickListener {
 
@@ -63,6 +65,7 @@ public class SearchActivity extends TypefaceStyleableActivity implements SearchR
     protected void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_search);
+        enableLightNavigationBar(this);
 
         searchField = findViewById(R.id.search_field);
         emptyView = findViewById(R.id.empty_view);

--- a/app/src/main/java/net/squanchy/search/SearchActivity.java
+++ b/app/src/main/java/net/squanchy/search/SearchActivity.java
@@ -64,11 +64,11 @@ public class SearchActivity extends TypefaceStyleableActivity implements SearchR
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_search);
 
-        searchField = (EditText) findViewById(R.id.search_field);
+        searchField = findViewById(R.id.search_field);
         emptyView = findViewById(R.id.empty_view);
-        emptyViewMessage = (TextView) findViewById(R.id.empty_view_message);
+        emptyViewMessage = findViewById(R.id.empty_view_message);
 
-        searchRecyclerView = (SearchRecyclerView) findViewById(R.id.speakers_view);
+        searchRecyclerView = findViewById(R.id.speakers_view);
         setupToolbar();
 
         SearchComponent component = SearchInjector.obtain(this);
@@ -78,7 +78,7 @@ public class SearchActivity extends TypefaceStyleableActivity implements SearchR
 
     @SuppressWarnings("ConstantConditions") // We set up the ActionBar ourselves, so it's not null
     private void setupToolbar() {
-        Toolbar toolbar = (Toolbar) findViewById(R.id.search_toolbar);
+        Toolbar toolbar = findViewById(R.id.search_toolbar);
         setSupportActionBar(toolbar);
         getSupportActionBar().setDisplayHomeAsUpEnabled(true);
     }
@@ -185,6 +185,7 @@ public class SearchActivity extends TypefaceStyleableActivity implements SearchR
             return true;
         } else if (item.getItemId() == android.R.id.home) {
             finish();
+            overridePendingTransition(0, android.R.anim.fade_out);
             return true;
         }
         return super.onOptionsItemSelected(item);

--- a/app/src/main/java/net/squanchy/support/view/SystemUi.kt
+++ b/app/src/main/java/net/squanchy/support/view/SystemUi.kt
@@ -1,0 +1,18 @@
+package net.squanchy.support.view
+
+import android.annotation.TargetApi
+import android.app.Activity
+import android.os.Build
+import android.view.View
+
+@TargetApi(Build.VERSION_CODES.O)
+fun enableLightNavigationBar(activity: Activity) {
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
+        return
+    }
+
+    activity.window.apply {
+        navigationBarColor = -0x111112
+        decorView.systemUiVisibility = decorView.systemUiVisibility or View.SYSTEM_UI_FLAG_LIGHT_NAVIGATION_BAR
+    }
+}

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -12,4 +12,6 @@
   <color name="experience_level_intermediate">#EEA53A</color>
   <color name="experience_level_advanced">#EE6227</color>
 
+  <color name="navigation_bar_light">#EEEEEE</color>
+
 </resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -111,7 +111,7 @@
 
   <style name="Theme.Squanchy.SignIn" parent="Theme.Squanchy.BottomSheet" />
 
-  <style name="Theme.Squanchy.Search" parent="Theme.Squanchy.PrimaryStatusBar" />
+  <style name="Theme.Squanchy.Search" parent="Theme.Squanchy.MostlyWhite" />
 
   <style name="Theme.Squanchy.Settings" parent="Theme.Squanchy.PrimaryStatusBar">
     <item name="colorAccent">?colorPrimary</item>


### PR DESCRIPTION
This PR:
 * Uses a less abrupt transition for the search activity (fade)
    * Plan is to replace it with a circular reveal eventually
 * The system nav bar now is light in both the onboarding and search activities (along with the status bar)

 Before | After
 --- | ---
 ![onboarding-before](https://user-images.githubusercontent.com/153802/31586758-3ef8d90e-b1cd-11e7-85dc-8fd67ad5f216.png) | ![onboarding-after](https://user-images.githubusercontent.com/153802/31586757-3eded7de-b1cd-11e7-8f40-e3a9baee2966.png)
 ![search-before](https://user-images.githubusercontent.com/153802/31586760-3f2e4cc4-b1cd-11e7-8f13-e0011180eebd.png) | ![search-after](https://user-images.githubusercontent.com/153802/31586759-3f158266-b1cd-11e7-90ea-06ae747d3c23.png)



