### PR TITLE
Hide copyGitHooks task from tasks list

### DIFF
--- a/team-props/git-hooks.gradle
+++ b/team-props/git-hooks.gradle
@@ -5,7 +5,6 @@ static def isLinuxOrMacOs() {
 
 task copyGitHooks(type: Copy) {
     description 'Copies the git hooks from team-props/git-hooks to the .git folder.'
-    group 'git hooks'
     from("${rootDir}/team-props/git-hooks/") {
         include '**/*.sh'
         rename '(.*).sh', '$1'


### PR DESCRIPTION
## Problem

The `copyGitHooks` task is meant to be a helper for `installGitHook` so it should not be listed by `gradlew tasks`.

## Solution

Remove the `group` from the task definition so it's not listed anymore.

### Paired with 

Nobody