### PR TITLE
Update Detekt to 1.0.0.RC5

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -7,7 +7,7 @@ buildscript {
 }
 
 plugins {
-    id 'io.gitlab.arturbosch.detekt' version '1.0.0.RC4-3'
+    id 'io.gitlab.arturbosch.detekt' version '1.0.0.RC5'
 }
 
 apply plugin: 'com.android.application'
@@ -105,7 +105,7 @@ play {
 }
 
 detekt {
-    version = '1.0.0.RC4-3'
+    version = '1.0.0.RC5'
 
     profile('main') {
         input = "$projectDir/src/main/java"

--- a/app/src/main/java/net/squanchy/notification/NotificationCreator.kt
+++ b/app/src/main/java/net/squanchy/notification/NotificationCreator.kt
@@ -197,9 +197,7 @@ class NotificationCreator(private val context: Context) {
         private val EVENTS_ABOUT_TO_START_CHANNEL_ID = "events_about_to_start"
 
         // pulsate every 1 second, indicating a relatively high degree of urgency
-        @SuppressWarnings("MagicNumber")
         private val NOTIFICATION_LED_ON_MS = 100
-        @SuppressWarnings("MagicNumber")
         private val NOTIFICATION_LED_OFF_MS = 1000
         private val ARGB_TRANSPARENT = "#00000000"
     }

--- a/app/src/main/java/net/squanchy/notification/NotificationsIntentService.kt
+++ b/app/src/main/java/net/squanchy/notification/NotificationsIntentService.kt
@@ -88,7 +88,6 @@ class NotificationsIntentService : IntentService(NotificationsIntentService::cla
     }
 
     companion object {
-        @SuppressWarnings("MagicNumber")
         private val NOTIFICATION_INTERVAL_MINUTES = 10
         private val SHOW_NOTIFICATIONS_DEFAULT = true
     }

--- a/app/src/main/java/net/squanchy/notification/Notifier.kt
+++ b/app/src/main/java/net/squanchy/notification/Notifier.kt
@@ -19,7 +19,6 @@ class Notifier(private val notificationManagerCompat: NotificationManagerCompat)
     }
 
     companion object {
-        @SuppressWarnings("MagicNumber")
         private val SINGLE_NOTIFICATION_ID = 42
     }
 }

--- a/team-props/static-analysis/detekt-config.yml
+++ b/team-props/static-analysis/detekt-config.yml
@@ -1,6 +1,22 @@
 autoCorrect: true
 failFast: false
 
+test-pattern: # Configure exclusions for test sources
+  active: true
+  patterns: # Test file regexes
+    - '.*/test/.*'
+    - '.*Test.kt'
+    - '.*Spec.kt'
+  exclude-rule-sets:
+    - 'comments'
+  exclude-rules:
+    - 'NamingRules'
+    - 'WildcardImport'
+    - 'MagicNumber'
+    - 'MaxLineLength'
+    - 'LateInitUsage'
+    - 'StringLiteralDuplication'
+
 build:
   warningThreshold: 1
   failThreshold: 1
@@ -9,16 +25,31 @@ build:
     complexity: 2
     formatting: 1
     LongParameterList: 1
-    comments: 0.5
+    comments: 1
 
 processors:
   active: true
+  exclude:
+  # - 'FunctionCountProcessor'
+  # - 'PropertyCountProcessor'
+  # - 'ClassCountProcessor'
+  # - 'PackageCountProcessor'
+  # - 'KtFileCountProcessor'
 
 console-reports:
   active: true
+  exclude:
+  #  - 'ProjectStatisticsReport'
+  #  - 'ComplexityReport'
+  #  - 'NotificationReport'
+  #  - 'FindingsReport'
+  #  - 'BuildFailureReport'
 
 output-reports:
   active: true
+  exclude:
+  #  - 'PlainOutputReport'
+  #  - 'XmlOutputReport'
 
 potential-bugs:
   active: true
@@ -28,14 +59,24 @@ potential-bugs:
     active: false
   EqualsWithHashCodeExist:
     active: true
