### PR TITLE
Update static-analysis to move lintOptions

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -92,12 +92,6 @@ android {
         }
     }
 
-    lintOptions {
-        lintConfig teamPropsFile('static-analysis/lint-config.xml')
-        abortOnError true
-        warningsAsErrors true
-    }
-
     sourceSets {
         test.java.srcDirs += 'src/test/kotlin'
     }

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -59,7 +59,7 @@ ext {
         android                   : 'com.android.tools.build:gradle:3.0.1',
         firebase                  : 'com.google.firebase:firebase-plugins:1.1.5',
         googleServices            : 'com.google.gms:google-services:3.2.0',
-        gradleStaticAnalysisPlugin: 'com.novoda:gradle-static-analysis-plugin:0.4.1',
+        gradleStaticAnalysisPlugin: 'com.novoda:gradle-static-analysis-plugin:0.5.2',
         jaCoCo                    : 'org.jacoco:org.jacoco.core:0.8.0',
         playPublisher             : 'com.github.triplet.gradle:play-publisher:1.2.0'
     ]

--- a/team-props/static-analysis.gradle
+++ b/team-props/static-analysis.gradle
@@ -29,6 +29,11 @@ staticAnalysis {
         excludeFilter teamPropsFile('static-analysis/findbugs-excludes.xml')
         includeVariants { variant -> excludeTestAndRelease(variant) }
     }
+    
+    lintOptions {
+        lintConfig teamPropsFile('static-analysis/lint-config.xml')
+        warningsAsErrors true
+    }
 }
 
 static boolean excludeTestAndRelease(variant) {


### PR DESCRIPTION
`static-analysis` plugin was updated to include lint support. This PR updates the version used here and moves the `lintOptions` config to the `static-analysis.gradle`
