### PR TITLE
SQ-455/Make the schedule filter data

### DIFF
--- a/app/src/main/java/net/squanchy/favorites/FavoritesComponent.kt
+++ b/app/src/main/java/net/squanchy/favorites/FavoritesComponent.kt
@@ -6,7 +6,7 @@ import net.squanchy.analytics.Analytics
 import net.squanchy.injection.ActivityContextModule
 import net.squanchy.injection.ActivityLifecycle
 import net.squanchy.injection.ApplicationComponent
-import net.squanchy.injection.createApplicationComponent
+import net.squanchy.injection.applicationComponent
 import net.squanchy.navigation.NavigationModule
 import net.squanchy.navigation.Navigator
 import net.squanchy.schedule.ScheduleModule
@@ -25,7 +25,7 @@ internal interface FavoritesComponent {
 
 internal fun favoritesComponent(activity: AppCompatActivity): FavoritesComponent {
     return DaggerFavoritesComponent.builder()
-        .applicationComponent(createApplicationComponent(activity.application))
+        .applicationComponent(activity.application.applicationComponent)
         .scheduleModule(ScheduleModule())
         .navigationModule(NavigationModule())
         .activityContextModule(ActivityContextModule(activity))

--- a/app/src/main/java/net/squanchy/schedule/SchedulePageView.kt
+++ b/app/src/main/java/net/squanchy/schedule/SchedulePageView.kt
@@ -102,7 +102,7 @@ class SchedulePageView @JvmOverloads constructor(
     }
 
     override fun stopLoading() {
-        subscriptions.dispose()
+        subscriptions.clear()
     }
 
     private fun hackToApplyTypefaces(tabLayout: TabLayout) {

--- a/app/src/main/java/net/squanchy/schedule/SchedulePageView.kt
+++ b/app/src/main/java/net/squanchy/schedule/SchedulePageView.kt
@@ -25,7 +25,6 @@ import net.squanchy.support.system.CurrentTime
 import net.squanchy.support.unwrapToActivityContext
 import timber.log.Timber
 
-@Suppress("UNUSED_ANONYMOUS_PARAMETER")
 class SchedulePageView @JvmOverloads constructor(
     context: Context,
     attrs: AttributeSet,

--- a/app/src/main/java/net/squanchy/schedule/domain/view/Track.kt
+++ b/app/src/main/java/net/squanchy/schedule/domain/view/Track.kt
@@ -5,7 +5,7 @@ import net.squanchy.support.lang.Optional
 data class Track(
     val id: String,
     val name: String,
-    val accentColor: Optional<String>,
-    val textColor: Optional<String>,
-    val iconUrl: Optional<String>
+    val accentColor: Optional<String> = Optional.absent(),
+    val textColor: Optional<String> = Optional.absent(),
+    val iconUrl: Optional<String> = Optional.absent()
 )

--- a/app/src/main/java/net/squanchy/schedule/tracksfilter/ScheduleTracksFilter.kt
+++ b/app/src/main/java/net/squanchy/schedule/tracksfilter/ScheduleTracksFilter.kt
@@ -55,7 +55,6 @@ class ScheduleTracksFilterActivity : AppCompatActivity() {
                     val selectedTracks = checkableTracks.allSelected()
                     val newSelectedTracks = selectedTracks.addOrRemove(track, selected)
                     tracksFilter.updateSelectedTracks(newSelectedTracks)
-                    trackAdapter.notifyItemChanged(checkableTracks.map { checkableTrack -> checkableTrack.first }.indexOf(track))
                 }
             }
     }

--- a/app/src/main/java/net/squanchy/schedule/tracksfilter/TracksFilter.kt
+++ b/app/src/main/java/net/squanchy/schedule/tracksfilter/TracksFilter.kt
@@ -14,6 +14,10 @@ interface TracksFilter {
 
 class InMemoryTracksFilter(private val tracksRepository: TracksRepository) : TracksFilter {
 
+    init {
+        println("!!! I AM ALIVE \uD83D\uDC76 ${hashCode()}")
+    }
+
     private val selectedTracksSubject = BehaviorSubject.create<Set<Track>>()
 
     override fun updateSelectedTracks(newSelectedTracks: Set<Track>) {

--- a/app/src/main/java/net/squanchy/schedule/tracksfilter/TracksFilter.kt
+++ b/app/src/main/java/net/squanchy/schedule/tracksfilter/TracksFilter.kt
@@ -24,7 +24,7 @@ class InMemoryTracksFilter(private val tracksRepository: TracksRepository) : Tra
         get() = selectedTracksSubject.orStartWithDbIfEmpty()
 
     private fun BehaviorSubject<Set<Track>>.orStartWithDbIfEmpty() =
-        if (hasValue()) this else this.startWith(tracksRepository.tracks().asSets())
+        if (hasValue()) this else this.startWith(tracksRepository.tracks().take(1).asSets())
 
     private fun <T> Observable<List<T>>.asSets(): Observable<Set<T>> = map { it -> it.toSet() }
 }

--- a/app/src/main/java/net/squanchy/schedule/tracksfilter/TracksFilter.kt
+++ b/app/src/main/java/net/squanchy/schedule/tracksfilter/TracksFilter.kt
@@ -14,10 +14,6 @@ interface TracksFilter {
 
 class InMemoryTracksFilter(private val tracksRepository: TracksRepository) : TracksFilter {
 
-    init {
-        println("!!! I AM ALIVE \uD83D\uDC76 ${hashCode()}")
-    }
-
     private val selectedTracksSubject = BehaviorSubject.create<Set<Track>>()
 
     override fun updateSelectedTracks(newSelectedTracks: Set<Track>) {

--- a/app/src/main/java/net/squanchy/schedule/tracksfilter/TracksFilterModule.kt
+++ b/app/src/main/java/net/squanchy/schedule/tracksfilter/TracksFilterModule.kt
@@ -2,11 +2,13 @@ package net.squanchy.schedule.tracksfilter
 
 import dagger.Module
 import dagger.Provides
+import net.squanchy.injection.ApplicationLifecycle
 import net.squanchy.service.repository.TracksRepository
 
 @Module
 class TracksFilterModule {
 
     @Provides
+    @ApplicationLifecycle
     fun trackFilter(tracksRepository: TracksRepository): TracksFilter = InMemoryTracksFilter(tracksRepository)
 }

--- a/app/src/main/java/net/squanchy/service/firestore/injection/FirestoreModule.kt
+++ b/app/src/main/java/net/squanchy/service/firestore/injection/FirestoreModule.kt
@@ -1,7 +1,6 @@
 package net.squanchy.service.firestore.injection
 
 import com.google.firebase.firestore.FirebaseFirestore
-import com.google.firebase.firestore.FirebaseFirestoreSettings
 import dagger.Module
 import dagger.Provides
 import net.squanchy.injection.ApplicationLifecycle
@@ -11,16 +10,12 @@ import net.squanchy.service.firestore.FirestoreDbService
 class FirestoreModule {
 
     @Provides
+    @ApplicationLifecycle
     internal fun firebaseFirestore(): FirebaseFirestore {
-        return FirebaseFirestore.getInstance().apply {
-            val settings = FirebaseFirestoreSettings.Builder(firestoreSettings)
-                .setPersistenceEnabled(false)
-                .build()
-            firestoreSettings = settings
-        }
+        return FirebaseFirestore.getInstance()
     }
 
-    @ApplicationLifecycle
     @Provides
+    @ApplicationLifecycle
     internal fun firebaseDbService(database: FirebaseFirestore): FirestoreDbService = FirestoreDbService(database)
 }


### PR DESCRIPTION
## Problem

The schedule is not actually filtered when we filter out tracks

## Solution

We were doing `dispose()` instead of `clear()` on the schedule composite subscription. That has been fixed. It also makes sure that the observable we use to start off the selected tracks is terminating correctly.

### Test(s) added 

No.

### Paired with 

@fourlastor 
