### PR TITLE
Add info to any DB errors to aid in tracking them down

### DIFF
--- a/app/src/main/java/net/squanchy/service/firebase/FirebaseDbService.kt
+++ b/app/src/main/java/net/squanchy/service/firebase/FirebaseDbService.kt
@@ -85,7 +85,7 @@ class FirebaseDbService(private val database: DatabaseReference) {
                         val value = dataSnapshot.getValue(clazz)
                         emitter.onNext(map(value))
                     } catch (e: Exception) {
-                        throw DatabaseException("Problem in DB at path $path, class $clazz", e)
+                        emitter.onError(DatabaseException("Problem in DB at path $path, class $clazz", e))
                     }
                 }
 

--- a/app/src/main/java/net/squanchy/service/firebase/FirebaseDbService.kt
+++ b/app/src/main/java/net/squanchy/service/firebase/FirebaseDbService.kt
@@ -76,6 +76,7 @@ class FirebaseDbService(private val database: DatabaseReference) {
     private fun <T, V> observeChildAndEmit(path: String, clazz: Class<V>, map: (V?) -> T): Observable<T> {
         return Observable.create { emitter: ObservableEmitter<T> ->
             val listener = object : ValueEventListener {
+                @Suppress("TooGenericExceptionCaught") // We want to add info to *any* problems
                 override fun onDataChange(dataSnapshot: DataSnapshot) {
                     if (emitter.isDisposed) {
                         return

--- a/app/src/main/java/net/squanchy/service/firebase/FirebaseDbService.kt
+++ b/app/src/main/java/net/squanchy/service/firebase/FirebaseDbService.kt
@@ -3,6 +3,7 @@ package net.squanchy.service.firebase
 import com.google.android.gms.tasks.Task
 import com.google.firebase.database.DataSnapshot
 import com.google.firebase.database.DatabaseError
+import com.google.firebase.database.DatabaseException
 import com.google.firebase.database.DatabaseReference
 import com.google.firebase.database.ValueEventListener
 import io.reactivex.Completable
@@ -79,8 +80,12 @@ class FirebaseDbService(private val database: DatabaseReference) {
                     if (emitter.isDisposed) {
                         return
                     }
-                    val value = dataSnapshot.getValue(clazz)
-                    emitter.onNext(map(value))
+                    try {
+                        val value = dataSnapshot.getValue(clazz)
+                        emitter.onNext(map(value))
+                    } catch (e: Exception) {
+                        throw DatabaseException("Problem in DB at path $path, class $clazz", e)
+                    }
                 }
 
                 override fun onCancelled(databaseError: DatabaseError) {


### PR DESCRIPTION
Any error coming out of the Firebase sync is startlingly uninformative. This just adds basic info on the path and class that was concerned, which can help track down the issue. Pretty basic but better than nothing.