+  InvalidLoopCondition:
+    active: false
   WrongEqualsTypeParameter:
+    active: false
+  IteratorHasNextCallsNextMethod:
     active: false
   ExplicitGarbageCollectionCall:
     active: true
+  UnconditionalJumpStatementInLoop:
+    active: false
+  IteratorNotThrowingNoSuchElementException:
+    active: false
   UnreachableCode:
     active: true
   LateinitUsage:
     active: false
+    excludeAnnotatedProperties: ''
+    ignoreOnClassesPattern: ''
   UnsafeCallOnNullableType:
     active: false
   UnsafeCast:
@@ -62,8 +103,12 @@ exceptions:
   TooGenericExceptionCaught:
     active: true
     exceptions:
+      - ArrayIndexOutOfBoundsException
       - Error
       - Exception
+      - IllegalMonitorStateException
+      - IndexOutOfBoundsException
+    # - InterruptedException
       - NullPointerException
       - RuntimeException
       - Throwable
@@ -77,9 +122,12 @@ exceptions:
       - Throwable
   InstanceOfCheckForException:
     active: false
-  IteratorNotThrowingNoSuchElementException:
+  NotImplementedDeclaration:
     active: false
-  PrintExceptionStackTrace:
+  ThrowingExceptionsWithoutMessageOrCause:
+    active: false
+    exceptions: 'IllegalArgumentException,IllegalStateException,IOException'
+  PrintStackTrace:
     active: false
   RethrowCaughtException:
     active: false
@@ -114,6 +162,8 @@ empty-blocks:
     active: true
   EmptyInitBlock:
     active: true
+  EmptyKtFile:
+    active: true
   EmptySecondaryConstructor:
     active: true
   EmptyWhenBlock:
@@ -124,23 +174,41 @@ empty-blocks:
 complexity:
   active: true
   LongMethod:
+    active: true
     threshold: 20
   NestedBlockDepth:
+    active: true
     threshold: 3
   LongParameterList:
-    threshold: 7
+    active: true
+    threshold: 5
   LargeClass:
+    active: true
     threshold: 150
-  ComplexMethod:
+  ComplexInterface:
+    active: false
     threshold: 10
+    includeStaticDeclarations: false
+  ComplexMethod:
+    active: true
+    threshold: 10
+  MethodOverloading:
+    active: false
+    threshold: 5
   TooManyFunctions:
     active: false
+    threshold: 20
   ComplexCondition:
+    active: true
     threshold: 3
   LabeledExpression:
     active: false
   StringLiteralDuplication:
     active: false
+    threshold: 2
+    ignoreAnnotation: true
+    excludeStringsWithLessThan5Characters: true
+    ignoreStringsRegex: '$^'
 
 code-smell:
   active: true
@@ -149,84 +217,53 @@ code-smell:
     weight: 0.45
     base: 0.5
 
-formatting:
-  active: true
-  useTabs: false
-  Indentation:
-    active: true
-    indentSize: 4
-  ConsecutiveBlankLines:
-    active: true
-    autoCorrect: true
-  MultipleSpaces:
-    active: true
-    autoCorrect: true
-  SpacingAfterComma:
-    active: true
-    autoCorrect: true
-  SpacingAfterKeyword:
-    active: true
-    autoCorrect: true
-  SpacingAroundColon:
-    active: true
-    autoCorrect: true
-  SpacingAroundBraces:
-    active: true
-    autoCorrect: true
-  SpacingAroundOperator:
-    active: true
-    autoCorrect: true
-  TrailingSpaces:
-    active: true
-    autoCorrect: true
-  UnusedImports:
-    active: true
-    autoCorrect: true
-  OptionalSemicolon:
-    active: true
-    autoCorrect: true
-  OptionalUnit:
-    active: true
-    autoCorrect: true
-  ExpressionBodySyntax:
-    active: false
-    autoCorrect: false
-  ExpressionBodySyntaxLineBreaks:
-    active: false
-    autoCorrect: false
-  OptionalReturnKeyword:
-    active: true
-    autoCorrect: false
-
 style:
   active: true
   ReturnCount:
     active: false
