### PR TITLE
SQ-390/Fix missing reveal on bottom nav

### DIFF
--- a/app/src/main/java/me/eugeniomarletti/renderthread/RenderThreadMethods.java
+++ b/app/src/main/java/me/eugeniomarletti/renderthread/RenderThreadMethods.java
@@ -22,7 +22,7 @@ import timber.log.Timber;
 @SuppressLint("PrivateApi")     // This class wraps the private APIs we rely on
 final class RenderThreadMethods {
 
-    private static final int MAX_SUPPORTED_ANDROID_VERSION = 25;
+    private static final int MAX_SUPPORTED_ANDROID_VERSION = 27;
     private static final int MIN_SUPPORTED_ANDROID_VERSION = 21;
 
     @NonNull

--- a/app/src/main/java/net/squanchy/support/graphics/CircularRevealDrawable.java
+++ b/app/src/main/java/net/squanchy/support/graphics/CircularRevealDrawable.java
@@ -52,7 +52,7 @@ public class CircularRevealDrawable extends ColorDrawable {
         revealDuration = durationMillis;
         pendingTargetColor = newColor;
         startAnimationOnNextDraw = true;
-        setColor(pendingTargetColor);
+        setColor(targetColor);
     }
 
     @Override


### PR DESCRIPTION
After #312 actually broke the circular reveals even more than they were already, I finally had the time to check whether we could make them work on API 26-27.

![](https://media0.giphy.com/media/1iZT3bqPZIfN3flm/giphy.gif)

Closes #390 

![les-circles](https://user-images.githubusercontent.com/153802/32232047-09dd2f70-be4f-11e7-9aca-c170733a7a6b.gif)
