### PR TITLE
Fix a bug in the Kotlin conversion

### DIFF
--- a/app/src/main/java/net/squanchy/home/HomeActivity.kt
+++ b/app/src/main/java/net/squanchy/home/HomeActivity.kt
@@ -79,7 +79,7 @@ class HomeActivity : AppCompatActivity() {
 
     private fun setupBottomNavigation(bottomNavigationView: InterceptingBottomNavigationView) {
         bottomNavigationView.disableShiftMode()
-        bottomNavigationView.setRevealDurationMillis(pageFadeDurationMillis)
+        bottomNavigationView.revealDurationMillis = pageFadeDurationMillis
 
         bottomNavigationView.setOnNavigationItemSelectedListener { item ->
             when (item.itemId) {
@@ -118,7 +118,7 @@ class HomeActivity : AppCompatActivity() {
 
         val theme = getThemeFor(section)
         animateStatusBarColorTo(getColorFromTheme(theme, android.R.attr.statusBarColor))
-        bottomNavigationView.setColorProvider { getColorFromTheme(theme, android.support.design.R.attr.colorPrimary) }
+        bottomNavigationView.colorProvider = { getColorFromTheme(theme, android.support.design.R.attr.colorPrimary) }
 
         currentSection = section
 

--- a/app/src/main/java/net/squanchy/support/widget/InterceptingBottomNavigationView.kt
+++ b/app/src/main/java/net/squanchy/support/widget/InterceptingBottomNavigationView.kt
@@ -22,7 +22,7 @@ class InterceptingBottomNavigationView @JvmOverloads constructor(
 
     private var lastUpEvent: MotionEvent? = null
     private var listener: BottomNavigationView.OnNavigationItemSelectedListener? = null
-    private var colorProvider: ColorProvider? = null
+    var colorProvider: (() -> Int)? = null
 
     var revealDurationMillis: Int
 
@@ -41,7 +41,7 @@ class InterceptingBottomNavigationView @JvmOverloads constructor(
         }
 
         if (itemSelected && colorProvider != null) {
-            startCircularReveal(colorProvider!!.selectedItemColor, menuItem)
+            startCircularReveal(colorProvider!!(), menuItem)
         }
 
         return itemSelected
@@ -125,20 +125,10 @@ class InterceptingBottomNavigationView @JvmOverloads constructor(
         return super.onInterceptTouchEvent(ev)
     }
 
-    fun setColorProvider(colorProvider: ColorProvider?) {
-        this.colorProvider = colorProvider
-    }
-
     // This is a hacky solution to BottomNavigationView's lack of APIs :(
     @SuppressLint("RestrictedApi")
     fun selectItemAt(@IntRange(from = 0) position: Int) {
         menu.getItem(position).isChecked = true
         bottomNavigationMenuView.updateMenuView()
-    }
-
-    interface ColorProvider {
-
-        @get:ColorInt
-        val selectedItemColor: Int
     }
 }


### PR DESCRIPTION
## Problem

After merging a pull request from a branch that was not up to date, something broke because of some restrictions that only apply to Kotlin (inability to use a lambda for a Kotlin interface)

## Solution

Make the interface a function property

### Test(s) added 

None

### Paired with 
Nobody
