### PR TITLE
SQ-288/Scroll to next event

### DIFF
--- a/app/src/debug/java/net/squanchy/support/injection/CurrentTimeModule.kt
+++ b/app/src/debug/java/net/squanchy/support/injection/CurrentTimeModule.kt
@@ -1,0 +1,13 @@
+package net.squanchy.support.injection
+
+import dagger.Module
+import dagger.Provides
+import net.squanchy.support.system.CurrentTime
+import net.squanchy.support.system.DebugCurrentTime
+
+@Module
+class CurrentTimeModule {
+
+    @Provides
+    internal fun provideCurrentTime(): CurrentTime = DebugCurrentTime()
+}

--- a/app/src/debug/java/net/squanchy/support/system/DebugCurrentTime.kt
+++ b/app/src/debug/java/net/squanchy/support/system/DebugCurrentTime.kt
@@ -1,0 +1,10 @@
+package net.squanchy.support.system
+
+import org.joda.time.DateTime
+
+class DebugCurrentTime : CurrentTime {
+
+    private val mockTime = DateTime.parse("2017-04-06T10:00:00.000+02:00")
+
+    override fun currentDateTime(): DateTime = mockTime
+}

--- a/app/src/main/java/net/squanchy/favorites/view/FavoritesAdapter.kt
+++ b/app/src/main/java/net/squanchy/favorites/view/FavoritesAdapter.kt
@@ -12,6 +12,7 @@ import net.squanchy.schedule.domain.view.SchedulePage
 import net.squanchy.schedule.view.EventItemView
 import net.squanchy.schedule.view.EventViewHolder
 import net.squanchy.search.view.HeaderViewHolder
+import org.joda.time.DateTimeZone
 
 import org.joda.time.LocalDateTime
 
@@ -25,7 +26,7 @@ internal class FavoritesAdapter(context: Context?) : RecyclerView.Adapter<Recycl
 
     private val layoutInflater = LayoutInflater.from(context)
 
-    private var schedule = Schedule.create(emptyList())
+    private var schedule = Schedule.create(emptyList(), DateTimeZone.UTC)
 
     private var listener: ((Event) -> Unit)? = null
 

--- a/app/src/main/java/net/squanchy/schedule/ScheduleComponent.kt
+++ b/app/src/main/java/net/squanchy/schedule/ScheduleComponent.kt
@@ -9,9 +9,11 @@ import net.squanchy.injection.ApplicationComponent
 import net.squanchy.injection.applicationComponent
 import net.squanchy.navigation.NavigationModule
 import net.squanchy.navigation.Navigator
+import net.squanchy.support.injection.CurrentTimeModule
+import net.squanchy.support.system.CurrentTime
 
 @ActivityLifecycle
