### PR TITLE
Use separator instead of prefix when joining speakers names

### DIFF
--- a/app/src/main/java/net/squanchy/notification/NotificationCreator.kt
+++ b/app/src/main/java/net/squanchy/notification/NotificationCreator.kt
@@ -158,7 +158,7 @@ class NotificationCreator(private val context: Context) {
     }
 
     private fun getSpeakerNamesFrom(speakers: List<Speaker>): String {
-        val speakerNames = speakers.joinToString(prefix = ", ", transform = { it.name })
+        val speakerNames = speakers.joinToString(separator = ", ", transform = { it.name })
 
         return context.getString(R.string.event_notification_starting_by, speakerNames)
     }


### PR DESCRIPTION
See screenshots:

Before | After | Multiple speakers
--- | --- | --- 
![device-2017-10-25-160442](https://user-images.githubusercontent.com/3942812/32003287-e34274ba-b99e-11e7-9aa1-fa06c20160f9.png) | ![device-2017-10-25-160511](https://user-images.githubusercontent.com/3942812/32003288-e394fece-b99e-11e7-956c-2278ae87d119.png) | ![device-2017-10-25-160712](https://user-images.githubusercontent.com/3942812/32003291-e3cf4bf6-b99e-11e7-946a-3c70272b4d2e.png)
