### PR TITLE
Update dependencies

### DIFF
--- a/app/src/main/java/net/squanchy/schedule/view/OtherEventItemView.kt
+++ b/app/src/main/java/net/squanchy/schedule/view/OtherEventItemView.kt
@@ -24,11 +24,11 @@ class OtherEventItemView @JvmOverloads constructor(
 
     @Suppress("ComplexCondition")
     private fun ensureSupportedType(type: Event.Type) {
-        if (type === Event.Type.COFFEE_BREAK
-            || type === Event.Type.LUNCH
-            || type === Event.Type.OTHER
-            || type === Event.Type.REGISTRATION
-            || type === Event.Type.SOCIAL) {
+        if (type === Event.Type.COFFEE_BREAK ||
+            type === Event.Type.LUNCH ||
+            type === Event.Type.OTHER ||
+            type === Event.Type.REGISTRATION ||
+            type === Event.Type.SOCIAL) {
             return
         }
         throw IllegalArgumentException("Event with type ${type.name} is not supported by this view")

--- a/app/src/main/java/net/squanchy/service/firebase/FirestoreMappers.kt
+++ b/app/src/main/java/net/squanchy/service/firebase/FirestoreMappers.kt
@@ -55,7 +55,7 @@ fun FirestoreEvent.toEvent(checksum: Checksum, dateTime: DateTimeZone, isFavorit
     endTime = LocalDateTime(endTime),
     title = title,
     place = place?.toPlace().optional(),
-    experienceLevel = experienceLevel.toExperienceLevel() ,
+    experienceLevel = experienceLevel.toExperienceLevel(),
     speakers = speakers.map { it.toSpeaker(checksum) },
     type = type.toEventType(),
     favorited = isFavorite,

--- a/app/src/main/java/net/squanchy/support/view/CardSpacingItemDecorator.kt
+++ b/app/src/main/java/net/squanchy/support/view/CardSpacingItemDecorator.kt
@@ -6,10 +6,8 @@ import android.support.v7.widget.RecyclerView
 import android.view.View
 
 class CardSpacingItemDecorator(
-    @param:Px @field:Px
-    private val horizontalSpacing: Int,
-    @param:Px @field:Px
-    private val verticalSpacing: Int
+    @param:Px @field:Px private val horizontalSpacing: Int,
+    @param:Px @field:Px private val verticalSpacing: Int
 ) : RecyclerView.ItemDecoration() {
 
     override fun getItemOffsets(outRect: Rect, view: View, parent: RecyclerView, state: RecyclerView.State) {

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -51,7 +51,7 @@ ext {
             truth   : 'com.google.truth:truth:0.39',
             jodaTime: 'joda-time:joda-time:2.9.9',
             jUnit4  : 'junit:junit:4.12',
-            mockito : 'org.mockito:mockito-inline:2.13.0'
+            mockito : 'org.mockito:mockito-inline:2.16.0'
         ]
     ]
 

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -38,7 +38,7 @@ ext {
             jodaTimeAndroid    : 'net.danlew:android.joda:2.9.9.2',
             kotlin             : "org.jetbrains.kotlin:kotlin-stdlib-jre7:${kotlinVersion}",
             playServicesAuth   : "com.google.android.gms:play-services-auth:${playServicesVersion}",
-            rxJava             : 'io.reactivex.rxjava2:rxjava:2.1.10',
+            rxJava             : 'io.reactivex.rxjava2:rxjava:2.1.11',
             rxAndroid          : 'io.reactivex.rxjava2:rxandroid:2.0.2',
             supportAppCompat   : "com.android.support:appcompat-v7:${supportLibVersion}",
             supportConstraint  : 'com.android.support.constraint:constraint-layout:1.1.0-beta5',

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -13,7 +13,7 @@ ext {
 
     gradlePlugins = [
         buildProperties: 'com.novoda:gradle-build-properties-plugin:0.3.9',
-        fabric         : 'io.fabric.tools:gradle:1.25.1',
+        fabric         : 'io.fabric.tools:gradle:1.25.2',
         kotlin         : "org.jetbrains.kotlin:kotlin-gradle-plugin:${kotlinVersion}"
     ]
 

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,5 +1,5 @@
 ext {
-    daggerVersion = '2.14.1'
+    daggerVersion = '2.15'
     glideVersion = '4.6.1'
     supportLibVersion = '27.1.0'
     playServicesVersion = '11.8.0'

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -12,7 +12,7 @@ ext {
     ktLintVersion = '0.20.0'
 
     gradlePlugins = [
-        buildProperties: 'com.novoda:gradle-build-properties-plugin:0.3.9',
+        buildProperties: 'com.novoda:gradle-build-properties-plugin:0.4',
         fabric         : 'io.fabric.tools:gradle:1.25.2',
         kotlin         : "org.jetbrains.kotlin:kotlin-gradle-plugin:${kotlinVersion}"
     ]

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -9,7 +9,7 @@ ext {
     findbugsVersion = '3.0.1'
     pmdVersion = '6.1.0'
 
-    ktLintVersion = '0.19.0'
+    ktLintVersion = '0.20.0'
 
     gradlePlugins = [
         buildProperties: 'com.novoda:gradle-build-properties-plugin:0.3.9',

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -56,7 +56,7 @@ ext {
     ]
 
     buildScript = [
-        android                   : 'com.android.tools.build:gradle:3.1.0-rc02',
+        android                   : 'com.android.tools.build:gradle:3.1.0-rc03',
         firebase                  : 'com.google.firebase:firebase-plugins:1.1.5',
         googleServices            : 'com.google.gms:google-services:3.2.0',
         gradleStaticAnalysisPlugin: 'com.novoda:gradle-static-analysis-plugin:0.5.2',

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -2,7 +2,7 @@ ext {
     daggerVersion = '2.15'
     glideVersion = '4.6.1'
     supportLibVersion = '27.1.0'
-    playServicesVersion = '11.8.0'
+    playServicesVersion = '12.0.0'
     kotlinVersion = '1.2.30'
 
     checkstyleVersion = '8.8'

--- a/team-props/git-hooks/pre-commit.sh
+++ b/team-props/git-hooks/pre-commit.sh
@@ -2,8 +2,8 @@
 
 echo "Running static analysis..."
 
-# Format code using KtLint
-./gradlew app:ktlintFormat app:detektCheck app:ktlint --daemon
+# Validate Kotlin code with detekt and KtLint before committing,
+./gradlew app:detektCheck app:ktlint --daemon
 
 status=$?
 

--- a/team-props/git-hooks/pre-commit.sh
+++ b/team-props/git-hooks/pre-commit.sh
@@ -2,7 +2,7 @@
 
 echo "Running static analysis..."
 
-# Validate Kotlin code with detekt and KtLint before committing,
+# Validate Kotlin code with detekt and KtLint before committing
 ./gradlew app:detektCheck app:ktlint --daemon
 
 status=$?

--- a/team-props/static-analysis/detekt-config.yml
+++ b/team-props/static-analysis/detekt-config.yml
@@ -20,8 +20,7 @@ test-pattern: # Configure exclusions for test sources
     - 'TooManyFunctions'
 
 build:
-  warningThreshold: 1
-  failThreshold: 1
+  maxIssues: 0
 
   weights:
     complexity: 2


### PR DESCRIPTION
## Problem

A bunch of dependencies are out of date (including the Android Gradle Plugin, which is a blocker)

## Solution

Update them all — see commits for details

Note: Detekt 1.0.0.RC6-4 isn't compatible with the Static Analysis plugin so I have kept it back for now.

Note 2: this PR requires #481 to be shipped first

### Test(s) added

No

### Paired with 

Nobody