### PR TITLE
Add badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-# Squanchy
+# Squanchy Android
+[![Master CI](https://img.shields.io/circleci/project/github/squanchy-dev/squanchy-android/develop.svg?style=for-the-badge)](https://circleci.com/gh/squanchy-dev/squanchy-android/tree/develop) [![Apache 2 license](https://img.shields.io/github/license/squanchy-dev/squanchy-android.svg?style=for-the-badge)](https://github.com/squanchy-dev/squanchy-android/blob/master/LICENSE)
 
 Squanchy is an open source schedule platform for conferences.
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Squanchy Android
-[![Master CI](https://img.shields.io/circleci/project/github/squanchy-dev/squanchy-android/develop.svg?style=for-the-badge)](https://circleci.com/gh/squanchy-dev/squanchy-android/tree/develop) [![Apache 2 license](https://img.shields.io/github/license/squanchy-dev/squanchy-android.svg?style=for-the-badge)](https://github.com/squanchy-dev/squanchy-android/blob/master/LICENSE)
+[![Master CI](https://img.shields.io/circleci/project/github/squanchy-dev/squanchy-android/develop.svg?style=for-the-badge)](https://circleci.com/gh/squanchy-dev/squanchy-android/tree/develop) [![Apache 2 license](https://img.shields.io/github/license/squanchy-dev/squanchy-android.svg?style=for-the-badge)](https://github.com/squanchy-dev/squanchy-android/blob/develop/LICENSE)
 
 Squanchy is an open source schedule platform for conferences.
 


### PR DESCRIPTION
## Problem

We don't have badges on the readme and have no visibility over `develop` build state

## Solution

Add them

### Test(s) added 

No

### Screenshots

![image](https://user-images.githubusercontent.com/153802/37203147-9ccd03ce-2384-11e8-99ac-aaea91b859bc.png)

### Paired with 

Nobody