### PR TITLE
Workaround for desugar eating memory up on CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,9 +34,10 @@ jobs:
           command: .circleci/ci-scripts/ci-mock-google-services-setup.sh
 
       # Run the main job command, delegating to Gradle
+      # See https://issuetracker.google.com/issues/62217354 for the parallelism option
       - run:
           name: Run Gradle :check command
-          command: ./gradlew check --continue
+          command: ./gradlew check --continue -Djava.util.concurrent.ForkJoinPool.common.parallelism=2
 
       # Store all the downloaded dependencies in the CI cache
       - save_cache:


### PR DESCRIPTION
Tested with [several builds](https://circleci.com/gh/squanchy-dev/squanchy-android/tree/test-ci) on CircleCI, all green 🎉 

Until this gets fixed/sorted out in 3.1, we're stuck with this.