### PR TITLE
Hotfix Firestore implementation

### DIFF
--- a/app/src/main/java/net/squanchy/favorites/view/FavoritesListView.kt
+++ b/app/src/main/java/net/squanchy/favorites/view/FavoritesListView.kt
@@ -10,7 +10,7 @@ import net.squanchy.schedule.domain.view.Schedule
 import net.squanchy.support.view.CardSpacingItemDecorator
 
 internal class FavoritesListView @JvmOverloads constructor(
-    context: Context?,
+    context: Context,
     attrs: AttributeSet? = null,
     defStyle: Int = 0
 ) : RecyclerView(context, attrs, defStyle) {

--- a/app/src/main/java/net/squanchy/schedule/domain/view/Event.kt
+++ b/app/src/main/java/net/squanchy/schedule/domain/view/Event.kt
@@ -32,7 +32,8 @@ data class Event(
         COFFEE_BREAK("coffee_break"),
         LUNCH("lunch"),
         SOCIAL("social"),
-        OTHER("other");
+        OTHER("other"),
+        WORKSHOP("workshop");
 
         companion object {
 

--- a/app/src/main/java/net/squanchy/schedule/view/EventsAdapter.kt
+++ b/app/src/main/java/net/squanchy/schedule/view/EventsAdapter.kt
@@ -34,7 +34,7 @@ internal class EventsAdapter(context: Context) : RecyclerView.Adapter<EventViewH
     override fun getItemViewType(position: Int): Int {
         val itemType = _events[position].type
         return when (itemType) {
-            Event.Type.KEYNOTE, Event.Type.TALK -> ItemViewType.TYPE_TALK.ordinal
+            Event.Type.KEYNOTE, Event.Type.TALK, Event.Type.WORKSHOP -> ItemViewType.TYPE_TALK.ordinal
             Event.Type.COFFEE_BREAK, Event.Type.LUNCH, Event.Type.OTHER, Event.Type.REGISTRATION, Event.Type.SOCIAL -> ItemViewType.TYPE_OTHER.ordinal
         }
     }

--- a/app/src/main/java/net/squanchy/schedule/view/TalkEventItemView.kt
+++ b/app/src/main/java/net/squanchy/schedule/view/TalkEventItemView.kt
@@ -32,7 +32,7 @@ class TalkEventItemView @JvmOverloads constructor(
     }
 
     private fun ensureSupportedType(type: Event.Type) {
-        if (type === Event.Type.TALK || type === Event.Type.KEYNOTE) {
+        if (type == Event.Type.TALK || type == Event.Type.KEYNOTE || type == Event.Type.WORKSHOP) {
             return
         }
         throw IllegalArgumentException("Event with type ${type.name} is not supported by this view")

--- a/app/src/main/java/net/squanchy/service/firestore/FirestoreDbService.kt
+++ b/app/src/main/java/net/squanchy/service/firestore/FirestoreDbService.kt
@@ -245,7 +245,7 @@ class FirestoreDbService(private val db: FirebaseFirestore) {
         private const val VIEW_EVENT_DETAILS = "event_details"
         private const val COLLECTION_EVENTS = "events"
         private const val COLLECTION_FAVORITES = "favorites"
-        private const val VIEW_TRACKS = "tracks_view"
+        private const val VIEW_TRACKS = "tracks"
         private const val COLLECTION_TRACKS = "tracks"
 
         private const val DAY_DATE_SORTING = "day.date"

--- a/app/src/main/java/net/squanchy/tweets/service/TwitterService.kt
+++ b/app/src/main/java/net/squanchy/tweets/service/TwitterService.kt
@@ -12,6 +12,7 @@ internal class TwitterService(
 ) {
 
     private val tweets = dbService.twitterView()
+        .map { tweets -> tweets.sortedByDescending { it.createdAt } }
         .map { tweets -> tweets.map { mapToViewModel(factory, it) } }
 
     private val hashtag = dbService.conferenceInfo()


### PR DESCRIPTION
## Problem

We have a couple of issues with Firestore after getting the data from Syx:
 1. The tracks view was moved (by us) from `/views/tracks_view/tracks` to `/views/tracks/tracks`
 2. Tweets were sorted by creation date ascending, but should be sorted by descending date
 3. We didn't have support for `workshop` event type on our side
 4. Favourites always show headers for all days, even when the day contains no favourites

## Solution

 1. Update the reference in `FirestoreDbService`
 2. Add a `sortByDescending` in `TwitterService`
 3. Add support for `workshop` event type
 4. Refactor, cleanup `FavoritesAdapter` and fix the logic to only show headers for the days that should.

### Test(s) added 

No

### Paired with 

Nobody