### PR TITLE
Use correct timezone in schedule

### DIFF
--- a/app/src/main/java/net/squanchy/schedule/ScheduleService.kt
+++ b/app/src/main/java/net/squanchy/schedule/ScheduleService.kt
@@ -36,7 +36,7 @@ class FirestoreScheduleService(
         return Observable.combineLatest(dbService.scheduleView(), dbService.timezone(), combineInAPair())
             .map { pagesAndTimeZone ->
                 val (schedulePages, timeZone) = pagesAndTimeZone
-                
+
                 schedulePages.map { schedulePage ->
                     SchedulePage(
                             schedulePage.day.id,

--- a/app/src/main/java/net/squanchy/schedule/ScheduleService.kt
+++ b/app/src/main/java/net/squanchy/schedule/ScheduleService.kt
@@ -35,8 +35,8 @@ class FirestoreScheduleService(
     override fun schedule(onlyFavorites: Boolean): Observable<Schedule> {
         return Observable.combineLatest(dbService.scheduleView(), dbService.timezone(), combineInAPair())
             .map { pagesAndTimeZone ->
-                val schedulePages = pagesAndTimeZone.first
-                val timeZone = pagesAndTimeZone.second
+                val (schedulePages, timeZone) = pagesAndTimeZone
+                
                 schedulePages.map { schedulePage ->
                     SchedulePage(
                             schedulePage.day.id,

--- a/app/src/main/java/net/squanchy/service/firestore/FirestoreDbService.kt
+++ b/app/src/main/java/net/squanchy/service/firestore/FirestoreDbService.kt
@@ -2,8 +2,10 @@ package net.squanchy.service.firestore
 
 import com.google.firebase.firestore.FirebaseFirestore
 import io.reactivex.Observable
+import net.squanchy.service.firestore.model.conferenceinfo.FirestoreVenue
 import net.squanchy.service.firestore.model.schedule.FirestoreSchedulePage
 import net.squanchy.service.firestore.model.twitter.FirestoreTweet
+import org.joda.time.DateTimeZone
 
 // TODO
 // val onCurrentThread = Executors.newSingleThreadExecutor { Thread.currentThread() }
@@ -39,6 +41,26 @@ class FirestoreDbService(private val db: FirebaseFirestore) {
                         return@addSnapshotListener
                     }
                     subscriber.onNext(snapshot.documents.map { it.toObject(FirestoreTweet::class.java) })
+                }
+
+            subscriber.setCancellable { registration.remove() }
+        }
+    }
+
+    fun timezone(): Observable<DateTimeZone> = venueInfo()
+        .map { it.timezone }
+        .map { DateTimeZone.forID(it) }
+
+    fun venueInfo(): Observable<FirestoreVenue> {
+        return Observable.create { subscriber ->
+            val registration = db.collection("conference_info")
+                .document("venue")
+                .addSnapshotListener { snapshot, exception ->
+                    if (exception != null && subscriber.isDisposed.not()) {
+                        subscriber.onError(exception)
+                        return@addSnapshotListener
+                    }
+                    subscriber.onNext(snapshot.toObject(FirestoreVenue::class.java) )
                 }
 
             subscriber.setCancellable { registration.remove() }

--- a/app/src/main/java/net/squanchy/service/firestore/model/conferenceinfo/FirestoreConferenceInfo.kt
+++ b/app/src/main/java/net/squanchy/service/firestore/model/conferenceinfo/FirestoreConferenceInfo.kt
@@ -1,0 +1,13 @@
+package net.squanchy.service.firestore.model.conferenceinfo
+
+import com.google.firebase.firestore.GeoPoint
+
+class FirestoreVenue {
+
+    lateinit var name: String
+    lateinit var address: String
+    lateinit var latLon: GeoPoint
+    lateinit var description: String
+    lateinit var mapUrl: String
+    lateinit var timezone: String
+}


### PR DESCRIPTION
## Problem

The schedule doesn't have the timezone info yet so all `LocalDateTime`s are treated as being on UTC.

## Solution

Obtain the timezone from the venue info node and use it when creating the events.

### Test(s) added 

Nope

### Paired with 

Nobody