### PR TITLE
Reformat code after updating dependencies

### DIFF
--- a/app/src/main/java/net/squanchy/schedule/view/OtherEventItemView.kt
+++ b/app/src/main/java/net/squanchy/schedule/view/OtherEventItemView.kt
@@ -24,11 +24,11 @@ class OtherEventItemView @JvmOverloads constructor(
 
     @Suppress("ComplexCondition")
     private fun ensureSupportedType(type: Event.Type) {
-        if (type === Event.Type.COFFEE_BREAK
-            || type === Event.Type.LUNCH
-            || type === Event.Type.OTHER
-            || type === Event.Type.REGISTRATION
-            || type === Event.Type.SOCIAL) {
+        if (type === Event.Type.COFFEE_BREAK ||
+            type === Event.Type.LUNCH ||
+            type === Event.Type.OTHER ||
+            type === Event.Type.REGISTRATION ||
+            type === Event.Type.SOCIAL) {
             return
         }
         throw IllegalArgumentException("Event with type ${type.name} is not supported by this view")

--- a/app/src/main/java/net/squanchy/service/firebase/FirestoreMappers.kt
+++ b/app/src/main/java/net/squanchy/service/firebase/FirestoreMappers.kt
@@ -55,7 +55,7 @@ fun FirestoreEvent.toEvent(checksum: Checksum, dateTime: DateTimeZone, isFavorit
     endTime = LocalDateTime(endTime),
     title = title,
     place = place?.toPlace().optional(),
-    experienceLevel = experienceLevel.toExperienceLevel() ,
+    experienceLevel = experienceLevel.toExperienceLevel(),
     speakers = speakers.map { it.toSpeaker(checksum) },
     type = type.toEventType(),
     favorited = isFavorite,

--- a/app/src/main/java/net/squanchy/support/view/CardSpacingItemDecorator.kt
+++ b/app/src/main/java/net/squanchy/support/view/CardSpacingItemDecorator.kt
@@ -6,10 +6,8 @@ import android.support.v7.widget.RecyclerView
 import android.view.View
 
 class CardSpacingItemDecorator(
-    @param:Px @field:Px
-    private val horizontalSpacing: Int,
-    @param:Px @field:Px
-    private val verticalSpacing: Int
+    @param:Px @field:Px private val horizontalSpacing: Int,
+    @param:Px @field:Px private val verticalSpacing: Int
 ) : RecyclerView.ItemDecoration() {
 
     override fun getItemOffsets(outRect: Rect, view: View, parent: RecyclerView, state: RecyclerView.State) {

--- a/team-props/git-hooks/pre-commit.sh
+++ b/team-props/git-hooks/pre-commit.sh
@@ -2,7 +2,7 @@
 
 echo "Running static analysis..."
 
-# Validate Kotlin code with detekt and KtLint before committing,
+# Validate Kotlin code with detekt and KtLint before committing
 ./gradlew app:detektCheck app:ktlint --daemon
 
 status=$?


### PR DESCRIPTION
## Problem

New KtLint has several formatting fixes, we need to reformat before the update dependencies PR can be shipped.

## Solution

`ktlint -F --android`

### Test(s) added

No

### Paired with 

Nobody