+    max: 2
+  ThrowsCount:
+    active: true
+    max: 2
   NewLineAtEndOfFile:
     active: true
   OptionalAbstractKeyword:
     active: true
   OptionalWhenBraces:
     active: false
+  CollapsibleIfStatements:
+    active: false
   EqualsNullCall:
     active: false
   ForbiddenComment:
     active: true
-    values: 'STOPSHIP'
+    values: 'STOPSHIP:'
   ForbiddenImport:
     active: false
+    imports: ''
   PackageDeclarationStyle:
-    active: true
+    active: false
+  LoopWithTooManyJumpStatements:
+    active: false
+    maxJumpCount: 1
+  MethodNameEqualsClassName:
+    active: false
+    ignoreOverriddenFunction: true
   ModifierOrder:
     active: true
   MagicNumber:
     active: true
     ignoreNumbers: '-1,0,1,2'
-    ignoreHashCodeFunction: true
+    ignoreHashCodeFunction: false
     ignorePropertyDeclaration: false
-    ignoreAnnotation: true
+    ignoreConstantDeclaration: true
+    ignoreCompanionObjectPropertyDeclaration: true
+    ignoreAnnotation: false
+    ignoreNamedArgument: true
+    ignoreEnums: false
   WildcardImport:
     active: true
+    excludeImports: ''
   SafeCast:
     active: true
   MaxLineLength:
@@ -245,12 +282,12 @@ style:
     enumEntryPattern: '^[A-Z$][a-zA-Z_$]*$'
   FunctionNaming:
     active: true
-    functionPattern: '^[a-z$][a-zA-Z$0-9]*$'
+    functionPattern: '^([a-z$][a-zA-Z$0-9]*)|(`.*`)$'
   FunctionMaxLength:
     active: false
     maximumFunctionNameLength: 30
   FunctionMinLength:
-    active: true
+    active: false
     minimumFunctionNameLength: 3
   VariableNaming:
     active: true
@@ -260,26 +297,48 @@ style:
     constantPattern: '^([A-Z_]*|serialVersionUID)$'
   VariableMaxLength:
     active: false
+    maximumVariableNameLength: 30
   VariableMinLength:
     active: false
+    minimumVariableNameLength: 3
   ForbiddenClassName:
     active: false
+    forbiddenName: ''
   ProtectedMemberInFinalClass:
     active: true
+  SerialVersionUIDInSerializableClass:
+    active: false
   UnnecessaryParentheses:
     active: false
-  UnnecessarySuperTypeDeclaration:
+  UnnecessaryInheritance:
+    active: false
+  UtilityClassWithPublicConstructor:
     active: false
   DataClassContainsFunctions:
     active: false
+    conversionFunctionPrefix: 'to'
   UseDataClass:
     active: false
   UnnecessaryAbstractClass:
-    active: true
+    active: false
+  OptionalUnit:
+    active: false
+  OptionalReturnKeyword:
+    active: false
+  ExpressionBodySyntax:
+    active: false
+  UnusedImports:
+    active: false
+  NestedClassesVisibility:
+    active: false
+  RedundantVisibilityModifierRule:
+    active: false
+  FunctionOnlyReturningConstant:
+    active: false
 
 comments:
   active: true
-  CommentOverPrivateMethod:
+  CommentOverPrivateFunction:
     active: true
   CommentOverPrivateProperty:
     active: true
@@ -292,5 +351,11 @@ comments:
   UndocumentedPublicFunction:
     active: false
 
+# *experimental feature*
+# Migration rules can be defined in the same config file or a new one
 migration:
   active: false
+  imports:
+    # your.package.Class: new.package.or.Class
+    # for example:
+    # io.gitlab.arturbosch.detekt.api.Rule: io.gitlab.arturbosch.detekt.rule.Rule


### PR DESCRIPTION
This PR updates Detekt to RC5, which allows us to get rid of some `@Suppress`es for `MagicNumber` that was flagging constants in companion objects.

The bulk of changes are merging in the default Detekt rules into ours, to minimise the amount of noise when doing it again in the future.