### PR TITLE
Improve filters UI — part 1

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -94,6 +94,11 @@
     <editorconfig>
       <option name="ENABLED" value="false" />
     </editorconfig>
+    <codeStyleSettings language="Groovy">
+      <indentOptions>
+        <option name="CONTINUATION_INDENT_SIZE" value="4" />
+      </indentOptions>
+    </codeStyleSettings>
     <codeStyleSettings language="JAVA">
       <option name="KEEP_BLANK_LINES_IN_DECLARATIONS" value="1" />
       <option name="KEEP_BLANK_LINES_IN_CODE" value="1" />

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -144,6 +144,8 @@ dependencies {
         exclude group: 'com.google.firebase'
     }
 
+    implementation libraries.app.flexbox
+
     annotationProcessor libraries.app.glideCompiler
     kapt libraries.app.glideCompiler
     implementation libraries.app.glide

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -47,7 +47,7 @@
 
     <activity
       android:name="net.squanchy.schedule.tracksfilter.ScheduleTracksFilterActivity"
-      android:theme="@style/Theme.Squanchy.Schedule" />
+      android:theme="@style/Theme.Squanchy.ScheduleTracksFilter" />
 
     <activity
       android:name="net.squanchy.eventdetails.EventDetailsActivity"

--- a/app/src/main/java/net/squanchy/schedule/tracksfilter/ScheduleTracksFilter.kt
+++ b/app/src/main/java/net/squanchy/schedule/tracksfilter/ScheduleTracksFilter.kt
@@ -6,6 +6,8 @@ import android.graphics.Color
 import android.os.Bundle
 import android.support.v4.content.ContextCompat
 import android.support.v7.app.AppCompatActivity
+import android.support.v7.recyclerview.extensions.ListAdapter
+import android.support.v7.util.DiffUtil
 import android.support.v7.widget.RecyclerView
 import android.view.LayoutInflater
 import android.view.ViewGroup
