### PR TITLE
Fix incorrect speaker images in search

### DIFF
--- a/app/src/main/java/net/squanchy/search/SearchItemView.java
+++ b/app/src/main/java/net/squanchy/search/SearchItemView.java
@@ -57,6 +57,8 @@ public class SearchItemView extends LinearLayout {
         Optional<String> avatarImageURL = speaker.getPhotoUrl();
         if (avatarImageURL.isPresent()) {
             imageLoader.load(avatarImageURL.get()).into(image);
+        } else {
+            image.setImageDrawable(null);
         }
     }
 }


### PR DESCRIPTION
View is recycled so needs to reset to nothing if speaker image is absent. Otherwise you get other speakers' images for those who are missing them.