### PR TITLE
SQ-455/Workaround persistence crashing the app

### DIFF
--- a/app/src/main/java/net/squanchy/schedule/SchedulePageView.kt
+++ b/app/src/main/java/net/squanchy/schedule/SchedulePageView.kt
@@ -8,7 +8,6 @@ import android.util.AttributeSet
 import android.view.View
 import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.disposables.CompositeDisposable
-import io.reactivex.schedulers.Schedulers
 import kotlinx.android.synthetic.main.view_page_schedule.view.*
 import net.squanchy.R
 import net.squanchy.analytics.Analytics
@@ -86,7 +85,6 @@ class SchedulePageView @JvmOverloads constructor(
     override fun startLoading() {
         subscriptions.add(
             service.schedule()
-                .subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(
                     { updateWith(it, { event -> onEventClicked(event) }) },

--- a/app/src/main/java/net/squanchy/schedule/ScheduleService.kt
+++ b/app/src/main/java/net/squanchy/schedule/ScheduleService.kt
@@ -2,6 +2,7 @@ package net.squanchy.schedule
 
 import io.reactivex.Observable
 import io.reactivex.functions.BiFunction
+import io.reactivex.schedulers.Schedulers
 import net.squanchy.schedule.domain.view.Schedule
 import net.squanchy.schedule.domain.view.SchedulePage
 import net.squanchy.schedule.domain.view.Track
@@ -29,6 +30,7 @@ class FirestoreScheduleService(
 
     override fun schedule(onlyFavorites: Boolean): Observable<Schedule> {
         val filteredDbSchedulePages = dbService.scheduleView()
+            .observeOn(Schedulers.io())
             .filterByFavorites(onlyFavorites)
             .filterByTracks(tracksFilter.selectedTracks)
 

--- a/app/src/main/java/net/squanchy/schedule/ScheduleService.kt
+++ b/app/src/main/java/net/squanchy/schedule/ScheduleService.kt
@@ -1,6 +1,7 @@
 package net.squanchy.schedule
 
 import io.reactivex.Observable
+import io.reactivex.Scheduler
 import io.reactivex.functions.BiFunction
 import io.reactivex.schedulers.Schedulers
 import net.squanchy.schedule.domain.view.Schedule
@@ -17,7 +18,9 @@ import org.joda.time.DateTimeZone
 import org.joda.time.LocalDate
 
 interface ScheduleService {
+
     fun schedule(onlyFavorites: Boolean = false): Observable<Schedule>
+
     fun currentUserIsSignedIn(): Observable<Boolean>
 }
 
@@ -28,9 +31,11 @@ class FirestoreScheduleService(
     private val checksum: Checksum
 ) : ScheduleService {
 
-    override fun schedule(onlyFavorites: Boolean): Observable<Schedule> {
+    override fun schedule(onlyFavorites: Boolean): Observable<Schedule> = schedule(onlyFavorites, Schedulers.io())
+
+    fun schedule(onlyFavorites: Boolean, observeScheduler: Scheduler): Observable<Schedule> {
         val filteredDbSchedulePages = dbService.scheduleView()
-            .observeOn(Schedulers.io())
+            .observeOn(observeScheduler)
             .filterByFavorites(onlyFavorites)
             .filterByTracks(tracksFilter.selectedTracks)
 

--- a/app/src/main/java/net/squanchy/service/firestore/injection/FirestoreModule.kt
+++ b/app/src/main/java/net/squanchy/service/firestore/injection/FirestoreModule.kt
@@ -10,7 +10,6 @@ import net.squanchy.service.firestore.FirestoreDbService
 class FirestoreModule {
 
     @Provides
-    @ApplicationLifecycle
     internal fun firebaseFirestore(): FirebaseFirestore {
         return FirebaseFirestore.getInstance()
     }

--- a/app/src/test/java/net/squanchy/schedule/FirestoreScheduleServiceTest.kt
+++ b/app/src/test/java/net/squanchy/schedule/FirestoreScheduleServiceTest.kt
@@ -1,9 +1,7 @@
 package net.squanchy.schedule
 
 import io.reactivex.Observable
-import io.reactivex.observers.TestObserver
 import io.reactivex.subjects.BehaviorSubject
-import net.squanchy.schedule.domain.view.Schedule
 import net.squanchy.schedule.domain.view.Track
 import net.squanchy.schedule.domain.view.aSchedule
 import net.squanchy.schedule.domain.view.aSchedulePage
@@ -76,17 +74,15 @@ class FirestoreScheduleServiceTest {
         val allowedTracks = setOf(aTrack())
         `when`(tracksFilter.selectedTracks).thenReturn(BehaviorSubject.createDefault(allowedTracks))
         `when`(checksum.getChecksumOf(anEvent().id)).thenReturn(1234)
-        val subscription = TestObserver<Schedule>()
 
         scheduleService.schedule(onlyFavorites = false)
-            .subscribe(subscription)
-
-        subscription.assertValue(
-            aSchedule(listOf(
-                aSchedulePage(dayId = "1", date = LocalDate(A_START_TIME.dateOnly())),
-                aSchedulePage(dayId = "2", date = LocalDate(A_START_TIME.plusOneDay().dateOnly()))
-            ))
-        )
+            .test()
+            .assertValue(
+                aSchedule(listOf(
+                    aSchedulePage(dayId = "1", date = LocalDate(A_START_TIME.dateOnly())),
+                    aSchedulePage(dayId = "2", date = LocalDate(A_START_TIME.plusOneDay().dateOnly()))
+                ))
+            )
     }
 
     @Test
@@ -116,49 +112,47 @@ class FirestoreScheduleServiceTest {
         `when`(checksum.getChecksumOf("4")).thenReturn(4)
         `when`(checksum.getChecksumOf("5")).thenReturn(5)
         `when`(checksum.getChecksumOf("6")).thenReturn(6)
-        val subscription = TestObserver<Schedule>()
 
         scheduleService.schedule(onlyFavorites = false)
-            .subscribe(subscription)
-
-        subscription.assertValue(aSchedule(listOf(
-            aSchedulePage(
-                dayId = "1",
-                date = LocalDate(A_START_TIME.dateOnly()),
-                events = listOf(
-                    anEvent(id = "1", numericId = 1, startTime = A_START_TIME.toLocalDateTime(), endTime = AN_END_TIME.toLocalDateTime()),
-                    anEvent(id = "3", numericId = 3, startTime = A_START_TIME.toLocalDateTime(), endTime = AN_END_TIME.toLocalDateTime()),
-                    anEvent(
-                        id = "2",
-                        numericId = 2,
-                        startTime = A_LATER_START_TIME.toLocalDateTime(),
-                        endTime = A_LATER_END_TIME.toLocalDateTime()
-                    )
-                )),
-            aSchedulePage(
-                dayId = "2",
-                date = LocalDate(A_START_TIME.plusOneDay().dateOnly()),
-                events = listOf(
-                    anEvent(
-                        id = "4",
-                        numericId = 4,
-                        startTime = A_START_TIME.plusOneDay().toLocalDateTime(),
-                        endTime = AN_END_TIME.plusOneDay().toLocalDateTime()
-                    ),
-                    anEvent(
-                        id = "5",
-                        numericId = 5,
-                        startTime = A_START_TIME.plusOneDay().toLocalDateTime(),
-                        endTime = AN_END_TIME.plusOneDay().toLocalDateTime()
-                    ),
-                    anEvent(
-                        id = "6",
-                        numericId = 6,
-                        startTime = A_LATER_START_TIME.plusOneDay().toLocalDateTime(),
-                        endTime = A_LATER_END_TIME.plusOneDay().toLocalDateTime()
-                    )
-                ))
-        )))
+            .test()
+            .assertValue(aSchedule(listOf(
+                aSchedulePage(
+                    dayId = "1",
+                    date = LocalDate(A_START_TIME.dateOnly()),
+                    events = listOf(
+                        anEvent(id = "1", numericId = 1, startTime = A_START_TIME.toLocalDateTime(), endTime = AN_END_TIME.toLocalDateTime()),
+                        anEvent(id = "3", numericId = 3, startTime = A_START_TIME.toLocalDateTime(), endTime = AN_END_TIME.toLocalDateTime()),
+                        anEvent(
+                            id = "2",
+                            numericId = 2,
+                            startTime = A_LATER_START_TIME.toLocalDateTime(),
+                            endTime = A_LATER_END_TIME.toLocalDateTime()
+                        )
+                    )),
+                aSchedulePage(
+                    dayId = "2",
+                    date = LocalDate(A_START_TIME.plusOneDay().dateOnly()),
+                    events = listOf(
+                        anEvent(
+                            id = "4",
+                            numericId = 4,
+                            startTime = A_START_TIME.plusOneDay().toLocalDateTime(),
+                            endTime = AN_END_TIME.plusOneDay().toLocalDateTime()
+                        ),
+                        anEvent(
+                            id = "5",
+                            numericId = 5,
+                            startTime = A_START_TIME.plusOneDay().toLocalDateTime(),
+                            endTime = AN_END_TIME.plusOneDay().toLocalDateTime()
+                        ),
+                        anEvent(
+                            id = "6",
+                            numericId = 6,
+                            startTime = A_LATER_START_TIME.plusOneDay().toLocalDateTime(),
+                            endTime = A_LATER_END_TIME.plusOneDay().toLocalDateTime()
+                        )
+                    ))
+            )))
     }
 
     @Test
@@ -175,19 +169,17 @@ class FirestoreScheduleServiceTest {
         `when`(checksum.getChecksumOf("1")).thenReturn(1)
         `when`(checksum.getChecksumOf("2")).thenReturn(2)
         // TODO mark one of the two firestore events above as favorite
-        val subscription = TestObserver<Schedule>()
 
         scheduleService.schedule(onlyFavorites = false)
-            .subscribe(subscription)
-
-        subscription.assertValue(
-            aSchedule(listOf(
-                aSchedulePage(events = listOf(
-                    anEvent(id = "1", numericId = 1, track = Optional.absent()),
-                    anEvent(id = "2", numericId = 2, track = Optional.absent())
+            .test()
+            .assertValue(
+                aSchedule(listOf(
+                    aSchedulePage(events = listOf(
+                        anEvent(id = "1", numericId = 1, track = Optional.absent()),
+                        anEvent(id = "2", numericId = 2, track = Optional.absent())
+                    ))
                 ))
-            ))
-        )
+            )
     }
 
     // TODO test events are filtered out when onyFavorites and they're not favorited
@@ -204,19 +196,17 @@ class FirestoreScheduleServiceTest {
         val allowedTracks = setOf(aTrack(id = "A"), aTrack("C"))
         `when`(tracksFilter.selectedTracks).thenReturn(BehaviorSubject.createDefault(allowedTracks))
         `when`(checksum.getChecksumOf(aFirestoreEvent().id)).thenReturn(1)
-        val subscription = TestObserver<Schedule>()
 
         scheduleService.schedule(onlyFavorites = false)
-            .subscribe(subscription)
-
-        subscription.assertValue(
-            aSchedule(listOf(
-                aSchedulePage(events = listOf(
-                    anEvent(track = Optional.absent(), numericId = 1),
-                    anEvent(track = Optional.absent(), numericId = 1)
+            .test()
+            .assertValue(
+                aSchedule(listOf(
+                    aSchedulePage(events = listOf(
+                        anEvent(track = Optional.absent(), numericId = 1),
+                        anEvent(track = Optional.absent(), numericId = 1)
+                    ))
                 ))
-            ))
-        )
+            )
     }
 
     @Test
@@ -231,19 +221,17 @@ class FirestoreScheduleServiceTest {
         val allowedTracks = emptySet<Track>()
         `when`(tracksFilter.selectedTracks).thenReturn(BehaviorSubject.createDefault(allowedTracks))
         `when`(checksum.getChecksumOf(aFirestoreEvent().id)).thenReturn(1)
-        val subscription = TestObserver<Schedule>()
 
         scheduleService.schedule(onlyFavorites = false)
-            .subscribe(subscription)
-
-        subscription.assertValue(
-            aSchedule(listOf(
-                aSchedulePage(events = listOf(
-                    anEvent(track = Optional.absent(), numericId = 1),
-                    anEvent(track = Optional.absent(), numericId = 1)
+            .test()
+            .assertValue(
+                aSchedule(listOf(
+                    aSchedulePage(events = listOf(
+                        anEvent(track = Optional.absent(), numericId = 1),
+                        anEvent(track = Optional.absent(), numericId = 1)
+                    ))
                 ))
-            ))
-        )
+            )
     }
 
     @Test
@@ -256,16 +244,14 @@ class FirestoreScheduleServiceTest {
         `when`(dbService.scheduleView()).thenReturn(Observable.just(listOf(schedulePage)))
         val allowedTracks = setOf(aTrack(id = "A"), aTrack("C"))
         `when`(tracksFilter.selectedTracks).thenReturn(BehaviorSubject.createDefault(allowedTracks))
-        val subscription = TestObserver<Schedule>()
 
         scheduleService.schedule(onlyFavorites = false)
-            .subscribe(subscription)
-
-        subscription.assertValue(
-            aSchedule(listOf(
-                aSchedulePage(events = emptyList())
-            ))
-        )
+            .test()
+            .assertValue(
+                aSchedule(listOf(
+                    aSchedulePage(events = emptyList())
+                ))
+            )
     }
 
     @Test
@@ -280,19 +266,17 @@ class FirestoreScheduleServiceTest {
         val allowedTracks = setOf(aTrack(id = "A"), aTrack("C"))
         `when`(tracksFilter.selectedTracks).thenReturn(BehaviorSubject.createDefault(allowedTracks))
         `when`(checksum.getChecksumOf(aFirestoreEvent().id)).thenReturn(1)
-        val subscription = TestObserver<Schedule>()
 
         scheduleService.schedule(onlyFavorites = false)
-            .subscribe(subscription)
-
-        subscription.assertValue(
-            aSchedule(listOf(
-                aSchedulePage(events = listOf(
-                    anEvent(track = Optional.of(aTrack(id = "A")), numericId = 1),
-                    anEvent(track = Optional.of(aTrack(id = "C")), numericId = 1)
+            .test()
+            .assertValue(
+                aSchedule(listOf(
+                    aSchedulePage(events = listOf(
+                        anEvent(track = Optional.of(aTrack(id = "A")), numericId = 1),
+                        anEvent(track = Optional.of(aTrack(id = "C")), numericId = 1)
+                    ))
                 ))
-            ))
-        )
+            )
     }
 
     @Test
@@ -308,18 +292,16 @@ class FirestoreScheduleServiceTest {
         val allowedTracks = emptySet<Track>()
         `when`(tracksFilter.selectedTracks).thenReturn(BehaviorSubject.createDefault(allowedTracks))
         `when`(checksum.getChecksumOf(aFirestoreEvent().id)).thenReturn(1)
-        val subscription = TestObserver<Schedule>()
 
         scheduleService.schedule(onlyFavorites = false)
-            .subscribe(subscription)
-
-        subscription.assertValue(
-            aSchedule(listOf(
-                aSchedulePage(events = listOf(
-                    anEvent(track = Optional.absent(), numericId = 1)
+            .test()
+            .assertValue(
+                aSchedule(listOf(
+                    aSchedulePage(events = listOf(
+                        anEvent(track = Optional.absent(), numericId = 1)
+                    ))
                 ))
-            ))
-        )
+            )
     }
 
     private fun Date.plusOneDay(): Date = CALENDAR.apply {

--- a/app/src/test/java/net/squanchy/schedule/FirestoreScheduleServiceTest.kt
+++ b/app/src/test/java/net/squanchy/schedule/FirestoreScheduleServiceTest.kt
@@ -1,6 +1,7 @@
 package net.squanchy.schedule
 
 import io.reactivex.Observable
+import io.reactivex.schedulers.Schedulers
 import io.reactivex.subjects.BehaviorSubject
 import net.squanchy.schedule.domain.view.Track
 import net.squanchy.schedule.domain.view.aSchedule
@@ -75,7 +76,7 @@ class FirestoreScheduleServiceTest {
         `when`(tracksFilter.selectedTracks).thenReturn(BehaviorSubject.createDefault(allowedTracks))
         `when`(checksum.getChecksumOf(anEvent().id)).thenReturn(1234)
 
-        scheduleService.schedule(onlyFavorites = false)
+        scheduleService.schedule(onlyFavorites = false, observeScheduler = Schedulers.trampoline())
             .test()
             .assertValue(
                 aSchedule(listOf(
@@ -113,7 +114,7 @@ class FirestoreScheduleServiceTest {
         `when`(checksum.getChecksumOf("5")).thenReturn(5)
         `when`(checksum.getChecksumOf("6")).thenReturn(6)
 
-        scheduleService.schedule(onlyFavorites = false)
+        scheduleService.schedule(onlyFavorites = false, observeScheduler = Schedulers.trampoline())
             .test()
             .assertValue(aSchedule(listOf(
                 aSchedulePage(
@@ -170,7 +171,7 @@ class FirestoreScheduleServiceTest {
         `when`(checksum.getChecksumOf("2")).thenReturn(2)
         // TODO mark one of the two firestore events above as favorite
 
-        scheduleService.schedule(onlyFavorites = false)
+        scheduleService.schedule(onlyFavorites = false, observeScheduler = Schedulers.trampoline())
             .test()
             .assertValue(
                 aSchedule(listOf(
@@ -197,7 +198,7 @@ class FirestoreScheduleServiceTest {
         `when`(tracksFilter.selectedTracks).thenReturn(BehaviorSubject.createDefault(allowedTracks))
         `when`(checksum.getChecksumOf(aFirestoreEvent().id)).thenReturn(1)
 
-        scheduleService.schedule(onlyFavorites = false)
+        scheduleService.schedule(onlyFavorites = false, observeScheduler = Schedulers.trampoline())
             .test()
             .assertValue(
                 aSchedule(listOf(
@@ -222,7 +223,7 @@ class FirestoreScheduleServiceTest {
         `when`(tracksFilter.selectedTracks).thenReturn(BehaviorSubject.createDefault(allowedTracks))
         `when`(checksum.getChecksumOf(aFirestoreEvent().id)).thenReturn(1)
 
-        scheduleService.schedule(onlyFavorites = false)
+        scheduleService.schedule(onlyFavorites = false, observeScheduler = Schedulers.trampoline())
             .test()
             .assertValue(
                 aSchedule(listOf(
@@ -245,7 +246,7 @@ class FirestoreScheduleServiceTest {
         val allowedTracks = setOf(aTrack(id = "A"), aTrack("C"))
         `when`(tracksFilter.selectedTracks).thenReturn(BehaviorSubject.createDefault(allowedTracks))
 
-        scheduleService.schedule(onlyFavorites = false)
+        scheduleService.schedule(onlyFavorites = false, observeScheduler = Schedulers.trampoline())
             .test()
             .assertValue(
                 aSchedule(listOf(
@@ -267,7 +268,7 @@ class FirestoreScheduleServiceTest {
         `when`(tracksFilter.selectedTracks).thenReturn(BehaviorSubject.createDefault(allowedTracks))
         `when`(checksum.getChecksumOf(aFirestoreEvent().id)).thenReturn(1)
 
-        scheduleService.schedule(onlyFavorites = false)
+        scheduleService.schedule(onlyFavorites = false, observeScheduler = Schedulers.trampoline())
             .test()
             .assertValue(
                 aSchedule(listOf(
@@ -293,7 +294,7 @@ class FirestoreScheduleServiceTest {
         `when`(tracksFilter.selectedTracks).thenReturn(BehaviorSubject.createDefault(allowedTracks))
         `when`(checksum.getChecksumOf(aFirestoreEvent().id)).thenReturn(1)
 
-        scheduleService.schedule(onlyFavorites = false)
+        scheduleService.schedule(onlyFavorites = false, observeScheduler = Schedulers.trampoline())
             .test()
             .assertValue(
                 aSchedule(listOf(


### PR DESCRIPTION
## Problem

Enabling the persistence in Firestore makes the app crash on startup randomly.

## Solution

It's sort of a hack but we need Firestore to work on the main thread otherwise it explodes badly. We've tested a bunch of possible solutions and the only one that reliably works is this somewhat dirty workaround to not subscribe on the `io()` schedulers, but instead start observing on `io()` immediately after Firestore emits data, and then switch to observing on the main thread where the subscription is.

Not ideal, but so far it's the only thing that doesn't die badly.

### Test(s) added 

No but smoke tested

### Paired with 

@fourlastor 