@@ -31,6 +33,7 @@ class ScheduleTracksFilterActivity : AppCompatActivity() {
     private lateinit var trackAdapter: TracksFilterAdapter
 
     private var subscription: Disposable? = null
+    private var checkableTracks: List<CheckableTrack>? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -44,15 +47,22 @@ class ScheduleTracksFilterActivity : AppCompatActivity() {
         tracksRepository = component.tracksRepository()
         tracksFilter = component.tracksFilter()
 
-        trackAdapter = TracksFilterAdapter(this)
+        trackAdapter = TracksFilterAdapter(this) { track, selected ->
+            val selectedTracks = checkableTracks?.allSelected() ?: emptySet()
+            val newSelectedTracks = selectedTracks.addOrRemove(track, selected)
+            tracksFilter.updateSelectedTracks(newSelectedTracks)
+        }
 
         trackFiltersList.layoutManager = FlexboxLayoutManager(this, FlexDirection.ROW)
         trackFiltersList.addItemDecoration(FlexboxItemDecoration(this).apply {
-            setDrawable(resources.getDrawable(R.drawable.filters_separator))
+            setDrawable(resources.getDrawable(R.drawable.filters_separator, theme))
             setOrientation(FlexboxItemDecoration.BOTH)
         })
         trackFiltersList.adapter = trackAdapter
     }
+
+    private fun Set<Track>.addOrRemove(track: Track, selected: Boolean): Set<Track> =
+        if (selected) this + track else this - track
 
     override fun onStart() {
         super.onStart()
@@ -61,19 +71,10 @@ class ScheduleTracksFilterActivity : AppCompatActivity() {
             .subscribeOn(Schedulers.computation())
             .observeOn(AndroidSchedulers.mainThread())
             .subscribe { checkableTracks ->
-                trackAdapter.updateTracks(checkableTracks) { track, selected ->
-                    val selectedTracks = checkableTracks.allSelected()
-                    val newSelectedTracks = selectedTracks.addOrRemove(track, selected)
-                    tracksFilter.updateSelectedTracks(newSelectedTracks)
-                }
+                this.checkableTracks = checkableTracks
+                trackAdapter.submitList(checkableTracks)
             }
     }
-
-    private fun Iterable<CheckableTrack>.allSelected(): Set<Track> =
-        filter { it.selected() }.map { it.track() }.toSet()
-
-    private fun Set<Track>.addOrRemove(track: Track, selected: Boolean): Set<Track> =
-        if (selected) this + track else this - track
 
     private fun combineIntoCheckableTracks(): BiFunction<List<Track>, Set<Track>, List<CheckableTrack>> {
         return BiFunction { tracks, selectedTracks ->
@@ -87,7 +88,10 @@ class ScheduleTracksFilterActivity : AppCompatActivity() {
     }
 }
 
-private class TracksFilterAdapter(context: Context) : RecyclerView.Adapter<TrackViewHolder>() {
+private class TracksFilterAdapter(
+    context: Context,
+    private val trackStateChangeListener: OnTrackSelectedChangeListener
+) : ListAdapter<CheckableTrack, TrackViewHolder>(DiffCallback()) {
 
     init {
         setHasStableIds(true)
@@ -95,28 +99,27 @@ private class TracksFilterAdapter(context: Context) : RecyclerView.Adapter<Track
 
     private val layoutInflater = LayoutInflater.from(context)
 
-    private var checkableTracks: List<CheckableTrack> = emptyList()
-    private lateinit var trackStateChangeListener: OnTrackSelectedChangeListener
-
-    override fun getItemCount(): Int = checkableTracks.size
-
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): TrackViewHolder {
         val view = layoutInflater.inflate(R.layout.track_filters_item, parent, false) as CheckBox
         return TrackViewHolder(view)
     }
 
     override fun onBindViewHolder(holder: TrackViewHolder, position: Int) {
-        holder.bind(checkableTracks[position], trackStateChangeListener)
+        holder.bind(getItem(position), trackStateChangeListener)
     }
 
     override fun getItemId(position: Int): Long {
-        return checkableTracks[position].track().id.hashCode().toLong() // TODO this should use a proper checksum
+        return getItem(position).track().id.hashCode().toLong() // TODO this should use a proper checksum
     }
 
-    fun updateTracks(newCheckableTracks: List<CheckableTrack>, listener: OnTrackSelectedChangeListener) {
-        checkableTracks = newCheckableTracks // TODO use DiffUtil instead
-        trackStateChangeListener = listener
-        notifyDataSetChanged()
+    class DiffCallback : DiffUtil.ItemCallback<CheckableTrack>() {
+        override fun areItemsTheSame(oldItem: CheckableTrack?, newItem: CheckableTrack?): Boolean {
+            return oldItem?.track()?.id == newItem?.track()?.id
+        }
+
+        override fun areContentsTheSame(oldItem: CheckableTrack?, newItem: CheckableTrack?): Boolean {
+            return oldItem == newItem
+        }
     }
 }
 
@@ -142,6 +145,7 @@ private class TrackViewHolder(val item: CheckBox) : RecyclerView.ViewHolder(item
             if (track.accentColor.isPresent) {
                 backgroundTintList = ColorStateList.valueOf(trackColor)
             }
+
             if (isChecked) {
                 setTextColor(trackColor.contrastingTextColor(darkTextColor, lightTextColor))
                 alpha = ALPHA_CHECKED
@@ -158,6 +162,9 @@ private class TrackViewHolder(val item: CheckBox) : RecyclerView.ViewHolder(item
 private typealias OnTrackSelectedChangeListener = (track: Track, selected: Boolean) -> Unit
 
 private typealias CheckableTrack = Pair<Track, Boolean>
+
+private fun Iterable<CheckableTrack>.allSelected(): Set<Track> =
+    filter { it.selected() }.map { it.track() }.toSet()
 
 private fun CheckableTrack.track() = this.first
 private fun CheckableTrack.selected() = this.second

--- a/app/src/main/java/net/squanchy/schedule/tracksfilter/ScheduleTracksFilter.kt
+++ b/app/src/main/java/net/squanchy/schedule/tracksfilter/ScheduleTracksFilter.kt
@@ -59,6 +59,7 @@ class ScheduleTracksFilterActivity : AppCompatActivity() {
             setOrientation(FlexboxItemDecoration.BOTH)
         })
         trackFiltersList.adapter = trackAdapter
+        trackFiltersList.itemAnimator = null
     }
 
     private fun Set<Track>.addOrRemove(track: Track, selected: Boolean): Set<Track> =

--- a/app/src/main/java/net/squanchy/schedule/tracksfilter/ScheduleTracksFilter.kt
+++ b/app/src/main/java/net/squanchy/schedule/tracksfilter/ScheduleTracksFilter.kt
@@ -33,7 +33,7 @@ class ScheduleTracksFilterActivity : AppCompatActivity() {
     private lateinit var trackAdapter: TracksFilterAdapter
 
     private var subscription: Disposable? = null
-    private var checkableTracks: List<CheckableTrack>? = null
+    private var checkableTracks: List<CheckableTrack> = emptyList()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -48,7 +48,7 @@ class ScheduleTracksFilterActivity : AppCompatActivity() {
         tracksFilter = component.tracksFilter()
 
         trackAdapter = TracksFilterAdapter(this) { track, selected ->
-            val selectedTracks = checkableTracks?.allSelected() ?: emptySet()
+            val selectedTracks = checkableTracks.allSelected()
             val newSelectedTracks = selectedTracks.addOrRemove(track, selected)
             tracksFilter.updateSelectedTracks(newSelectedTracks)
         }

--- a/app/src/main/java/net/squanchy/support/graphics/Color.kt
+++ b/app/src/main/java/net/squanchy/support/graphics/Color.kt
@@ -1,0 +1,29 @@
+package net.squanchy.support.graphics
+
+import android.graphics.Color
+import android.support.annotation.ColorInt
+
+private const val MAX_COLOR_COMPONENT = 255.0
+private const val GAMMA_FACTOR = 2.2
+private const val MAX_LIGHTNESS_FOR_LIGHT_TEXT = .18
+private const val FACTOR_RED = 0.2126
+private const val FACTOR_GREEN = 0.7151
+private const val FACTOR_BLUE = 0.0721
+
+@ColorInt
+internal fun Int.contrastingTextColor(darkTextColor: Int, lightTextColor: Int): Int {
+    val r = Color.red(this)
+    val g = Color.green(this)
+    val b = Color.blue(this)
+    val lightness = FACTOR_RED * gamaCorrectColorComponent(r) +
+        FACTOR_GREEN * gamaCorrectColorComponent(g) +
+        FACTOR_BLUE * gamaCorrectColorComponent(b)
+
+    return if (lightness > MAX_LIGHTNESS_FOR_LIGHT_TEXT) {
+        darkTextColor
+    } else {
+        lightTextColor
+    }
+}
+
+private fun gamaCorrectColorComponent(r: Int) = Math.pow(r / MAX_COLOR_COMPONENT, GAMMA_FACTOR)

--- a/app/src/main/java/net/squanchy/support/graphics/Color.kt
+++ b/app/src/main/java/net/squanchy/support/graphics/Color.kt
@@ -11,7 +11,7 @@ private const val FACTOR_GREEN = 0.7151
 private const val FACTOR_BLUE = 0.0721
 
 @ColorInt
-internal fun Int.contrastingTextColor(darkTextColor: Int, lightTextColor: Int): Int {
+internal fun Int.contrastingTextColor(@ColorInt darkTextColor: Int, @ColorInt lightTextColor: Int): Int {
     val r = Color.red(this)
     val g = Color.green(this)
     val b = Color.blue(this)

--- a/app/src/main/res/drawable/chip_background.xml
+++ b/app/src/main/res/drawable/chip_background.xml
@@ -2,18 +2,16 @@
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
   <item android:state_checked="true">
     <shape android:shape="rectangle">
-      <corners android:radius="20dp" />
-      <solid android:color="#fff" />
-      <stroke android:color="#fff" android:width="2dp" />
-      <padding android:left="8dp" android:top="8dp" android:right="8dp" android:bottom="8dp" />
+      <corners android:radius="@dimen/track_filters_item_corner_radius" />
+      <solid android:color="@color/white" />
+      <stroke android:color="@color/white" android:width="@dimen/track_filters_item_stroke_width" />
     </shape>
   </item>
   <item android:state_checked="false">
     <shape android:shape="rectangle">
-      <corners android:radius="20dp" />
-      <solid android:color="#0000" />
-      <stroke android:color="#fff" android:width="2dp" />
-      <padding android:left="8dp" android:top="8dp" android:right="8dp" android:bottom="8dp" />
+      <corners android:radius="@dimen/track_filters_item_corner_radius" />
+      <solid android:color="@color/transparent" />
+      <stroke android:color="@color/white" android:width="@dimen/track_filters_item_stroke_width" />
     </shape>
   </item>
 </selector>

--- a/app/src/main/res/drawable/chip_background.xml
+++ b/app/src/main/res/drawable/chip_background.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+  <item android:state_checked="true">
+    <shape android:shape="rectangle">
+      <corners android:radius="20dp" />
+      <solid android:color="#fff" />
+      <stroke android:color="#fff" android:width="2dp" />
+      <padding android:left="8dp" android:top="8dp" android:right="8dp" android:bottom="8dp" />
+    </shape>
+  </item>
+  <item android:state_checked="false">
+    <shape android:shape="rectangle">
+      <corners android:radius="20dp" />
+      <solid android:color="#0000" />
+      <stroke android:color="#fff" android:width="2dp" />
+      <padding android:left="8dp" android:top="8dp" android:right="8dp" android:bottom="8dp" />
+    </shape>
+  </item>
+</selector>

--- a/app/src/main/res/drawable/filters_separator.xml
+++ b/app/src/main/res/drawable/filters_separator.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape
+  xmlns:android="http://schemas.android.com/apk/res/android"
+  android:shape="rectangle">
+
+  <size
+    android:height="16dp"
+    android:width="8dp" />
+</shape>

--- a/app/src/main/res/layout/activity_track_filters.xml
+++ b/app/src/main/res/layout/activity_track_filters.xml
@@ -1,9 +1,75 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.v7.widget.RecyclerView
+
+<FrameLayout
   xmlns:android="http://schemas.android.com/apk/res/android"
-  android:id="@+id/trackFiltersList"
+  xmlns:app="http://schemas.android.com/apk/res-auto"
+  android:id="@+id/backgroundDim"
   android:layout_width="match_parent"
   android:layout_height="match_parent"
-  android:paddingLeft="@dimen/track_filters_item_padding_horizontal"
-  android:paddingRight="@dimen/track_filters_item_padding_horizontal"
-  android:clipToPadding="false"/>
+  android:background="#4d000000">
+
+  <android.support.constraint.ConstraintLayout
+    android:id="@+id/filtersRoot"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="@color/window_background"
+    android:clickable="true"
+    android:focusable="false"
+    android:elevation="4dp">
+
+    <TextView
+      android:id="@+id/title"
+      android:layout_width="@dimen/match_constraint"
+      android:layout_height="wrap_content"
+      android:layout_marginTop="12dp"
+      android:layout_marginStart="16dp"
+      android:layout_marginEnd="16dp"
+      android:fontFamily="@font/title_typeface"
+      android:textSize="20sp"
+      android:textColor="#434343"
+      android:text="Visible tracks"
+      app:layout_constraintTop_toTopOf="parent"
+      app:layout_constraintStart_toStartOf="parent"
+      app:layout_constraintEnd_toStartOf="@+id/closeButton" />
+
+    <TextView
+      android:id="@+id/subtitle"
+      android:layout_width="@dimen/match_constraint"
+      android:layout_height="wrap_content"
+      android:layout_marginTop="4dp"
+      android:fontFamily="@font/default_typeface_medium"
+      android:textSize="12sp"
+      android:textColor="#909090"
+      android:text="Select the tracks to show in your schedule"
+      app:layout_constraintStart_toStartOf="@+id/title"
+      app:layout_constraintTop_toBottomOf="@+id/title"
+      app:layout_constraintEnd_toEndOf="@+id/title" />
+
+    <ImageButton
+      android:id="@+id/closeButton"
+      android:layout_width="24dp"
+      android:layout_height="24dp"
+      android:layout_marginTop="16dp"
+      android:layout_marginEnd="16dp"
+      android:src="@drawable/ic_close"
+      android:tint="#4D000000"
+      android:background="?android:attr/selectableItemBackgroundBorderless"
+      app:layout_constraintEnd_toEndOf="parent"
+      app:layout_constraintTop_toTopOf="parent" />
+
+    <android.support.v7.widget.RecyclerView
+      xmlns:android="http://schemas.android.com/apk/res/android"
+      android:id="@+id/trackFiltersList"
+      android:layout_width="match_parent"
+      android:layout_height="@dimen/match_constraint"
+      android:layout_marginTop="16dp"
+      android:paddingBottom="16dp"
+      android:paddingLeft="@dimen/track_filters_item_padding_horizontal"
+      android:paddingRight="@dimen/track_filters_item_padding_horizontal"
+      android:clipToPadding="false"
+      app:layout_constraintTop_toBottomOf="@+id/subtitle" />
+
+  </android.support.constraint.ConstraintLayout>
+
+</FrameLayout>
+

--- a/app/src/main/res/layout/activity_track_filters.xml
+++ b/app/src/main/res/layout/activity_track_filters.xml
@@ -51,9 +51,11 @@
     <android.support.v7.widget.RecyclerView
       android:id="@+id/trackFiltersList"
       style="@style/TrackFilters.Filters.Tracks"
-      android:layout_width="match_parent"
+      android:layout_width="@dimen/match_constraint"
       android:layout_height="@dimen/match_constraint"
-      app:layout_constraintTop_toBottomOf="@+id/subtitle" />
+      app:layout_constraintStart_toStartOf="parent"
+      app:layout_constraintTop_toBottomOf="@+id/subtitle"
+      app:layout_constraintEnd_toEndOf="parent" />
 
   </android.support.constraint.ConstraintLayout>
 

--- a/app/src/main/res/layout/activity_track_filters.xml
+++ b/app/src/main/res/layout/activity_track_filters.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-
+<!-- We can't use merge here because we have  -->
 <FrameLayout
   xmlns:android="http://schemas.android.com/apk/res/android"
   xmlns:app="http://schemas.android.com/apk/res-auto"
@@ -7,7 +7,8 @@
   android:id="@+id/backgroundDim"
   style="@style/TrackFilters.BackgroundDim"
   android:layout_width="match_parent"
-  android:layout_height="match_parent">
+  android:layout_height="match_parent"
+  tools:ignore="MergeRootFrame">
 
   <!-- This is not accessible to the keyboard by design, it should only stop taps from going through it -->
   <android.support.constraint.ConstraintLayout

--- a/app/src/main/res/layout/activity_track_filters.xml
+++ b/app/src/main/res/layout/activity_track_filters.xml
@@ -3,70 +3,56 @@
 <FrameLayout
   xmlns:android="http://schemas.android.com/apk/res/android"
   xmlns:app="http://schemas.android.com/apk/res-auto"
+  xmlns:tools="http://schemas.android.com/tools"
   android:id="@+id/backgroundDim"
+  style="@style/TrackFilters.BackgroundDim"
   android:layout_width="match_parent"
-  android:layout_height="match_parent"
-  android:background="#4d000000">
+  android:layout_height="match_parent">
 
+  <!-- This is not accessible to the keyboard by design, it should only stop taps from going through it -->
   <android.support.constraint.ConstraintLayout
     android:id="@+id/filtersRoot"
+    style="@style/TrackFilters.Filters"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:background="@color/window_background"
-    android:clickable="true"
-    android:focusable="false"
-    android:elevation="4dp">
+    tools:ignore="KeyboardInaccessibleWidget">
 
     <TextView
       android:id="@+id/title"
+      style="@style/TrackFilters.Filters.Title"
       android:layout_width="@dimen/match_constraint"
       android:layout_height="wrap_content"
-      android:layout_marginTop="12dp"
-      android:layout_marginStart="16dp"
-      android:layout_marginEnd="16dp"
-      android:fontFamily="@font/title_typeface"
-      android:textSize="20sp"
-      android:textColor="#434343"
-      android:text="Visible tracks"
+      android:layout_marginTop="@dimen/track_filters_title_margin_top"
+      android:layout_marginStart="@dimen/track_filters_title_margin_horizontal"
+      android:layout_marginEnd="@dimen/track_filters_title_margin_horizontal"
       app:layout_constraintTop_toTopOf="parent"
       app:layout_constraintStart_toStartOf="parent"
       app:layout_constraintEnd_toStartOf="@+id/closeButton" />
 
     <TextView
       android:id="@+id/subtitle"
+      style="@style/TrackFilters.Filters.Subtitle"
       android:layout_width="@dimen/match_constraint"
       android:layout_height="wrap_content"
-      android:layout_marginTop="4dp"
-      android:fontFamily="@font/default_typeface_medium"
-      android:textSize="12sp"
-      android:textColor="#909090"
-      android:text="Select the tracks to show in your schedule"
+      android:layout_marginTop="@dimen/track_filters_subtitle_margin_top"
       app:layout_constraintStart_toStartOf="@+id/title"
       app:layout_constraintTop_toBottomOf="@+id/title"
       app:layout_constraintEnd_toEndOf="@+id/title" />
 
     <ImageButton
       android:id="@+id/closeButton"
-      android:layout_width="24dp"
-      android:layout_height="24dp"
-      android:layout_marginTop="16dp"
-      android:layout_marginEnd="16dp"
-      android:src="@drawable/ic_close"
-      android:tint="#4D000000"
-      android:background="?android:attr/selectableItemBackgroundBorderless"
+      style="@style/TrackFilters.Filters.CloseButton"
+      android:layout_width="@dimen/track_filters_close_button_size"
+      android:layout_height="@dimen/track_filters_close_button_size"
+      android:layout_marginTop="@dimen/track_filters_close_button_margin"
       app:layout_constraintEnd_toEndOf="parent"
       app:layout_constraintTop_toTopOf="parent" />
 
     <android.support.v7.widget.RecyclerView
-      xmlns:android="http://schemas.android.com/apk/res/android"
       android:id="@+id/trackFiltersList"
+      style="@style/TrackFilters.Filters.Tracks"
       android:layout_width="match_parent"
       android:layout_height="@dimen/match_constraint"
-      android:layout_marginTop="16dp"
-      android:paddingBottom="16dp"
-      android:paddingLeft="@dimen/track_filters_item_padding_horizontal"
-      android:paddingRight="@dimen/track_filters_item_padding_horizontal"
-      android:clipToPadding="false"
       app:layout_constraintTop_toBottomOf="@+id/subtitle" />
 
   </android.support.constraint.ConstraintLayout>

--- a/app/src/main/res/layout/track_filters_item.xml
+++ b/app/src/main/res/layout/track_filters_item.xml
@@ -2,13 +2,7 @@
 <CheckBox
   xmlns:android="http://schemas.android.com/apk/res/android"
   xmlns:tools="http://schemas.android.com/tools"
+  style="@style/TrackFilters.Filters.Tracks.Item"
   android:layout_width="wrap_content"
   android:layout_height="wrap_content"
-  android:background="@drawable/chip_background"
-  android:button="@null"
-  android:fontFamily="@font/default_typeface_bold"
-  android:gravity="center"
-  android:paddingLeft="@dimen/track_filters_item_padding_horizontal"
-  android:paddingRight="@dimen/track_filters_item_padding_horizontal"
-  android:textSize="12sp"
   tools:text="Track name" />

--- a/app/src/main/res/layout/track_filters_item.xml
+++ b/app/src/main/res/layout/track_filters_item.xml
@@ -1,10 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <CheckBox
   xmlns:android="http://schemas.android.com/apk/res/android"
-  android:layout_width="match_parent"
+  xmlns:tools="http://schemas.android.com/tools"
+  android:layout_width="wrap_content"
   android:layout_height="wrap_content"
-  android:minHeight="?android:attr/listPreferredItemHeightSmall"
-  android:textAppearance="?android:attr/textAppearanceMedium"
-  android:gravity="center_vertical"
+  android:background="@drawable/chip_background"
+  android:button="@null"
+  android:fontFamily="@font/default_typeface_bold"
+  android:gravity="center"
   android:paddingLeft="@dimen/track_filters_item_padding_horizontal"
-  android:paddingRight="@dimen/track_filters_item_padding_horizontal" />
+  android:paddingRight="@dimen/track_filters_item_padding_horizontal"
+  android:textSize="12sp"
+  tools:text="Track name" />

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -2,16 +2,18 @@
 <resources>
 
   <color name="card_background">@color/white</color>
-  <color name="licenses_notice_background">#e0e0e0</color>
+  <color name="licenses_notice_background">#E0E0E0</color>
   <color name="notification_led_color">@color/accent</color>
-  <color name="venue_info_name">#2e676e</color>
-  <color name="venue_info_address">#38828a</color>
-  <color name="venue_info_label">#38828a</color>
+  <color name="venue_info_name">#2E676E</color>
+  <color name="venue_info_address">#38828A</color>
+  <color name="venue_info_label">#38828A</color>
 
   <color name="experience_level_beginner">#A1D450</color>
   <color name="experience_level_intermediate">#EEA53A</color>
   <color name="experience_level_advanced">#EE6227</color>
 
   <color name="navigation_bar_light">#EEEEEE</color>
+  <color name="dialog_dim">#4D000000</color>
+  <color name="track_filters_close_button_tint">#4D000000</color>
 
 </resources>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -189,8 +189,19 @@
   <dimen name="first_start_with_no_network_progress_size">48dp</dimen>
 
   <dimen name="match_constraint">0dp</dimen>
+
   <dimen name="preference_header_margin_vertical">16dp</dimen>
+
+  <dimen name="track_filters_elevation">4dp</dimen>
+  <dimen name="track_filters_title_margin_top">12dp</dimen>
+  <dimen name="track_filters_title_margin_horizontal">16dp</dimen>
+  <dimen name="track_filters_subtitle_margin_top">4dp</dimen>
+  <dimen name="track_filters_tracks_padding">16dp</dimen>
+  <dimen name="track_filters_item_padding_vertical">8dp</dimen>
   <dimen name="track_filters_item_padding_horizontal">16dp</dimen>
-  <dimen name="track_filters_item_padding_vertical">@dimen/track_filters_item_padding_horizontal</dimen>
+  <dimen name="track_filters_close_button_size">48dp</dimen>
+  <dimen name="track_filters_close_button_margin">4dp</dimen>
+  <dimen name="track_filters_item_corner_radius">200dp</dimen>
+  <dimen name="track_filters_item_stroke_width">2dp</dimen>
 
 </resources>

--- a/app/src/main/res/values/palette.xml
+++ b/app/src/main/res/values/palette.xml
@@ -42,7 +42,9 @@
   <color name="text_inverse_inactive">#99ffffff</color>
 
   <color name="shadows">#19000000</color>
+
   <color name="white">#ffffff</color>
   <color name="white_60">#99ffffff</color>
+  <color name="transparent">#0000</color>
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -115,4 +115,7 @@
   <string name="first_start_with_no_network_cancel_button">You know what, nevermind</string>
 
   <string name="filter_schedule">Filter</string>
+  <string name="filter_tracks_title">Visible tracks</string>
+  <string name="filter_tracks_subtitle">Select the tracks to show in your schedule</string>
+
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -632,4 +632,67 @@
     <item name="android:paddingTop">@dimen/preference_header_margin_vertical</item>
   </style>
 
+  <style name="TrackFilters" parent="None" />
+
+  <style name="TrackFilters.BackgroundDim" parent="None">
+    <item name="android:background">@color/dialog_dim</item>
+  </style>
+
+  <style name="TrackFilters.Filters" parent="None">
+    <item name="android:background">@color/window_background</item>
+    <item name="android:clickable">true</item>
+    <item name="android:elevation">@dimen/track_filters_elevation</item>
+    <item name="android:focusable">false</item>
+  </style>
+
+  <style name="TrackFilters.Filters.Title" parent="None">
+    <item name="android:text">@string/filter_tracks_title</item>
+    <item name="android:textAppearance">@style/TextAppearance.Squanchy.TrackFilters.Filters.Title</item>
+  </style>
+
+  <style name="TextAppearance.Squanchy.TrackFilters.Filters.Title" parent="None">
+    <item name="android:textColor">#434343</item>
+    <item name="android:textSize">20sp</item>
+    <item name="fontFamily">@font/title_typeface</item>
+  </style>
+
+  <style name="TrackFilters.Filters.Subtitle" parent="None">
+    <item name="android:text">@string/filter_tracks_title</item>
+    <item name="android:textAppearance">@style/TextAppearance.Squanchy.TrackFilters.Filters.Subtitle</item>
+  </style>
+
+  <style name="TextAppearance.Squanchy.TrackFilters.Filters.Subtitle" parent="None">
+    <item name="android:textColor">#909090</item>
+    <item name="android:textSize">12sp</item>
+    <item name="fontFamily">@font/default_typeface_medium</item>
+  </style>
+
+  <style name="TrackFilters.Filters.CloseButton" parent="None">
+    <item name="android:background">?android:attr/selectableItemBackgroundBorderless</item>
+    <item name="android:scaleType">centerInside</item>
+    <item name="android:src">@drawable/ic_close</item>
+    <item name="android:tint">@color/track_filters_close_button_tint</item>
+  </style>
+
+  <style name="TrackFilters.Filters.Tracks" parent="None">
+    <item name="android:clipToPadding">false</item>
+    <item name="android:padding">@dimen/track_filters_tracks_padding</item>
+  </style>
+
+  <style name="TrackFilters.Filters.Tracks.Item" parent="None">
+    <item name="android:background">@drawable/chip_background</item>
+    <item name="android:button">@null</item>
+    <item name="android:gravity">center</item>
+    <item name="android:paddingLeft">@dimen/track_filters_item_padding_horizontal</item>
+    <item name="android:paddingTop">@dimen/track_filters_item_padding_vertical</item>
+    <item name="android:paddingRight">@dimen/track_filters_item_padding_horizontal</item>
+    <item name="android:paddingBottom">@dimen/track_filters_item_padding_vertical</item>
+    <item name="android:textAppearance">@style/TextAppearance.Squanchy.TrackFilters.Filters.Tracks.Item</item>
+  </style>
+
+  <style name="TextAppearance.Squanchy.TrackFilters.Filters.Tracks.Item" parent="None">
+    <item name="android:textSize">12sp</item>
+    <item name="fontFamily">@font/default_typeface_bold</item>
+  </style>
+
 </resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -105,7 +105,7 @@
   <style name="Theme.Squanchy.Search" parent="Theme.Squanchy.MostlyWhite" />
 
   <style name="Theme.Squanchy.Settings" parent="Theme.Squanchy.PrimaryStatusBar">
-    <item name="colorAccent">?colorPrimary</item>
+    <item name="colorAccent">?attr/colorPrimary</item>
     <item name="fontFamily">@font/default_typeface_regular</item>
   </style>
 
@@ -117,6 +117,24 @@
 
   <style name="Theme.Squanchy.FirstStartWithNoNetwork" parent="Theme.Squanchy.Dialog">
     <item name="android:backgroundDimEnabled">false</item>
+  </style>
+
+  <style name="Theme.Squanchy.ScheduleTracksFilter" parent="Theme.Squanchy">
+    <item name="windowActionBar">false</item>
+    <item name="windowNoTitle">true</item>
+    <item name="android:windowElevation">4dp</item>
+    <item name="android:windowCloseOnTouchOutside">true</item>
+    <item name="android:windowBackground">@android:color/transparent</item>
+    <item name="android:colorBackground">?attr/colorBackgroundFloating</item>
+    <item name="android:colorBackgroundCacheHint">@null</item>
+
+    <item name="android:windowFrame">@null</item>
+    <item name="android:windowIsFloating">false</item>
+    <item name="android:windowIsTranslucent">true</item>
+    <item name="android:backgroundDimEnabled">true</item>
+    <item name="android:windowContentOverlay">@null</item>
+    <item name="android:windowAnimationStyle">@style/Animation.AppCompat.Dialog</item>
+    <item name="android:windowSoftInputMode">stateUnspecified|adjustPan</item>
   </style>
 
 </resources>

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -32,6 +32,7 @@ ext {
             firebasePerf       : "com.google.firebase:firebase-perf:${playServicesVersion}",
             firebaseStorage    : "com.google.firebase:firebase-storage:${playServicesVersion}",
             firebaseUiStorage  : 'com.firebaseui:firebase-ui-storage:3.2.1',
+            flexbox            : 'com.google.android:flexbox:0.3.2',
             glide              : "com.github.bumptech.glide:glide:${glideVersion}",
             glideCompiler      : "com.github.bumptech.glide:compiler:${glideVersion}",
             glideOkHttp3       : "com.github.bumptech.glide:okhttp3-integration:${glideVersion}",


### PR DESCRIPTION
## Problem

Our filters UI look like crap :D

## Solution

Implement @ScribblyPixels' awesome new design — for now just the basic UI. Will have as TODO in next PRs:
* the animation in/out of the dialog UI
* the animation of the state changes for the items
* fixing a bug for which "no tracks" show some talks instead of the breaks/sessions without tracks (our side? backend side? needs looking into)
* fixing the typeface not being picked up by the checkboxes for whatever reason
* using chips proper in the list
* signaling somehow in the main UI that filters are active

Unfortunately the chips implementation from the material components library requires having P as a target, which we can't do yet. I'm currently just using a CheckBox with a hacky BG.

### Test(s) addedNo

### Screenshots

 All selected | Some unselected
 --- | ---
 ![tracks_after_1](https://user-images.githubusercontent.com/153802/37786265-2353ef06-2df4-11e8-8ba0-701168f8f678.png) | ![tracks_after_2](https://user-images.githubusercontent.com/153802/37786266-23687796-2df4-11e8-93e2-d2fc6f8adfd7.png)

![tracks](https://user-images.githubusercontent.com/153802/37786267-237dc768-2df4-11e8-9c27-f3cb2bbca1b0.gif)

### Paired with 

Nobody