### PR TITLE
Add Detekt and KtLint to pre-commit hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,9 @@ Please note that this app uses some third party services:
 While not all of them are strictly necessary for the app to work (with the exception of Firebase's RTDB), it is currently not possible for the code to work without them.
 We plan on eventually abstracting away the implementations so that they would simply be disabled if there is no API configured, but we haven't done it yet.
 If you need to use Squanchy without some of those implementations, please feel free to make them optional and contribute back to mainline your changes.  
+
+## Git hooks
+
+The project uses Detekt and KtLint to automatically reformat, and then validate, Kotlin code before committing. This is done with a Git `pre-commit` hook, which is automatically installed by Gradle when the `clean` or `assemble` tasks are run. You can also install the hook manually from Gradle by executing the `installGitHooks` task on the root project: `$ ./gradlew installGitHooks`.
+
+If you wish to commit code that is failing this test for whatever reason, you can use the `--no-verify` flag when committing with `git`. Please note that if you don't address the issues before pushing, the CI will fail the build.

--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,7 @@ def teamPropsFile(propsFile) {
 }
 
 apply from: 'dependencies.gradle'
+apply from: teamPropsFile('git-hooks.gradle')
 
 detekt {
     profile('main') {

--- a/team-props/git-hooks.gradle
+++ b/team-props/git-hooks.gradle
@@ -1,0 +1,37 @@
+static def isLinuxOrMacOs() {
+    def osName = System.getProperty('os.name').toLowerCase(Locale.ROOT)
+    return osName.contains('linux') || osName.contains('mac os') || osName.contains('macos')
+}
+
+task copyGitHooks(type: Copy) {
+    description 'Installs the git hooks from team-props/git-hooks.'
+    from("${rootDir}/team-props/git-hooks/") {
+        include '**/*.sh'
+        rename '(.*).sh', '$1'
+    }
+    into "${rootDir}/.git/hooks"
+    onlyIf {
+        return isLinuxOrMacOs()
+    }
+}
+
+task installGitHooks(type: Exec) {
+    description 'Copies the resource directory to the target directory.'
+    workingDir rootDir
+    commandLine 'chmod'
+    args '-R', '+x', '.git/hooks/'
+    dependsOn copyGitHooks
+    onlyIf {
+        def preCommitHook = new File("${rootDir}/.git/hooks/pre-commit")
+        return isLinuxOrMacOs() && !preCommitHook.canExecute()
+    }
+    doLast {
+        logger.info('Git hook installed successfully.')
+    }
+}
+
+afterEvaluate {
+    // We install the hook at the first occasion
+    tasks['clean'].dependsOn installGitHooks
+    tasks['assemble'].dependsOn installGitHooks
+}

--- a/team-props/git-hooks.gradle
+++ b/team-props/git-hooks.gradle
@@ -4,7 +4,8 @@ static def isLinuxOrMacOs() {
 }
 
 task copyGitHooks(type: Copy) {
-    description 'Installs the git hooks from team-props/git-hooks.'
+    description 'Copies the git hooks from team-props/git-hooks to the .git folder.'
+    group 'git hooks'
     from("${rootDir}/team-props/git-hooks/") {
         include '**/*.sh'
         rename '(.*).sh', '$1'
@@ -16,7 +17,8 @@ task copyGitHooks(type: Copy) {
 }
 
 task installGitHooks(type: Exec) {
-    description 'Copies the resource directory to the target directory.'
+    description 'Installs the pre-commit git hooks from team-props/git-hooks.'
+    group 'git hooks'
     workingDir rootDir
     commandLine 'chmod'
     args '-R', '+x', '.git/hooks/'

--- a/team-props/git-hooks/pre-commit.sh
+++ b/team-props/git-hooks/pre-commit.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+echo "Running static analysis..."
+
+# Format code using KtLint
+./gradlew app:ktlintFormat app:detektCheck app:ktlint --daemon
+
+status=$?
+
+if [ "$status" = 0 ] ; then
+    echo "Static analysis found no problems."
+    exit 0
+else
+    echo 1>&2 "Static analysis found style violations it could not fix."
+    exit 1
+fi


### PR DESCRIPTION
## Problem

We often forget to check the code style before committing, and the CI takes a long time to verify it — plus it has no convenient way to find out what the errors were.

## Solution

Create a Git hook for `pre-commit` that will abort the commit if ktLint and Detekt find any issues. It also applies `ktLintFormat` to make sure the code is properly formatted before committing.

### Test(s) added 

No, but extensively smoke-tested

### Paired with 

Nobody