### PR TITLE
Update Detekt

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ buildscript {
 }
 
 plugins {
-    id 'io.gitlab.arturbosch.detekt' version '1.0.0.RC6'
+    id 'io.gitlab.arturbosch.detekt' version '1.0.0.RC6-2'
 }
 
 def teamPropsFile(propsFile) {

--- a/team-props/static-analysis/detekt-config.yml
+++ b/team-props/static-analysis/detekt-config.yml
@@ -16,6 +16,8 @@ test-pattern: # Configure exclusions for test sources
     - 'MaxLineLength'
     - 'LateinitUsage'
     - 'StringLiteralDuplication'
+    - 'SpreadOperator'
+    - 'TooManyFunctions'
 
 build:
   warningThreshold: 1
@@ -51,93 +53,63 @@ output-reports:
   #  - 'PlainOutputReport'
   #  - 'XmlOutputReport'
 
-potential-bugs:
+comments:
   active: true
-  DuplicateCaseInWhenExpression:
+  CommentOverPrivateFunction:
     active: true
-  EqualsAlwaysReturnsTrueOrFalse:
-    active: false
-  EqualsWithHashCodeExist:
+  CommentOverPrivateProperty:
     active: true
-  InvalidLoopCondition:
+  UndocumentedPublicClass:
     active: false
-  WrongEqualsTypeParameter:
-    active: false
-  IteratorHasNextCallsNextMethod:
-    active: false
-  ExplicitGarbageCollectionCall:
-    active: true
-  UnconditionalJumpStatementInLoop:
-    active: false
-  IteratorNotThrowingNoSuchElementException:
-    active: false
-  UnreachableCode:
-    active: true
-  LateinitUsage:
-    active: false
-    excludeAnnotatedProperties: ''
-    ignoreOnClassesPattern: ''
-  UnsafeCallOnNullableType:
-    active: false
-  UnsafeCast:
-    active: false
-  UselessPostfixExpression:
+    searchInNestedClass: true
+    searchInInnerClass: true
+    searchInInnerObject: true
+    searchInInnerInterface: true
+  UndocumentedPublicFunction:
     active: false
 
-performance:
+complexity:
   active: true
-  ForEachOnRange:
+  LongParameterList:
     active: true
-  SpreadOperator:
+    threshold: 5
+    ignoreDefaultParameters: false
+  LongMethod:
     active: true
-  UnnecessaryTemporaryInstantiation:
+    threshold: 20
+  LargeClass:
     active: true
-
-exceptions:
-  active: true
-  ExceptionRaisedInUnexpectedLocation:
+    threshold: 150
+  ComplexInterface:
     active: false
-    methodNames: 'toString,hashCode,equals,finalize'
-  SwallowedException:
-    active: false
-  TooGenericExceptionCaught:
+    threshold: 10
+    includeStaticDeclarations: false
+  ComplexMethod:
     active: true
-    exceptions:
-      - ArrayIndexOutOfBoundsException
-      - Error
-      - Exception
-      - IllegalMonitorStateException
-      - IndexOutOfBoundsException
-    # - InterruptedException
-      - NullPointerException
-      - RuntimeException
-      - Throwable
-  TooGenericExceptionThrown:
+    threshold: 10
+  StringLiteralDuplication:
+    active: false
+    threshold: 2
+    ignoreAnnotation: true
+    excludeStringsWithLessThan5Characters: true
+    ignoreStringsRegex: '$^'
+  MethodOverloading:
+    active: false
+    threshold: 5
+  NestedBlockDepth:
     active: true
-    exceptions:
-      - Error
-      - Exception
-      - NullPointerException
-      - RuntimeException
-      - Throwable
-  InstanceOfCheckForException:
+    threshold: 3
+  TooManyFunctions:
     active: false
-  NotImplementedDeclaration:
-    active: false
-  ThrowingExceptionsWithoutMessageOrCause:
-    active: false
-    exceptions: 'IllegalArgumentException,IllegalStateException,IOException'
-  PrintStackTrace:
-    active: false
-  RethrowCaughtException:
-    active: false
-  ReturnFromFinally:
-    active: false
-  ThrowingExceptionFromFinally:
-    active: false
-  ThrowingExceptionInMain:
-    active: false
-  ThrowingNewInstanceOfSameException:
+    thresholdInFiles: 10
+    thresholdInClasses: 10
+    thresholdInInterfaces: 10
+    thresholdInObjects: 10
+    thresholdInEnums: 10
+  ComplexCondition:
+    active: true
+    threshold: 3
+  LabeledExpression:
     active: false
 
 empty-blocks:
@@ -171,106 +143,155 @@ empty-blocks:
   EmptyWhileBlock:
     active: true
 
-complexity:
+exceptions:
   active: true
-  LongMethod:
-    active: true
-    threshold: 20
-  NestedBlockDepth:
-    active: true
-    threshold: 3
-  LongParameterList:
-    active: true
-    threshold: 5
-  LargeClass:
-    active: true
-    threshold: 150
-  ComplexInterface:
+  SwallowedException:
     active: false
-    threshold: 10
-    includeStaticDeclarations: false
-  ComplexMethod:
+  TooGenericExceptionCaught:
     active: true
-    threshold: 10
-  MethodOverloading:
+    exceptions:
+     - ArrayIndexOutOfBoundsException
+     - Error
+     - Exception
+     - IllegalMonitorStateException
+     - NullPointerException
+     - IndexOutOfBoundsException
+     - RuntimeException
+     - Throwable
+  ExceptionRaisedInUnexpectedLocation:
     active: false
-    threshold: 5
-  TooManyFunctions:
-    active: false
-    threshold: 10
-  ComplexCondition:
+    methodNames: 'toString,hashCode,equals,finalize'
+  TooGenericExceptionThrown:
     active: true
-    threshold: 3
-  LabeledExpression:
+    exceptions:
+     - Error
+     - Exception
+     - NullPointerException
+     - Throwable
+     - RuntimeException
+  NotImplementedDeclaration:
     active: false
-  StringLiteralDuplication:
+  PrintStackTrace:
     active: false
-    threshold: 2
-    ignoreAnnotation: true
-    excludeStringsWithLessThan5Characters: true
-    ignoreStringsRegex: '$^'
+  InstanceOfCheckForException:
+    active: false
+  ThrowingExceptionsWithoutMessageOrCause:
+    active: false
+    exceptions: 'IllegalArgumentException,IllegalStateException,IOException'
+  ReturnFromFinally:
+    active: false
+  ThrowingExceptionFromFinally:
+    active: false
+  ThrowingExceptionInMain:
+    active: false
+  RethrowCaughtException:
+    active: false
+  ThrowingNewInstanceOfSameException:
+    active: false
+  SwallowedException:
+    active: false
 
-code-smell:
+performance:
   active: true
-  FeatureEnvy:
-    threshold: 0.5
-    weight: 0.45
-    base: 0.5
+  ForEachOnRange:
+    active: true
+  SpreadOperator:
+    active: true
+  UnnecessaryTemporaryInstantiation:
+    active: true
+
+potential-bugs:
+  active: true
+  DuplicateCaseInWhenExpression:
+    active: true
+  EqualsAlwaysReturnsTrueOrFalse:
+    active: false
+  EqualsWithHashCodeExist:
+    active: true
+  IteratorNotThrowingNoSuchElementException:
+    active: false
+  IteratorHasNextCallsNextMethod:
+    active: false
+  UselessPostfixExpression:
+    active: false
+  InvalidRange:
+    active: false
+  WrongEqualsTypeParameter:
+    active: false
+  ExplicitGarbageCollectionCall:
+    active: true
+  LateinitUsage:
+    active: false
+    excludeAnnotatedProperties: ""
+    ignoreOnClassesPattern: ""
+  UnconditionalJumpStatementInLoop:
+    active: false
+  UnreachableCode:
+    active: true
+  UnsafeCallOnNullableType:
+    active: false
+  UnsafeCast:
+    active: false
 
 style:
   active: true
+  CollapsibleIfStatements:
+    active: false
   ReturnCount:
     active: false
     max: 2
+    excludedFunctions: "equals"
   ThrowsCount:
     active: true
     max: 2
   NewLineAtEndOfFile:
     active: true
-  OptionalAbstractKeyword:
-    active: true
-  OptionalWhenBraces:
-    active: false
-  CollapsibleIfStatements:
-    active: false
-  EqualsNullCall:
-    active: false
-  ForbiddenComment:
-    active: true
-    values: 'STOPSHIP:'
-  ForbiddenImport:
-    active: false
-    imports: ''
-  PackageDeclarationStyle:
-    active: false
-  LoopWithTooManyJumpStatements:
-    active: false
-    maxJumpCount: 1
-  MethodNameEqualsClassName:
-    active: false
-    ignoreOverriddenFunction: true
-  ModifierOrder:
-    active: true
-  MagicNumber:
-    active: true
-    ignoreNumbers: '-1,0,1,2'
-    ignoreHashCodeFunction: false
-    ignorePropertyDeclaration: false
-    ignoreConstantDeclaration: true
-    ignoreCompanionObjectPropertyDeclaration: true
-    ignoreAnnotation: false
-    ignoreNamedArgument: true
-    ignoreEnums: false
   WildcardImport:
     active: true
     excludeImports: 'kotlinx.android.synthetic.*'
-  SafeCast:
-    active: true
   MaxLineLength:
     active: true
     maxLineLength: 150
     excludePackageStatements: false
     excludeImportStatements: false
+  EqualsNullCall:
+    active: false
+  ForbiddenComment:
+    active: true
+    values: 'STOPSHIP'
+  ForbiddenImport:
+    active: false
+    imports: ''
+  FunctionOnlyReturningConstant:
+    active: false
+    ignoreOverridableFunction: true
+    excludedFunctions: 'describeContents'
+  SpacingBetweenPackageAndImports:
+    active: false
+  LoopWithTooManyJumpStatements:
+    active: false
+    maxJumpCount: 1
+  MemberNameEqualsClassName:
+    active: false
+    ignoreOverriddenFunction: true
+  VariableNaming:
+    active: true
+    variablePattern: '[a-z][a-zA-Z$0-9]*'
+    privateVariablePattern: '(_)?[a-z][A-Za-z0-9]*'
+  VariableMinLength:
+    active: false
+    minimumVariableNameLength: 1
+  VariableMaxLength:
+    active: false
+    maximumVariableNameLength: 64
+  TopLevelPropertyNaming:
+    active: true
+    constantPattern: '[A-Z][_A-Z0-9]*'
+    propertyPattern: '[a-z][A-Za-z\d]*'
+    privatePropertyPattern: '(_)?[a-z][A-Za-z0-9]*'
+  ObjectPropertyNaming:
+    active: true
+    propertyPattern: '[A-Za-z][_A-Za-z0-9]*'
   PackageNaming:
     active: true
     packagePattern: '^[a-z]+(\.[a-z][a-z0-9]*)*$'
@@ -289,24 +310,12 @@ style:
   FunctionMinLength:
     active: false
     minimumFunctionNameLength: 3
-  VariableNaming:
-    active: true
-    variablePattern: '^(_)?[a-z$][a-zA-Z$0-9]*$'
-  ConstantNaming:
-    active: true
-    constantPattern: '^([A-Z_]*|serialVersionUID)$'
-  VariableMaxLength:
-    active: false
-    maximumVariableNameLength: 30
-  VariableMinLength:
-    active: false
-    minimumVariableNameLength: 3
   ForbiddenClassName:
     active: false
     forbiddenName: ''
-  ProtectedMemberInFinalClass:
+  SafeCast:
     active: true
-  SerialVersionUIDInSerializableClass:
+  UnnecessaryAbstractClass:
     active: false
   UnnecessaryParentheses:
     active: false
@@ -314,50 +323,44 @@ style:
     active: false
   UtilityClassWithPublicConstructor:
     active: false
+  OptionalAbstractKeyword:
+    active: true
+  OptionalWhenBraces:
+    active: false
+  OptionalReturnKeyword:
+    active: false
+  OptionalUnit:
+    active: false
+  ProtectedMemberInFinalClass:
+    active: true
+  SerialVersionUIDInSerializableClass:
+    active: false
+  MagicNumber:
+    active: true
+    ignoreNumbers: '-1,0,1,2'
+    ignoreHashCodeFunction: false
+    ignorePropertyDeclaration: false
+    ignoreConstantDeclaration: true
+    ignoreCompanionObjectPropertyDeclaration: true
+    ignoreAnnotation: false
+    ignoreNamedArgument: true
+    ignoreEnums: false
+  ModifierOrder:
+    active: true
   DataClassContainsFunctions:
     active: false
     conversionFunctionPrefix: 'to'
   UseDataClass:
     active: false
-  UnnecessaryAbstractClass:
-    active: false
-  OptionalUnit:
-    active: false
-  OptionalReturnKeyword:
+  UnusedImports:
     active: false
   ExpressionBodySyntax:
-    active: false
-  UnusedImports:
     active: false
   NestedClassesVisibility:
     active: false
   RedundantVisibilityModifierRule:
     active: false
-  FunctionOnlyReturningConstant:
+  MatchingDeclarationName:
     active: false
-    ignoreOverridableFunction: true
-    excludedFunctions: 'describeContents'
-
-comments:
-  active: true
-  CommentOverPrivateFunction:
-    active: true
-  CommentOverPrivateProperty:
-    active: true
-  UndocumentedPublicClass:
+  UntilInsteadOfRangeTo:
     active: false
-    searchInNestedClass: true
-    searchInInnerClass: true
-    searchInInnerObject: true
-    searchInInnerInterface: true
-  UndocumentedPublicFunction:
-    active: false
-
-# *experimental feature*
-# Migration rules can be defined in the same config file or a new one
-migration:
-  active: false
-  imports:
-    # your.package.Class: new.package.or.Class
-    # for example:
-    # io.gitlab.arturbosch.detekt.api.Rule: io.gitlab.arturbosch.detekt.rule.Rule


### PR DESCRIPTION
## Problem

We are on Detekt 1.0.0.RC6 and the latest version is 1.0.0.RC6-2 with some new rules.

## Solution

Update Detekt, and update the ruleset for it (ignore the whole rules file, it's a mess cause everything changed order for like no reason, but it's pretty much all the same)

### Test(s) added 

No

### Paired with 

Nobody