### PR TITLE
SQ-371/Fix text styling

### DIFF
--- a/app/src/main/java/net/squanchy/about/AboutActivity.java
+++ b/app/src/main/java/net/squanchy/about/AboutActivity.java
@@ -9,6 +9,8 @@ import android.view.MenuItem;
 import net.squanchy.R;
 import net.squanchy.navigation.Navigator;
 
+import static net.squanchy.support.view.SystemUiKt.enableLightNavigationBar;
+
 public class AboutActivity extends AppCompatActivity {
 
     private static final String SQUANCHY_WEBSITE = "https://squanchy.net";
@@ -19,6 +21,7 @@ public class AboutActivity extends AppCompatActivity {
         super.onCreate(savedInstanceState);
 
         setContentView(R.layout.activity_about);
+        enableLightNavigationBar(this);
 
         setupToolbar();
 

--- a/app/src/main/java/net/squanchy/search/SearchActivity.java
+++ b/app/src/main/java/net/squanchy/search/SearchActivity.java
@@ -116,6 +116,10 @@ public class SearchActivity extends AppCompatActivity implements SearchRecyclerV
 
     private void requestShowKeyboard(View view) {
         InputMethodManager imm = (InputMethodManager) getSystemService(Context.INPUT_METHOD_SERVICE);
+        if (imm == null) {
+            return;
+        }
+
         imm.showSoftInput(view, 0, new ResultReceiver(new Handler()) {
             @Override
             protected void onReceiveResult(int resultCode, Bundle resultData) {

--- a/app/src/main/java/net/squanchy/settings/SettingsActivity.java
+++ b/app/src/main/java/net/squanchy/settings/SettingsActivity.java
@@ -23,7 +23,7 @@ public class SettingsActivity extends AppCompatActivity {
         super.onCreate(savedInstanceState);
 
         setContentView(R.layout.activity_settings);
-        headerLayout = (SettingsHeaderLayout) findViewById(R.id.settings_header);
+        headerLayout = findViewById(R.id.settings_header);
 
         setupToolbar();
 
@@ -36,7 +36,7 @@ public class SettingsActivity extends AppCompatActivity {
     }
 
     private void setupToolbar() {
-        Toolbar toolbar = (Toolbar) findViewById(R.id.toolbar);
+        Toolbar toolbar = findViewById(R.id.toolbar);
         setSupportActionBar(toolbar);
         getSupportActionBar().setDisplayHomeAsUpEnabled(true);
         getSupportActionBar().setDisplayShowTitleEnabled(false);

--- a/app/src/main/res/layout/activity_about.xml
+++ b/app/src/main/res/layout/activity_about.xml
@@ -60,6 +60,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="center"
+        android:layout_marginBottom="@dimen/about_squanchy_website_margin_bottom"
         android:text="@string/squanchy_website" />
 
       <!-- We cannot use compound drawables here unfortunately -->

--- a/app/src/main/res/layout/activity_home.xml
+++ b/app/src/main/res/layout/activity_home.xml
@@ -31,6 +31,7 @@
 
   <net.squanchy.support.widget.InterceptingBottomNavigationView
     android:id="@+id/bottom_navigation"
+    android:theme="@style/ThemeOverlay.Squanchy.Home.BottomNavigationBar"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:background="?colorPrimary"

--- a/app/src/main/res/layout/preference_category_header.xml
+++ b/app/src/main/res/layout/preference_category_header.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TextView xmlns:android="http://schemas.android.com/apk/res/android"
+  android:id="@+android:id/title"
+  style="@style/Squanchy.PreferenceListHeader"
+  android:layout_width="match_parent"
+  android:layout_height="wrap_content"
+  android:layout_marginBottom="@dimen/preference_header_margin_vertical" />

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -185,5 +185,6 @@
   <dimen name="first_start_with_no_network_progress_size">48dp</dimen>
 
   <dimen name="match_constraint">0dp</dimen>
+  <dimen name="preference_header_margin_vertical">16dp</dimen>
 
 </resources>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -119,8 +119,10 @@
   <dimen name="about_app_name_text">26sp</dimen>
   <dimen name="about_attribution_label_text">12sp</dimen>
   <dimen name="about_powered_by_margin_top">16dp</dimen>
-  <dimen name="about_squanchy_text">32sp</dimen>
+  <dimen name="about_squanchy_text">48sp</dimen>
   <dimen name="about_squanchy_website_text">12sp</dimen>
+  <dimen name="about_squanchy_website_padding">2dp</dimen>
+  <dimen name="about_squanchy_website_margin_bottom">16dp</dimen>
   <dimen name="about_opensource_margin_bottom">32dp</dimen>
   <dimen name="about_opensource_logo_size">80dp</dimen>
   <dimen name="about_opensource_logo_margin_end">16dp</dimen>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -118,7 +118,8 @@
   <dimen name="about_content_padding_vertical">24dp</dimen>
   <dimen name="about_app_name_text">26sp</dimen>
   <dimen name="about_attribution_label_text">12sp</dimen>
-  <dimen name="about_powered_by_margin_top">16dp</dimen>
+  <dimen name="about_powered_by_margin_top">8dp</dimen>
+  <dimen name="about_powered_by_margin_bottom">16dp</dimen>
   <dimen name="about_squanchy_text">48sp</dimen>
   <dimen name="about_squanchy_website_text">12sp</dimen>
   <dimen name="about_squanchy_website_padding">2dp</dimen>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,4 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE resources [
+  <!ENTITY nbsp "&#160;">
+  <!ENTITY thinsp "&#8201;">
+  ]>
+
 <resources>
 
   <string name="activity_social_feed">@string/social_query</string>
@@ -76,13 +81,14 @@
   <string name="favorites_empty_state_signed_out_cta">SIGN IN</string>
   <string name="favorites_empty_state_signed_in_blurb">You haven’t picked any favorites yet.\n\n1️⃣ Find a talk you like.\n2️⃣ Aim for the big ♥ button.\n3️⃣ That’s it. Really.</string>
   <string name="favorites_achievement_fast_learner"><![CDATA[Achievement Unlocked: <b>The Fast Learner</b>]]></string>
-  <string name="favorites_achievement_persevering"><![CDATA[Achievement Unlocked: <b>The harder you try, the luckier you get.</b> Now give it a rest.]]></string>
+  <string
+    name="favorites_achievement_persevering"><![CDATA[Achievement Unlocked: <b>The harder you try, the luckier you get.</b> Now give it a rest.]]></string>
 
   <string name="about_label">About</string>
   <string name="about_powered_by">is powered by</string>
-  <string name="squanchy" translatable="false">&#8201;Squanchy&#8201;</string>
+  <string name="squanchy" translatable="false">&thinsp;Squanchy&thinsp;</string>
   <string name="squanchy_website" translatable="false">https://squanchy.net</string>
-  <string name="about_opensource_blurb">This&#160;app&#32;is&#160;proudly&#32;open&#160;source&#32;and&#32;any&#32;contribution&#32;is&#160;welcome.</string>
+  <string name="about_opensource_blurb">This&nbsp;app is&nbsp;proudly open&nbsp;source and any contribution is&nbsp;welcome.</string>
   <string name="about_fork_me">Fork me on GitHub</string>
   <string name="about_licenses">Open source licenses</string>
 
@@ -95,7 +101,8 @@
 
   <string name="onboarding_account_label">Sign in</string>
   <string name="onboarding_account_title">Sign in with Google</string>
-  <string name="onboarding_account_blurb">Get&#160;your&#160;favourites&#160;synced&#32;across&#160;devices&#32;in&#160;one&#160;tap&#32;by&#160;signing&#160;in&#32;with&#160;your&#160;Google&#160;account</string>
+  <string name="onboarding_account_blurb">Get&nbsp;your&nbsp;favourites&nbsp;synced across&nbsp;devices in&nbsp;one&nbsp;tap
+    by&nbsp;signing&nbsp;in with&nbsp;your&nbsp;Google&nbsp;account</string>
   <string name="onboarding_account_cta">Sure, let’s!</string>
 
   <string name="routing_sign_in_unexpected_error">Something went very wrong while starting Squanchy, sorry.</string>
@@ -103,7 +110,8 @@
   <string name="first_start_with_no_network_label">Not so fast!</string>
   <string name="first_start_with_no_network_network_connected">Yay, network is back!</string>
   <string name="first_start_with_no_network_title">Not so fast!</string>
-  <string name="first_start_with_no_network_blurb">Unfortunately, the first time you open this app you will need to be connected to the internet.</string>
+  <string
+    name="first_start_with_no_network_blurb">Unfortunately, the first time you open this app you will need to be connected to the internet.</string>
   <string name="first_start_with_no_network_cta">Go ahead, connect to a network. I’ll be waiting.</string>
   <string name="first_start_with_no_network_cancel_button">You know what, nevermind</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -80,9 +80,9 @@
 
   <string name="about_label">About</string>
   <string name="about_powered_by">is powered by</string>
-  <string name="squanchy" translatable="false">Squanchy</string>
+  <string name="squanchy" translatable="false">&#8201;Squanchy&#8201;</string>
   <string name="squanchy_website" translatable="false">https://squanchy.net</string>
-  <string name="about_opensource_blurb">This app is proudly open source and any contribution is welcome.</string>
+  <string name="about_opensource_blurb">This&#160;app&#32;is&#160;proudly&#32;open&#160;source&#32;and&#32;any&#32;contribution&#32;is&#160;welcome.</string>
   <string name="about_fork_me">Fork me on GitHub</string>
   <string name="about_licenses">Open source licenses</string>
 

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -436,7 +436,7 @@
   </style>
 
   <style name="TextAppearance.Squanchy.About.Squanchy" parent="None">
-    <item name="android:textColor">@color/primary_dark_text_blue</item>
+    <item name="android:textColor">@color/primary_dark_azure</item>
     <item name="android:textSize">@dimen/about_squanchy_text</item>
     <item name="fontFamily">@font/title_typeface</item>
   </style>
@@ -448,6 +448,7 @@
 
   <style name="About.SquanchyWebsite" parent="About.BorderlessButton">
     <item name="android:textAppearance">@style/TextAppearance.Squanchy.About.SquanchyWebsite</item>
+    <item name="android:padding">@dimen/about_squanchy_website_padding</item>
   </style>
 
   <style name="TextAppearance.Squanchy.About.SquanchyWebsite" parent="None">

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -387,12 +387,12 @@
   <style name="Settings.Header.User.Name" parent="None">
     <item name="android:maxLines">2</item>
     <item name="android:textAppearance">@style/TextAppearance.Squanchy.Settings.Header.User.Name</item>
+    <item name="fontFamily">@font/title_typeface</item>
   </style>
 
   <style name="TextAppearance.Squanchy.Settings.Header.User.Name" parent="None">
     <item name="android:textColor">?android:textColorPrimary</item>
     <item name="android:textSize">@dimen/settings_header_user_name_text</item>
-    <item name="fontFamily">@font/title_typeface</item>
   </style>
 
   <style name="ThemeOverlay.About.AppBar" parent="ThemeOverlay.AppCompat.Light">
@@ -620,5 +620,15 @@
   </style>
 
   <style name="TextAppearance.Squanchy.FirstStartWithNoNetwork.Cancel" parent="TextAppearance.Squanchy.Button.Colored" />
+
+  <style name="Squanchy.PreferenceListHeader" parent="None">
+    <item name="android:fontFamily">@font/title_typeface</item>
+    <item name="fontFamily">@font/title_typeface</item>
+    <item name="android:textAppearance">@android:style/TextAppearance.Material.Body2</item>
+    <item name="android:textColor">?android:attr/colorAccent</item>
+    <item name="android:paddingStart">?android:attr/listPreferredItemPaddingStart</item>
+    <item name="android:paddingEnd">?android:attr/listPreferredItemPaddingEnd</item>
+    <item name="android:paddingTop">@dimen/preference_header_margin_vertical</item>
+  </style>
 
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -125,12 +125,15 @@
 
   <style name="Search.SectionHeader" parent="TextAppearance.AppCompat.Body1">
     <item name="android:textColor">?android:colorPrimary</item>
+    <item name="android:fontFamily">@font/title_typeface</item>
     <item name="fontFamily">@font/title_typeface</item>
   </style>
 
   <style name="Search.Caption" parent="TextAppearance.AppCompat.Caption">
     <item name="android:maxLines">2</item>
     <item name="android:textColor">?android:textColorSecondary</item>
+    <item name="android:fontFamily">@font/default_typeface_regular</item>
+    <item name="fontFamily">@font/default_typeface_regular</item>
   </style>
 
   <style name="Search.EditText" parent="None">
@@ -139,6 +142,8 @@
     <item name="android:imeOptions">actionSearch</item>
     <item name="android:inputType">text</item>
     <item name="android:maxLines">1</item>
+    <item name="android:fontFamily">@font/default_typeface_medium</item>
+    <item name="fontFamily">@font/default_typeface_medium</item>
   </style>
 
   <style name="Search.GenericItem" parent="None">
@@ -151,6 +156,7 @@
     <item name="android:textColor">?android:textColorSecondary</item>
     <item name="android:textSize">@dimen/search_empty_state_text</item>
     <item name="fontFamily">@font/default_typeface_light</item>
+    <item name="android:fontFamily">@font/default_typeface_light</item>
   </style>
 
   <style name="EventDetails.Header.Speaker.Names" parent="None">

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -58,10 +58,9 @@
     <item name="fontFamily">@font/title_typeface</item>
   </style>
 
-  <style name="TextAppearance.Squanchy.Card.Speaker" parent="None">
-    <item name="android:textColor">?android:textColorSecondary</item>
-    <item name="android:textSize">@dimen/card_speaker</item>
-    <item name="fontFamily">@font/default_typeface_medium</item>
+  <style name="ThemeOverlay.Squanchy.Home.BottomNavigationBar" parent="None">
+    <item name="android:fontFamily">@font/default_typeface_regular</item>
+    <item name="fontFamily">@font/default_typeface_regular</item>
   </style>
 
   <style name="Schedule.Card.Timestamp" parent="None">
@@ -104,6 +103,12 @@
     <item name="android:lineSpacingExtra">@dimen/card_speaker_line_spacing_extra</item>
     <item name="android:lineSpacingMultiplier">1</item>
     <item name="android:textAppearance">@style/TextAppearance.Squanchy.Card.Speaker</item>
+  </style>
+
+  <style name="TextAppearance.Squanchy.Card.Speaker" parent="None">
+    <item name="android:textColor">?android:textColorSecondary</item>
+    <item name="android:textSize">@dimen/card_speaker</item>
+    <item name="fontFamily">@font/default_typeface_medium</item>
   </style>
 
   <style name="Search.Appbar" parent="Widget.Design.AppBarLayout">

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -8,6 +8,8 @@
     <item name="colorControlNormal">@color/white</item>
     <item name="tweetLinkTextColor">@color/tweet_link</item>
     <item name="toolbarStyle">@style/Squanchy.Toolbar</item>
+    <item name="android:fontFamily">@font/default_typeface_regular</item>
+    <item name="fontFamily">@font/default_typeface_regular</item>
     <item name="android:statusBarColor">@color/status_bar</item>
     <item name="android:textColorPrimary">@color/selector_text_color_primary</item>
     <item name="android:textColorPrimaryInverse">@color/text_inverse</item>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -8,8 +8,6 @@
     <item name="colorControlNormal">@color/white</item>
     <item name="tweetLinkTextColor">@color/tweet_link</item>
     <item name="toolbarStyle">@style/Squanchy.Toolbar</item>
-    <item name="android:fontFamily">@font/default_typeface_regular</item>
-    <item name="fontFamily">@font/default_typeface_regular</item>
     <item name="android:statusBarColor">@color/status_bar</item>
     <item name="android:textColorPrimary">@color/selector_text_color_primary</item>
     <item name="android:textColorPrimaryInverse">@color/text_inverse</item>
@@ -108,6 +106,7 @@
 
   <style name="Theme.Squanchy.Settings" parent="Theme.Squanchy.PrimaryStatusBar">
     <item name="colorAccent">?colorPrimary</item>
+    <item name="fontFamily">@font/default_typeface_regular</item>
   </style>
 
   <style name="Theme.Squanchy.About" parent="Theme.Squanchy.MostlyWhite" />

--- a/app/src/main/res/xml/settings_preferences.xml
+++ b/app/src/main/res/xml/settings_preferences.xml
@@ -6,6 +6,7 @@
   <PreferenceCategory
     android:key="@string/account_category_key"
     android:title="@string/account_category_label"
+    android:layout="@layout/preference_category_header"
     android:orderingFromXml="true">
 
     <Preference
@@ -26,6 +27,7 @@
   <PreferenceCategory
     android:key="@string/settings_category_key"
     android:title="@string/settings_and_help_title"
+    android:layout="@layout/preference_category_header"
     android:orderingFromXml="true">
 
     <SwitchPreference
@@ -54,7 +56,8 @@
 
   <PreferenceCategory
     android:key="@string/debug_category_preference_key"
-    android:title="@string/settings_debug_category">
+    android:title="@string/settings_debug_category"
+    android:layout="@layout/preference_category_header">
 
     <Preference
       android:key="@string/open_debug_preference_key"


### PR DESCRIPTION
I have noticed several elements in the UI are not styled correctly in that they don't have the correct typefaces applied to them. This PR fixes it. Also thrown in is a potential NPE fix and some tweaks to the about screen.

 Before | After
 --- | ---
 ![image](https://user-images.githubusercontent.com/153802/31862169-9ed3a3ea-b731-11e7-924c-96c97b28c1a5.png) | ![favourites-after](https://user-images.githubusercontent.com/153802/31862163-94f9fdd8-b731-11e7-97e3-5c249294e5f3.png)
 ![search](https://user-images.githubusercontent.com/153802/31862171-a6d5ae3a-b731-11e7-9505-1737e7377cd8.png) | ![search-after](https://user-images.githubusercontent.com/153802/31862173-ac2d1c60-b731-11e7-9dd1-bcb078ed10da.png)
 ![search-results](https://user-images.githubusercontent.com/153802/31862175-b1a638ac-b731-11e7-8801-faf549f575a2.png) | ![search-results-after](https://user-images.githubusercontent.com/153802/31862177-b61a7466-b731-11e7-84bd-e03d2875a566.png)
 ![settings](https://user-images.githubusercontent.com/153802/31862178-bb3f82ba-b731-11e7-8c39-472304025131.png) | ![settings-after](https://user-images.githubusercontent.com/153802/31862247-9abeb96a-b732-11e7-92b6-62a8b5791413.png)
 ![about-before](https://user-images.githubusercontent.com/153802/31862204-f9eab35e-b731-11e7-9cfc-169494b79ddb.png) | ![about-after](https://user-images.githubusercontent.com/153802/31862193-ce65eb54-b731-11e7-93e6-8fd15b793835.png)