-@Component(modules = [ScheduleModule::class, NavigationModule::class], dependencies = [ApplicationComponent::class])
+@Component(modules = [ScheduleModule::class, NavigationModule::class, CurrentTimeModule::class], dependencies = [ApplicationComponent::class])
 internal interface ScheduleComponent {
 
     fun service(): ScheduleService
@@ -19,6 +21,8 @@ internal interface ScheduleComponent {
     fun navigator(): Navigator
 
     fun analytics(): Analytics
+
+    fun currentTime(): CurrentTime
 }
 
 internal fun scheduleComponent(activity: AppCompatActivity): ScheduleComponent = DaggerScheduleComponent.builder()
@@ -26,4 +30,5 @@ internal fun scheduleComponent(activity: AppCompatActivity): ScheduleComponent =
     .scheduleModule(ScheduleModule())
     .navigationModule(NavigationModule())
     .activityContextModule(ActivityContextModule(activity))
+    .currentTimeModule(CurrentTimeModule())
     .build()

--- a/app/src/main/java/net/squanchy/schedule/SchedulePageView.kt
+++ b/app/src/main/java/net/squanchy/schedule/SchedulePageView.kt
@@ -149,28 +149,31 @@ class SchedulePageView @JvmOverloads constructor(
                 startDateTime.isAfter(currentDateTime)
             }
 
-    private inner class ScrollingOnTabSelectedListener constructor(
+    private interface OnTabSelectedListener : TabLayout.OnTabSelectedListener {
+
+        override fun onTabReselected(tab: TabLayout.Tab) {}
+        override fun onTabUnselected(tab: TabLayout.Tab) {}
+        override fun onTabSelected(tab: TabLayout.Tab) {}
+    }
+
+    private inner class ScrollingOnTabSelectedListener(
             private val schedule: Schedule,
             private val viewPagerAdapter: ScheduleViewPagerAdapter
     ) : OnTabSelectedListener {
+
         override fun onTabReselected(tab: TabLayout.Tab) {
             val page = schedule.pages[tab.position]
             findNextEventForPage(page)?.let { viewPagerAdapter.refresh(tab.position, it) }
         }
     }
 
-    private class TrackingOnTabSelectedListener constructor(
+    private class TrackingOnTabSelectedListener(
             private val analytics: Analytics,
             private val viewPagerAdapter: ScheduleViewPagerAdapter
     ) : OnTabSelectedListener {
+
         override fun onTabSelected(tab: TabLayout.Tab) {
             analytics.trackItemSelected(ContentType.SCHEDULE_DAY, viewPagerAdapter.getPageDayId(tab.position))
         }
-    }
-
-    private interface OnTabSelectedListener : TabLayout.OnTabSelectedListener {
-        override fun onTabReselected(tab: TabLayout.Tab) {}
-        override fun onTabUnselected(tab: TabLayout.Tab) {}
-        override fun onTabSelected(tab: TabLayout.Tab) {}
     }
 }

--- a/app/src/main/java/net/squanchy/schedule/SchedulePageView.kt
+++ b/app/src/main/java/net/squanchy/schedule/SchedulePageView.kt
@@ -129,7 +129,7 @@ class SchedulePageView @JvmOverloads constructor(
         val todayPageIndex = schedule.findTodayIndexOrDefault(currentTime)
         viewpager.setCurrentItem(todayPageIndex, false)
 
-        tabstrip.addOnTabSelectedListener(ScrollingOnTabSelectedListener(schedule, viewPagerAdapter))
+        tabstrip.addOnTabSelectedListener(ScrollingOnTabSelectedListener(schedule, viewPagerAdapter, currentTime))
         progressbar.visibility = View.GONE
     }
 
@@ -140,9 +140,10 @@ class SchedulePageView @JvmOverloads constructor(
         override fun onTabSelected(tab: TabLayout.Tab) {}
     }
 
-    private inner class ScrollingOnTabSelectedListener(
+    private class ScrollingOnTabSelectedListener(
             private val schedule: Schedule,
-            private val viewPagerAdapter: ScheduleViewPagerAdapter
+            private val viewPagerAdapter: ScheduleViewPagerAdapter,
+            private val currentTime: CurrentTime
     ) : OnTabSelectedListener {
 
         override fun onTabReselected(tab: TabLayout.Tab) {

--- a/app/src/main/java/net/squanchy/schedule/SchedulePageView.kt
+++ b/app/src/main/java/net/squanchy/schedule/SchedulePageView.kt
@@ -143,8 +143,10 @@ class SchedulePageView @JvmOverloads constructor(
     private fun findNextEventForPage(page: SchedulePage) =
         page
             .events
-            .firstOrNull {
-                it.startTime.toDateTime(it.timeZone).isAfter(currentTime.currentLocalDateTime().toDateTime(it.timeZone))
+            .firstOrNull { event ->
+                val startDateTime = event.startTime.toDateTime(event.timeZone)
+                val currentDateTime = currentTime.currentLocalDateTime().toDateTime(event.timeZone)
+                startDateTime.isAfter(currentDateTime)
             }
 
     private inner class ScrollingOnTabSelectedListener constructor(

--- a/app/src/main/java/net/squanchy/schedule/SchedulePageView.kt
+++ b/app/src/main/java/net/squanchy/schedule/SchedulePageView.kt
@@ -16,11 +16,13 @@ import net.squanchy.home.Loadable
 import net.squanchy.navigation.Navigator
 import net.squanchy.schedule.domain.view.Event
 import net.squanchy.schedule.domain.view.Schedule
+import net.squanchy.schedule.domain.view.SchedulePage
 import net.squanchy.schedule.view.ScheduleViewPagerAdapter
 import net.squanchy.support.font.applyTypeface
 import net.squanchy.support.font.getFontFor
 import net.squanchy.support.font.hasTypefaceSpan
 import net.squanchy.support.unwrapToActivityContext
+import org.joda.time.LocalDateTime
 import timber.log.Timber
 
 @Suppress("UNUSED_ANONYMOUS_PARAMETER")
@@ -121,7 +123,16 @@ class SchedulePageView @JvmOverloads constructor(
 
     fun updateWith(schedule: Schedule, onEventClicked: (Event) -> Unit) {
         viewPagerAdapter.updateWith(schedule.pages, onEventClicked)
+
+        viewpager.setCurrentItem(findTodayIndexOrDefault(schedule.pages), false)
+
         progressbar.visibility = View.GONE
+    }
+
+    private fun findTodayIndexOrDefault(pages: List<SchedulePage>): Int {
+        val now = LocalDateTime.now()
+        return pages.firstOrNull { it.date.toLocalDate().isEqual(now.toLocalDate()) }
+            ?.let (pages::indexOf) ?: 0
     }
 
     private class TrackingOnTabSelectedListener constructor(

--- a/app/src/main/java/net/squanchy/schedule/ScheduleService.kt
+++ b/app/src/main/java/net/squanchy/schedule/ScheduleService.kt
@@ -1,7 +1,7 @@
 package net.squanchy.schedule
 
 import io.reactivex.Observable
-import io.reactivex.functions.BiFunction
+import io.reactivex.functions.Function3
 import io.reactivex.schedulers.Schedulers
 import net.squanchy.schedule.domain.view.Event
 import net.squanchy.schedule.domain.view.Schedule
@@ -10,9 +10,13 @@ import net.squanchy.service.firebase.FirebaseAuthService
 import net.squanchy.service.firebase.FirebaseDbService
 import net.squanchy.service.firebase.model.FirebaseDay
 import net.squanchy.service.firebase.model.FirebaseDays
+import net.squanchy.service.firebase.model.FirebaseVenue
 import net.squanchy.service.repository.EventRepository
+import org.joda.time.DateTimeZone
 import org.joda.time.LocalDateTime
 import org.joda.time.format.DateTimeFormat
+
+private val dateFormatter = DateTimeFormat.forPattern("yyyy-MM-dd")
 
 class ScheduleService internal constructor(
         private val dbService: FirebaseDbService,
@@ -29,19 +33,20 @@ class ScheduleService internal constructor(
                 .map { it.groupBy { it.dayId } }
 
             eventsObservable
-                .withLatestFrom(daysObservable, combineEventsById())
+                .withLatestFrom(daysObservable, dbService.venueInfo(), combineEventsById())
                 .subscribeOn(Schedulers.io())
         }
     }
 
-    private fun combineEventsById(): BiFunction<Map<String, List<Event>>, FirebaseDays, Schedule> {
-        return BiFunction { eventsMap, (days) ->
+    private fun combineEventsById(): Function3<Map<String, List<Event>>, FirebaseDays, FirebaseVenue, Schedule> {
+        return Function3 { eventsMap, (days), venue ->
             val pages = eventsMap.keys
                 .mapNotNull(findDayById(days!!))
                 .map(toSchedulePage(eventsMap))
                 .sortedBy { it.date }
 
-            Schedule.create(pages)
+            val timezone = DateTimeZone.forID(venue.timezone)
+            Schedule.create(pages, timezone)
         }
     }
 
@@ -55,7 +60,7 @@ class ScheduleService internal constructor(
 
     private fun toSchedulePage(eventsMap: Map<String, List<Event>>): (FirebaseDay) -> SchedulePage {
         return { (id, date) ->
-            val parsedDate = LocalDateTime.parse(date!!, DATE_FORMATTER)
+            val parsedDate = LocalDateTime.parse(date!!, dateFormatter)
             val events = (eventsMap[id!!] ?: emptyList()).sortedBy { it.startTime }
             SchedulePage.create(id, parsedDate, events)
         }
@@ -64,10 +69,5 @@ class ScheduleService internal constructor(
     fun currentUserIsSignedIn(): Observable<Boolean> {
         return authService.currentUser()
             .map { optionalUser -> optionalUser.map { user -> !user.isAnonymous }.or(false) }
-    }
-
-    companion object {
-
-        private val DATE_FORMATTER = DateTimeFormat.forPattern("yyyy-MM-dd")
     }
 }

--- a/app/src/main/java/net/squanchy/schedule/domain/view/Schedule.kt
+++ b/app/src/main/java/net/squanchy/schedule/domain/view/Schedule.kt
@@ -18,10 +18,10 @@ data class Schedule(val pages: List<SchedulePage>, val timezone: DateTimeZone) {
         fun create(pages: List<SchedulePage>, timezone: DateTimeZone) = Schedule(pages, timezone)
     }
 
-    fun findTodayIndexOrDefault(currentTime: CurrentTime) =
-        pages
+    fun findTodayIndexOrDefault(currentTime: CurrentTime): Int {
+        val now = currentTime.currentDateTime().withZone(timezone)
+        return pages
             .indexOfFirst { page ->
-                val now = currentTime.currentDateTime().toDateTime(timezone)
                 page.date.toLocalDate().isEqual(now.toLocalDate())
             }
             .let {
@@ -30,6 +30,7 @@ data class Schedule(val pages: List<SchedulePage>, val timezone: DateTimeZone) {
                     else -> it
                 }
             }
+    }
 
     fun findNextEventForPage(page: SchedulePage, currentTime: CurrentTime) =
         page.events

--- a/app/src/main/java/net/squanchy/schedule/domain/view/Schedule.kt
+++ b/app/src/main/java/net/squanchy/schedule/domain/view/Schedule.kt
@@ -1,5 +1,6 @@
 package net.squanchy.schedule.domain.view
 
+import net.squanchy.support.system.CurrentTime
 import org.joda.time.DateTimeZone
 
 data class Schedule(val pages: List<SchedulePage>, val timezone: DateTimeZone) {
@@ -11,4 +12,26 @@ data class Schedule(val pages: List<SchedulePage>, val timezone: DateTimeZone) {
 
         fun create(pages: List<SchedulePage>, timezone: DateTimeZone) = Schedule(pages, timezone)
     }
+
+    fun findTodayIndexOrDefault(currentTime: CurrentTime) =
+        pages
+            .indexOfFirst { page ->
+                val now = currentTime.currentDateTime().toDateTime(timezone)
+                page.date.toLocalDate().isEqual(now.toLocalDate())
+            }
+            .let {
+                when (it) {
+                    -1 -> 0 // default to the first page
+                    else -> it
+                }
+            }
+
+    fun findNextEventForPage(page: SchedulePage, currentTime: CurrentTime) =
+        page
+            .events
+            .firstOrNull { event ->
+                val startDateTime = event.startTime.toDateTime().withZone(event.timeZone)
+                val currentDateTime = currentTime.currentDateTime().toDateTime().withZone(event.timeZone)
+                startDateTime.isAfter(currentDateTime)
+            }
 }

--- a/app/src/main/java/net/squanchy/schedule/domain/view/Schedule.kt
+++ b/app/src/main/java/net/squanchy/schedule/domain/view/Schedule.kt
@@ -3,6 +3,9 @@ package net.squanchy.schedule.domain.view
 import net.squanchy.support.system.CurrentTime
 import org.joda.time.DateTimeZone
 
+private const val NOT_FOUND_INDEX = -1
+private const val FIRST_PAGE_INDEX = 0
+
 data class Schedule(val pages: List<SchedulePage>, val timezone: DateTimeZone) {
 
     val isEmpty: Boolean
@@ -21,7 +24,7 @@ data class Schedule(val pages: List<SchedulePage>, val timezone: DateTimeZone) {
             }
             .let {
                 when (it) {
-                    -1 -> 0 // default to the first page
+                    NOT_FOUND_INDEX -> FIRST_PAGE_INDEX
                     else -> it
                 }
             }

--- a/app/src/main/java/net/squanchy/schedule/domain/view/Schedule.kt
+++ b/app/src/main/java/net/squanchy/schedule/domain/view/Schedule.kt
@@ -1,12 +1,14 @@
 package net.squanchy.schedule.domain.view
 
-data class Schedule(val pages: List<SchedulePage>) {
+import org.joda.time.DateTimeZone
+
+data class Schedule(val pages: List<SchedulePage>, val timezone: DateTimeZone) {
 
     val isEmpty: Boolean
         get() = pages.isEmpty()
 
     companion object {
 
-        fun create(pages: List<SchedulePage>) = Schedule(pages)
+        fun create(pages: List<SchedulePage>, timezone: DateTimeZone) = Schedule(pages, timezone)
     }
 }

--- a/app/src/main/java/net/squanchy/schedule/view/ScheduleDayPageView.kt
+++ b/app/src/main/java/net/squanchy/schedule/view/ScheduleDayPageView.kt
@@ -5,11 +5,9 @@ import android.support.v7.util.DiffUtil
 import android.support.v7.widget.LinearLayoutManager
 import android.support.v7.widget.RecyclerView
 import android.util.AttributeSet
-
 import net.squanchy.R
 import net.squanchy.schedule.domain.view.Event
 import net.squanchy.support.view.CardSpacingItemDecorator
-import org.joda.time.LocalDateTime
 
 class ScheduleDayPageView @JvmOverloads constructor(
         context: Context,
@@ -32,20 +30,13 @@ class ScheduleDayPageView @JvmOverloads constructor(
         addItemDecoration(CardSpacingItemDecorator(horizontalSpacing, verticalSpacing))
     }
 
-    fun updateWith(newData: List<Event>, listener: (Event) -> Unit) {
+    fun updateWith(newData: List<Event>, initialEvent: Event?, listener: (Event) -> Unit) {
         val callback = EventsDiffCallback(adapter.events, newData)
         val diffResult = DiffUtil.calculateDiff(callback, true) // TODO move off the UI thread
         adapter.updateWith(newData, listener)
         diffResult.dispatchUpdatesTo(adapter)
 
-        val backThen = LocalDateTime.now()
-        adapter.events
-            .firstOrNull {
-                it.startTime.toDateTime(it.timeZone).isAfter(backThen.toDateTime(it.timeZone))
-            }
-            ?.let {
-                scrollToPosition(adapter.events.indexOf(it))
-            }
+        initialEvent?.let { scrollToPosition(adapter.events.indexOf(it)) }
     }
 
     private class EventsDiffCallback(

--- a/app/src/main/java/net/squanchy/schedule/view/ScheduleDayPageView.kt
+++ b/app/src/main/java/net/squanchy/schedule/view/ScheduleDayPageView.kt
@@ -1,15 +1,15 @@
 package net.squanchy.schedule.view
 
 import android.content.Context
+import android.graphics.PointF
 import android.support.v7.util.DiffUtil
 import android.support.v7.widget.LinearLayoutManager
+import android.support.v7.widget.LinearSmoothScroller
 import android.support.v7.widget.RecyclerView
 import android.util.AttributeSet
 import net.squanchy.R
 import net.squanchy.schedule.domain.view.Event
 import net.squanchy.support.view.CardSpacingItemDecorator
-import android.graphics.PointF
-import android.support.v7.widget.LinearSmoothScroller
 
 class ScheduleDayPageView @JvmOverloads constructor(
         context: Context,

--- a/app/src/main/java/net/squanchy/schedule/view/ScheduleDayPageView.kt
+++ b/app/src/main/java/net/squanchy/schedule/view/ScheduleDayPageView.kt
@@ -1,7 +1,6 @@
 package net.squanchy.schedule.view
 
 import android.content.Context
-import android.graphics.PointF
 import android.support.v7.util.DiffUtil
 import android.support.v7.widget.LinearLayoutManager
 import android.support.v7.widget.LinearSmoothScroller
@@ -56,20 +55,15 @@ class ScheduleDayPageView @JvmOverloads constructor(
 
         override fun areContentsTheSame(oldItemPosition: Int, newItemPosition: Int) = oldEvents[oldItemPosition] == newEvents[newItemPosition]
     }
-}
 
-private class SnappingLinearLayoutManager(context: Context) : LinearLayoutManager(context) {
+    private class SnappingLinearLayoutManager(context: Context) : LinearLayoutManager(context) {
 
-    override fun smoothScrollToPosition(recyclerView: RecyclerView, state: RecyclerView.State?, position: Int) {
-        val smoothScroller = TopSnappedSmoothScroller(this, recyclerView.context)
-        smoothScroller.targetPosition = position
-        startSmoothScroll(smoothScroller)
+        override fun smoothScrollToPosition(recyclerView: RecyclerView, state: RecyclerView.State?, position: Int) {
+            val smoothScroller = object : LinearSmoothScroller(recyclerView.context) {
+                override fun getVerticalSnapPreference() = SNAP_TO_START
+            }
+            smoothScroller.targetPosition = position
+            startSmoothScroll(smoothScroller)
+        }
     }
-}
-
-private class TopSnappedSmoothScroller(private val layoutManager: SnappingLinearLayoutManager, context: Context) : LinearSmoothScroller(context) {
-    override fun computeScrollVectorForPosition(targetPosition: Int): PointF? =
-        layoutManager.computeScrollVectorForPosition(targetPosition)
-
-    override fun getVerticalSnapPreference() = SNAP_TO_START
 }

--- a/app/src/main/java/net/squanchy/schedule/view/ScheduleDayPageView.kt
+++ b/app/src/main/java/net/squanchy/schedule/view/ScheduleDayPageView.kt
@@ -9,6 +9,7 @@ import android.util.AttributeSet
 import net.squanchy.R
 import net.squanchy.schedule.domain.view.Event
 import net.squanchy.support.view.CardSpacingItemDecorator
+import org.joda.time.LocalDateTime
 
 class ScheduleDayPageView @JvmOverloads constructor(
         context: Context,
@@ -36,6 +37,15 @@ class ScheduleDayPageView @JvmOverloads constructor(
         val diffResult = DiffUtil.calculateDiff(callback, true) // TODO move off the UI thread
         adapter.updateWith(newData, listener)
         diffResult.dispatchUpdatesTo(adapter)
+
+        val backThen = LocalDateTime.now()
+        adapter.events
+            .firstOrNull {
+                it.startTime.toDateTime(it.timeZone).isAfter(backThen.toDateTime(it.timeZone))
+            }
+            ?.let {
+                scrollToPosition(adapter.events.indexOf(it))
+            }
     }
 
     private class EventsDiffCallback(

--- a/app/src/main/java/net/squanchy/schedule/view/ScheduleViewPagerAdapter.kt
+++ b/app/src/main/java/net/squanchy/schedule/view/ScheduleViewPagerAdapter.kt
@@ -15,9 +15,11 @@ class ScheduleViewPagerAdapter(private val context: Context) : ViewPagerAdapter<
     private lateinit var listener: (Event) -> Unit
 
     private var pages = emptyList<SchedulePage>()
+    private var initialEventForPage = emptyList<Event?>()
 
-    fun updateWith(pages: List<SchedulePage>, listener: (Event) -> Unit) {
+    fun updateWith(pages: List<SchedulePage>, initialEventForPage: List<Event?>, listener: (Event) -> Unit) {
         this.pages = pages
+        this.initialEventForPage = initialEventForPage
         this.listener = listener
         notifyDataSetChanged()
     }
@@ -31,7 +33,8 @@ class ScheduleViewPagerAdapter(private val context: Context) : ViewPagerAdapter<
 
     override fun bindView(view: ScheduleDayPageView, position: Int) {
         val events = pages[position].events
-        view.updateWith(events, listener)
+        val initialEvent = initialEventForPage[position]
+        view.updateWith(events, initialEvent, listener)
     }
 
     override fun getPageTitle(position: Int): CharSequence? {

--- a/app/src/main/java/net/squanchy/schedule/view/ScheduleViewPagerAdapter.kt
+++ b/app/src/main/java/net/squanchy/schedule/view/ScheduleViewPagerAdapter.kt
@@ -15,12 +15,14 @@ class ScheduleViewPagerAdapter(private val context: Context) : ViewPagerAdapter<
     private lateinit var listener: (Event) -> Unit
 
     private var pages = emptyList<SchedulePage>()
-    private var initialEventForPage = emptyList<Event?>()
+    private var initialEventForPage = emptyArray<Event?>()
+    private var triggerScrollForPage = emptyArray<((Event) -> Unit)?>()
 
-    fun updateWith(pages: List<SchedulePage>, initialEventForPage: List<Event?>, listener: (Event) -> Unit) {
+    fun updateWith(pages: List<SchedulePage>, initialEventForPage: Array<Event?>, listener: (Event) -> Unit) {
         this.pages = pages
         this.initialEventForPage = initialEventForPage
         this.listener = listener
+        this.triggerScrollForPage = arrayOfNulls(pages.size)
         notifyDataSetChanged()
     }
 
@@ -34,7 +36,9 @@ class ScheduleViewPagerAdapter(private val context: Context) : ViewPagerAdapter<
     override fun bindView(view: ScheduleDayPageView, position: Int) {
         val events = pages[position].events
         val initialEvent = initialEventForPage[position]
-        view.updateWith(events, initialEvent, listener)
+        triggerScrollForPage[position] = { view.scrollToEvent(events.indexOf(it), true) }
+        view.updateWith(events, listener)
+        initialEvent?.let { view.scrollToEvent(events.indexOf(it), false) }
     }
 
     override fun getPageTitle(position: Int): CharSequence? {
@@ -43,6 +47,10 @@ class ScheduleViewPagerAdapter(private val context: Context) : ViewPagerAdapter<
     }
 
     fun getPageDayId(position: Int) = pages[position].dayId
+
+    fun refresh(page: Int, event: Event) {
+        triggerScrollForPage[page]?.invoke(event)
+    }
 
     override fun isViewFromObject(view: View, `object`: Any) = view === `object`
 

--- a/app/src/main/java/net/squanchy/support/injection/CurrentTimeModule.kt
+++ b/app/src/main/java/net/squanchy/support/injection/CurrentTimeModule.kt
@@ -1,9 +1,8 @@
 package net.squanchy.support.injection
 
-import net.squanchy.support.system.CurrentTime
-
 import dagger.Module
 import dagger.Provides
+import net.squanchy.support.system.CurrentTime
 
 @Module
 class CurrentTimeModule {

--- a/app/src/main/java/net/squanchy/support/system/CurrentTime.kt
+++ b/app/src/main/java/net/squanchy/support/system/CurrentTime.kt
@@ -8,5 +8,4 @@ class CurrentTime {
     private val mockTime = LocalDateTime.parse("2017-10-27T12:00:00.000")
 
     fun currentLocalDateTime(): LocalDateTime = if (BuildConfig.DEBUG) mockTime else LocalDateTime.now()
-
 }

--- a/app/src/main/java/net/squanchy/support/system/CurrentTime.kt
+++ b/app/src/main/java/net/squanchy/support/system/CurrentTime.kt
@@ -1,11 +1,12 @@
 package net.squanchy.support.system
 
-import net.squanchy.BuildConfig
-import org.joda.time.LocalDateTime
+import org.joda.time.DateTime
 
-class CurrentTime {
+interface CurrentTime {
+    fun currentDateTime(): DateTime
+}
 
-    private val mockTime = LocalDateTime.parse("2017-10-27T12:00:00.000")
+class AndroidCurrentTime : CurrentTime {
 
-    fun currentLocalDateTime(): LocalDateTime = if (BuildConfig.DEBUG) mockTime else LocalDateTime.now()
+    override fun currentDateTime(): DateTime = DateTime.now()
 }

--- a/app/src/main/java/net/squanchy/support/system/CurrentTime.kt
+++ b/app/src/main/java/net/squanchy/support/system/CurrentTime.kt
@@ -1,10 +1,12 @@
 package net.squanchy.support.system
 
+import net.squanchy.BuildConfig
 import org.joda.time.LocalDateTime
 
 class CurrentTime {
 
-    fun currentTimestamp(): Long = System.currentTimeMillis()
+    private val mockTime = LocalDateTime.parse("2017-10-27T12:00:00.000")
 
-    fun currentLocalDateTime(): LocalDateTime = LocalDateTime.now()
+    fun currentLocalDateTime(): LocalDateTime = if (BuildConfig.DEBUG) mockTime else LocalDateTime.now()
+
 }

--- a/app/src/release/java/net/squanchy/support/injection/CurrentTimeModule.kt
+++ b/app/src/release/java/net/squanchy/support/injection/CurrentTimeModule.kt
@@ -2,11 +2,12 @@ package net.squanchy.support.injection
 
 import dagger.Module
 import dagger.Provides
+import net.squanchy.support.system.AndroidCurrentTime
 import net.squanchy.support.system.CurrentTime
 
 @Module
 class CurrentTimeModule {
 
     @Provides
-    internal fun provideCurrentTime() = CurrentTime()
+    internal fun provideCurrentTime(): CurrentTime = AndroidCurrentTime()
 }


### PR DESCRIPTION
## Problem

We want to automatically scroll to the current/next event slot when opening app.
This is related to https://github.com/squanchy-dev/squanchy-android/issues/288

## Solution

* When the schedule is updated, select the right tab and scroll (not smoothly) to the next slot automatically (only if we are in the days of the conference).
* We also added the option for the user to tap the day tab to automatically scroll (smoothly) to the next slot, in case the app was opened without a refresh / the user navigated to other times
* To ease testing, we used the `CurrentTimeModule` to specify the current time: in production will use the system clock while in debug it's using an hardcoded date. That date is now to the Droidcon London 2017, in a future PR we'll update it to be selectable from the debug activity.

**Note:**
Me and @dextorer are in disagreement regarding one aspect of the implementation: which slot to jump on. The selected option here is to jump to the *next* slot compared to the current one, while the alternative option is to jump to the *current* slot.
Feedbacks are highly appreciated here.

### Test(s) added 

Nope, manual testing 👍 

### Paired with 

@dextorer
