### PR TITLE
Add Material Components' Chip

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,1 @@
-include ':app'
+include ':app', ':support-chip'

--- a/support-chip/build.gradle
+++ b/support-chip/build.gradle
@@ -1,0 +1,23 @@
+apply plugin: 'com.android.library'
+
+android {
+    compileSdkVersion Integer.parseInt(project.COMPILE_SDK_VERSION)
+
+    defaultConfig {
+        minSdkVersion Integer.parseInt(project.MIN_SDK_VERSION)
+        targetSdkVersion Integer.parseInt(project.TARGET_SDK_VERSION)
+
+        versionCode 1
+        versionName '1.0'
+    }
+    
+    lintOptions {
+        abortOnError false
+        ignoreWarnings true
+        baseline file("lint-baseline.xml")
+    }
+}
+
+dependencies {
+    implementation libraries.app.supportAppCompat
+}

--- a/support-chip/lint-baseline.xml
+++ b/support-chip/lint-baseline.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<issues format="4" by="lint 3.1.0-rc03">
+
+</issues>

--- a/support-chip/src/main/AndroidManifest.xml
+++ b/support-chip/src/main/AndroidManifest.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (C) 2017 The Android Open Source Project
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+  package="android.support.design.chip">
+
+  <application />
+</manifest>

--- a/support-chip/src/main/java/android/support/design/animation/AnimationUtils.java
+++ b/support-chip/src/main/java/android/support/design/animation/AnimationUtils.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2015 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package android.support.design.animation;
+
+import android.animation.TimeInterpolator;
+import android.support.annotation.RestrictTo;
+import android.support.annotation.RestrictTo.Scope;
+import android.support.v4.view.animation.FastOutLinearInInterpolator;
+import android.support.v4.view.animation.FastOutSlowInInterpolator;
+import android.support.v4.view.animation.LinearOutSlowInInterpolator;
+import android.view.animation.DecelerateInterpolator;
+import android.view.animation.LinearInterpolator;
+
+/** Utility class for animations containing Material interpolators. */
+@RestrictTo(Scope.LIBRARY_GROUP)
+public class AnimationUtils {
+
+  public static final TimeInterpolator LINEAR_INTERPOLATOR = new LinearInterpolator();
+  public static final TimeInterpolator FAST_OUT_SLOW_IN_INTERPOLATOR =
+      new FastOutSlowInInterpolator();
+  public static final TimeInterpolator FAST_OUT_LINEAR_IN_INTERPOLATOR =
+      new FastOutLinearInInterpolator();
+  public static final TimeInterpolator LINEAR_OUT_SLOW_IN_INTERPOLATOR =
+      new LinearOutSlowInInterpolator();
+  public static final TimeInterpolator DECELERATE_INTERPOLATOR = new DecelerateInterpolator();
+
+  /** Linear interpolation between {@code startValue} and {@code endValue} by {@code fraction}. */
+  public static float lerp(float startValue, float endValue, float fraction) {
+    return startValue + (fraction * (endValue - startValue));
+  }
+
+  /** Linear interpolation between {@code startValue} and {@code endValue} by {@code fraction}. */
+  public static int lerp(int startValue, int endValue, float fraction) {
+    return startValue + Math.round(fraction * (endValue - startValue));
+  }
+}

--- a/support-chip/src/main/java/android/support/design/animation/MotionSpec.java
+++ b/support-chip/src/main/java/android/support/design/animation/MotionSpec.java
@@ -1,0 +1,188 @@
+/*
+ * Copyright 2017 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package android.support.design.animation;
+
+import android.animation.Animator;
+import android.animation.AnimatorInflater;
+import android.animation.AnimatorSet;
+import android.animation.ObjectAnimator;
+import android.content.Context;
+import android.content.res.TypedArray;
+import android.support.annotation.AnimatorRes;
+import android.support.annotation.Nullable;
+import android.support.annotation.StyleableRes;
+import android.support.v4.util.SimpleArrayMap;
+import android.util.Log;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A motion spec contains multiple named {@link MotionTiming motion timings}.
+ *
+ * <p>Inflate an instance of MotionSpec from XML by creating a <a
+ * href="https://developer.android.com/guide/topics/resources/animation-resource.html#Property">Property
+ * Animation resource</a> in {@code res/animator}. The file must contain an {@code <objectAnimator>}
+ * or a {@code <set>} of object animators.
+ *
+ * <p>This class will store a map of String keys to MotionTiming values. Each animator's {@code
+ * android:propertyName} attribute will be used as the key, while the other attributes {@code
+ * android:startOffset}, {@code android:duration}, {@code android:interpolator}, {@code
+ * android:repeatCount}, and {@code android:repeatMode} will be used to create the MotionTiming
+ * instance.
+ *
+ * <p>A motion spec resource can either be an &lt;objectAnimator&gt; or a &lt;set&gt; of multiple
+ * &lt;objectAnimator&gt;.
+ *
+ * <pre>{@code
+ * <set xmlns:android="http://schemas.android.com/apk/res/android">
+ *   <objectAnimator
+ *       android:propertyName="alpha"
+ *       android:startOffset="0"
+ *       android:duration="100"
+ *       android:interpolator="@interpolator/mtrl_fast_out_slow_in"/>
+ *   <objectAnimator
+ *       android:propertyName="translation"
+ *       android:startOffset="50"
+ *       android:duration="150"/>
+ * </set>
+ * }</pre>
+ */
+public class MotionSpec {
+
+  private static final String TAG = "MotionSpec";
+
+  private final SimpleArrayMap<String, MotionTiming> timings = new SimpleArrayMap<>();
+
+  /** Returns whether this motion spec contains a MotionTiming with the given name. */
+  public boolean hasTiming(String name) {
+    return timings.get(name) != null;
+  }
+
+  /**
+   * Returns the MotionTiming with the given name, or throws IllegalArgumentException if it does not
+   * exist.
+   */
+  public MotionTiming getTiming(String name) {
+    if (!hasTiming(name)) {
+      throw new IllegalArgumentException();
+    }
+    return timings.get(name);
+  }
+
+  /** Sets a MotionTiming with the given name. */
+  public void setTiming(String name, @Nullable MotionTiming timing) {
+    timings.put(name, timing);
+  }
+
+  /**
+   * Returns the total duration of this motion spec, which is the maximum delay+duration of its
+   * motion timings.
+   */
+  public long getTotalDuration() {
+    long duration = 0;
+    for (int i = 0, count = timings.size(); i < count; i++) {
+      MotionTiming timing = timings.valueAt(i);
+      duration = Math.max(duration, timing.getDelay() + timing.getDuration());
+    }
+    return duration;
+  }
+
+  /**
+   * Inflates an instance of MotionSpec from the animator resource indexed in the given attributes
+   * array.
+   */
+  @Nullable
+  public static MotionSpec createFromAttribute(
+      Context context, TypedArray attributes, @StyleableRes int index) {
+    if (attributes.hasValue(index)) {
+      int resourceId = attributes.getResourceId(index, 0);
+      if (resourceId != 0) {
+        return createFromResource(context, resourceId);
+      }
+    }
+    return null;
+  }
+
+  /** Inflates an instance of MotionSpec from the given animator resource. */
+  @Nullable
+  public static MotionSpec createFromResource(Context context, @AnimatorRes int id) {
+    try {
+      Animator animator = AnimatorInflater.loadAnimator(context, id);
+      if (animator instanceof AnimatorSet) {
+        AnimatorSet set = (AnimatorSet) animator;
+        return createSpecFromAnimators(set.getChildAnimations());
+      } else if (animator != null) {
+        List<Animator> animators = new ArrayList<>();
+        animators.add(animator);
+        return createSpecFromAnimators(animators);
+      } else {
+        return null;
+      }
+    } catch (Exception e) {
+      Log.w(TAG, "Can't load animation resource ID #0x" + Integer.toHexString(id), e);
+      return null;
+    }
+  }
+
+  private static MotionSpec createSpecFromAnimators(List<Animator> animators) {
+    MotionSpec spec = new MotionSpec();
+    for (int i = 0, count = animators.size(); i < count; i++) {
+      addTimingFromAnimator(spec, animators.get(i));
+    }
+    return spec;
+  }
+
+  private static void addTimingFromAnimator(MotionSpec spec, Animator animator) {
+    if (animator instanceof ObjectAnimator) {
+      ObjectAnimator anim = (ObjectAnimator) animator;
+      spec.setTiming(anim.getPropertyName(), MotionTiming.createFromAnimator(anim));
+    } else {
+      throw new IllegalArgumentException("Animator must be an ObjectAnimator: " + animator);
+    }
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    MotionSpec that = (MotionSpec) o;
+
+    return timings.equals(that.timings);
+  }
+
+  @Override
+  public int hashCode() {
+    return timings.hashCode();
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder out = new StringBuilder();
+    out.append('\n');
+    out.append(getClass().getName());
+    out.append('{');
+    out.append(Integer.toHexString(System.identityHashCode(this)));
+    out.append(" timings: ");
+    out.append(timings);
+    out.append("}\n");
+    return out.toString();
+  }
+}

--- a/support-chip/src/main/java/android/support/design/animation/MotionTiming.java
+++ b/support-chip/src/main/java/android/support/design/animation/MotionTiming.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright 2017 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package android.support.design.animation;
+
+import android.animation.Animator;
+import android.animation.TimeInterpolator;
+import android.animation.ValueAnimator;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.view.animation.AccelerateDecelerateInterpolator;
+import android.view.animation.AccelerateInterpolator;
+import android.view.animation.DecelerateInterpolator;
+
+/** A representation of timing for an animation. */
+public class MotionTiming {
+
+  private long delay = 0;
+  private long duration = 300;
+  /** Set to an instance, or null for {@link AnimationUtils#FAST_OUT_SLOW_IN_INTERPOLATOR}. */
+  @Nullable private TimeInterpolator interpolator = null;
+  /** Set to 0, greater than 0, or {@link ValueAnimator#INFINITE}. */
+  private int repeatCount = 0;
+  /** Set to {@link ValueAnimator#RESTART} or {@link ValueAnimator#REVERSE}. */
+  private int repeatMode = ValueAnimator.RESTART;
+
+  public MotionTiming(long delay, long duration) {
+    this.delay = delay;
+    this.duration = duration;
+  }
+
+  public MotionTiming(long delay, long duration, @NonNull TimeInterpolator interpolator) {
+    this.delay = delay;
+    this.duration = duration;
+    this.interpolator = interpolator;
+  }
+
+  public void apply(Animator animator) {
+    animator.setStartDelay(getDelay());
+    animator.setDuration(getDuration());
+    animator.setInterpolator(getInterpolator());
+    if (animator instanceof ValueAnimator) {
+      ((ValueAnimator) animator).setRepeatCount(getRepeatCount());
+      ((ValueAnimator) animator).setRepeatMode(getRepeatMode());
+    }
+  }
+
+  public long getDelay() {
+    return delay;
+  }
+
+  public long getDuration() {
+    return duration;
+  }
+
+  public TimeInterpolator getInterpolator() {
+    return interpolator != null ? interpolator : AnimationUtils.FAST_OUT_SLOW_IN_INTERPOLATOR;
+  }
+
+  public int getRepeatCount() {
+    return repeatCount;
+  }
+
+  public int getRepeatMode() {
+    return repeatMode;
+  }
+
+  static MotionTiming createFromAnimator(ValueAnimator animator) {
+    MotionTiming timing =
+        new MotionTiming(
+            animator.getStartDelay(), animator.getDuration(), getInterpolatorCompat(animator));
+    timing.repeatCount = animator.getRepeatCount();
+    timing.repeatMode = animator.getRepeatMode();
+    return timing;
+  }
+
+  /**
+   * This compat implementation enables pre-21 support for
+   * {@code @interpolator/mtrl_fast_out_linear_in}, {@code @interpolator/mtrl_fast_out_slow_in}, and
+   * {@code @interpolator/mtrl_linear_out_slow_in}. Because the respective
+   * {@code @android:interpolator/} resources are not available in pre-21, we use
+   * {@code @android:interpolator/accelerate_quad},
+   * {@code @android:interpolator/accelerate_decelerate}, and
+   * {@code @android:interpolator/decelerate_quad} respectively. This method maps those compat
+   * interpolators back to Material interpolators, which can be instantiated dynamically.
+   */
+  private static TimeInterpolator getInterpolatorCompat(ValueAnimator animator) {
+    @Nullable TimeInterpolator interpolator = animator.getInterpolator();
+    if (interpolator instanceof AccelerateDecelerateInterpolator || interpolator == null) {
+      return AnimationUtils.FAST_OUT_SLOW_IN_INTERPOLATOR;
+    } else if (interpolator instanceof AccelerateInterpolator) {
+      return AnimationUtils.FAST_OUT_LINEAR_IN_INTERPOLATOR;
+    } else if (interpolator instanceof DecelerateInterpolator) {
+      return AnimationUtils.LINEAR_OUT_SLOW_IN_INTERPOLATOR;
+    } else {
+      return interpolator;
+    }
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    MotionTiming that = (MotionTiming) o;
+
+    if (getDelay() != that.getDelay()) {
+      return false;
+    }
+    if (getDuration() != that.getDuration()) {
+      return false;
+    }
+    if (getRepeatCount() != that.getRepeatCount()) {
+      return false;
+    }
+    if (getRepeatMode() != that.getRepeatMode()) {
+      return false;
+    }
+    return getInterpolator().getClass().equals(that.getInterpolator().getClass());
+  }
+
+  @Override
+  public int hashCode() {
+    int result = (int) (getDelay() ^ (getDelay() >>> 32));
+    result = 31 * result + (int) (getDuration() ^ (getDuration() >>> 32));
+    result = 31 * result + getInterpolator().getClass().hashCode();
+    result = 31 * result + getRepeatCount();
+    result = 31 * result + getRepeatMode();
+    return result;
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder out = new StringBuilder();
+    out.append('\n');
+    out.append(getClass().getName());
+    out.append('{');
+    out.append(Integer.toHexString(System.identityHashCode(this)));
+    out.append(" delay: ");
+    out.append(getDelay());
+    out.append(" duration: ");
+    out.append(getDuration());
+    out.append(" interpolator: ");
+    out.append(getInterpolator().getClass());
+    out.append(" repeatCount: ");
+    out.append(getRepeatCount());
+    out.append(" repeatMode: ");
+    out.append(getRepeatMode());
+    out.append("}\n");
+    return out.toString();
+  }
+}

--- a/support-chip/src/main/java/android/support/design/canvas/CanvasCompat.java
+++ b/support-chip/src/main/java/android/support/design/canvas/CanvasCompat.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2017 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package android.support.design.canvas;
+
+import android.graphics.Canvas;
+import android.graphics.Paint;
+import android.graphics.RectF;
+import android.os.Build.VERSION;
+import android.os.Build.VERSION_CODES;
+import android.support.annotation.RestrictTo;
+
+import static android.support.annotation.RestrictTo.Scope.LIBRARY_GROUP;
+
+/** Compat methods for Canvas. */
+@RestrictTo(LIBRARY_GROUP)
+public class CanvasCompat {
+
+  private CanvasCompat() {}
+
+  /**
+   * Convenience for {@link Canvas#saveLayer(RectF, Paint)} but instead of taking a entire Paint
+   * object it takes only the {@code alpha} parameter.
+   */
+  public static int saveLayerAlpha(Canvas canvas, RectF bounds, int alpha) {
+    if (VERSION.SDK_INT > VERSION_CODES.LOLLIPOP) {
+      return canvas.saveLayerAlpha(bounds, alpha);
+    } else {
+      return canvas.saveLayerAlpha(bounds, alpha, Canvas.ALL_SAVE_FLAG);
+    }
+  }
+
+  /**
+   * Convenience for {@link #saveLayerAlpha(Canvas, RectF, int)} that takes the four float
+   * coordinates of the bounds rectangle.
+   */
+  public static int saveLayerAlpha(
+      Canvas canvas, float left, float top, float right, float bottom, int alpha) {
+    if (VERSION.SDK_INT > VERSION_CODES.LOLLIPOP) {
+      return canvas.saveLayerAlpha(left, top, right, bottom, alpha);
+    } else {
+      return canvas.saveLayerAlpha(left, top, right, bottom, alpha, Canvas.ALL_SAVE_FLAG);
+    }
+  }
+}

--- a/support-chip/src/main/java/android/support/design/chip/Chip.java
+++ b/support-chip/src/main/java/android/support/design/chip/Chip.java
@@ -1,0 +1,1082 @@
+/*
+ * Copyright 2017 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package android.support.design.chip;
+
+import android.annotation.SuppressLint;
+import android.annotation.TargetApi;
+import android.content.Context;
+import android.content.res.ColorStateList;
+import android.graphics.Outline;
+import android.graphics.Rect;
+import android.graphics.RectF;
+import android.graphics.drawable.Drawable;
+import android.graphics.drawable.RippleDrawable;
+import android.os.Build.VERSION;
+import android.os.Build.VERSION_CODES;
+import android.os.Bundle;
+import android.support.annotation.AnimatorRes;
+import android.support.annotation.BoolRes;
+import android.support.annotation.CallSuper;
+import android.support.annotation.ColorRes;
+import android.support.annotation.DimenRes;
+import android.support.annotation.DrawableRes;
+import android.support.annotation.IntDef;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.support.annotation.StringRes;
+import android.support.annotation.StyleRes;
+import android.support.design.animation.MotionSpec;
+import android.support.design.chip.ChipDrawable.Delegate;
+import android.support.design.internal.ViewUtils;
+import android.support.design.resources.TextAppearance;
+import android.support.design.ripple.RippleUtils;
+import android.support.v4.view.ViewCompat;
+import android.support.v4.view.accessibility.AccessibilityNodeInfoCompat;
+import android.support.v4.view.accessibility.AccessibilityNodeInfoCompat.AccessibilityActionCompat;
+import android.support.v4.widget.ExploreByTouchHelper;
+import android.support.v7.widget.AppCompatCheckBox;
+import android.util.AttributeSet;
+import android.view.KeyEvent;
+import android.view.MotionEvent;
+import android.view.PointerIcon;
+import android.view.SoundEffectConstants;
+import android.view.View;
+import android.view.ViewOutlineProvider;
+import android.view.ViewParent;
+import android.view.accessibility.AccessibilityEvent;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.util.List;
+
+/**
+ * Chips are compact elements that represent an attribute, text, entity, or action. They allow users
+ * to enter information, select a choice, filter content, or trigger an action.
+ *
+ * <p>The Chip widget is a thin view wrapper around the {@link ChipDrawable}, which contains all of
+ * the layout and draw logic. The extra logic exists to support touch, mouse, keyboard, and
+ * accessibility navigation. The main chip and close icon are considered to be separate logical
+ * sub-views, and contain their own navigation behavior and state.
+ *
+ * <p>All attributes from {@link R.styleable#ChipDrawable} are supported. Do not use the {@code
+ * android:background} and {@code android:text} attributes. They will be ignored because Chip
+ * manages its own background Drawable and text. The basic attributes you can set are:
+ *
+ * <ul>
+ *   <li>{@link android.R.attr#checkable android:checkable} - If true, the chip can be toggled. If
+ *       false, the chip acts like a button.
+ *   <li>{@link R.attr#chipText app:chipText} - Sets the text of the chip.
+ *   <li>{@link R.attr#chipIcon app:chipIcon} and {@link R.attr#chipIconEnabled app:chipIconEnabled}
+ *       - Sets the icon of the chip. Usually on the left.
+ *   <li>{@link R.attr#checkedIcon app:checkedIcon} and {@link R.attr#checkedIconEnabled
+ *       app:checkedIconEnabled} - Sets a custom icon to use when checked. Usually on the left.
+ *   <li>{@link R.attr#closeIcon app:closeIcon} and {@link R.attr#closeIconEnabled
+ *       app:closeIconEnabled} - Sets a custom icon that the user can click to close. Usually on the
+ *       right.
+ * </ul>
+ *
+ * <p>You can register a listener on the main chip with {@link #setOnClickListener(OnClickListener)}
+ * or {@link #setOnCheckedChangeListener(OnCheckedChangeListener)}. You can register a listener on
+ * the close icon with {@link #setOnCloseIconClickListener(OnClickListener)}.
+ *
+ * @see ChipDrawable
+ */
+public class Chip extends AppCompatCheckBox implements Delegate {
+
+  private static final int CLOSE_ICON_VIRTUAL_ID = 0;
+  private static final Rect EMPTY_BOUNDS = new Rect();
+
+  private static final int[] SELECTED_STATE = new int[] {android.R.attr.state_selected};
+
+  @Retention(RetentionPolicy.SOURCE)
+  @IntDef({ExploreByTouchHelper.INVALID_ID, ExploreByTouchHelper.HOST_ID, CLOSE_ICON_VIRTUAL_ID})
+  private @interface VirtualId {}
+
+  @Nullable private ChipDrawable chipDrawable;
+
+  @Nullable private OnClickListener onCloseIconClickListener;
+  @Nullable private OnCheckedChangeListener onCheckedChangeListenerInternal;
+  private boolean deferredCheckedValue;
+  @VirtualId private int focusedVirtualView = ExploreByTouchHelper.INVALID_ID;
+  private boolean closeIconPressed;
+  private boolean closeIconHovered;
+  private boolean closeIconFocused;
+
+  private final ChipTouchHelper touchHelper;
+  private final Rect rect = new Rect();
+  private final RectF rectF = new RectF();
+
+  public Chip(Context context) {
+    this(context, null);
+  }
+
+  public Chip(Context context, AttributeSet attrs) {
+    this(context, attrs, R.attr.chipStyle);
+  }
+
+  public Chip(Context context, AttributeSet attrs, int defStyleAttr) {
+    super(context, attrs, defStyleAttr);
+
+    ChipDrawable drawable =
+        ChipDrawable.createFromAttributes(
+            context, attrs, defStyleAttr, R.style.Widget_MaterialComponents_Chip_Action);
+    setChipDrawable(drawable);
+
+    touchHelper = new ChipTouchHelper(this);
+    ViewCompat.setAccessibilityDelegate(this, touchHelper);
+    ViewCompat.setImportantForAccessibility(this, ViewCompat.IMPORTANT_FOR_ACCESSIBILITY_YES);
+
+    initOutlineProvider();
+    setChecked(deferredCheckedValue);
+  }
+
+  private void initOutlineProvider() {
+    if (VERSION.SDK_INT >= VERSION_CODES.LOLLIPOP) {
+      setOutlineProvider(
+          new ViewOutlineProvider() {
+            @Override
+            @TargetApi(VERSION_CODES.LOLLIPOP)
+            public void getOutline(View view, Outline outline) {
+              if (chipDrawable != null) {
+                chipDrawable.getOutline(outline);
+              } else {
+                outline.setAlpha(0.0f);
+              }
+            }
+          });
+    }
+  }
+
+  /**
+   * Returns the ChipDrawable backing this chip.
+   */
+  public Drawable getChipDrawable() {
+    return chipDrawable;
+  }
+
+  /**
+   * Sets the ChipDrawable backing this chip.
+   */
+  public void setChipDrawable(@NonNull ChipDrawable drawable) {
+    if (chipDrawable != drawable) {
+      unapplyChipDrawable(chipDrawable);
+      chipDrawable = drawable;
+      applyChipDrawable(chipDrawable);
+
+      if (RippleUtils.USE_FRAMEWORK_RIPPLE) {
+        //noinspection NewApi
+        RippleDrawable ripple =
+            new RippleDrawable(
+                RippleUtils.convertToRippleDrawableColor(chipDrawable.getRippleColor()),
+                chipDrawable,
+                null);
+        chipDrawable.setUseCompatRipple(false);
+        //noinspection NewApi
+        ViewCompat.setBackground(this, ripple);
+      } else {
+        chipDrawable.setUseCompatRipple(true);
+        ViewCompat.setBackground(this, chipDrawable);
+      }
+    }
+  }
+
+  private void unapplyChipDrawable(@Nullable ChipDrawable chipDrawable) {
+    if (chipDrawable != null) {
+      chipDrawable.setDelegate(null);
+    }
+  }
+
+  private void applyChipDrawable(@NonNull ChipDrawable chipDrawable) {
+    chipDrawable.setDelegate(this);
+  }
+
+  @Override
+  protected int[] onCreateDrawableState(int extraSpace) {
+    final int[] state = super.onCreateDrawableState(extraSpace + 1);
+    if (isChecked()) {
+      mergeDrawableStates(state, SELECTED_STATE);
+    }
+    return state;
+  }
+
+  @Override
+  public void onChipDrawableSizeChange() {
+    requestLayout();
+    if (VERSION.SDK_INT >= VERSION_CODES.LOLLIPOP) {
+      invalidateOutline();
+    }
+  }
+
+  @Override
+  public void setChecked(boolean checked) {
+    if (chipDrawable == null) {
+      // Defer the setChecked() call until after initialization.
+      deferredCheckedValue = checked;
+    } else if (chipDrawable.isCheckable()) {
+      boolean wasChecked = isChecked();
+      super.setChecked(checked);
+
+      if (wasChecked != checked) {
+        if (onCheckedChangeListenerInternal != null) {
+          onCheckedChangeListenerInternal.onCheckedChanged(this, checked);
+        }
+      }
+    }
+  }
+
+  /**
+   * Register a callback to be invoked when the checked state of this chip changes. This callback is
+   * used for internal purpose only.
+   */
+  void setOnCheckedChangeListenerInternal(OnCheckedChangeListener listener) {
+    onCheckedChangeListenerInternal = listener;
+  }
+
+  /** Register a callback to be invoked when the close icon is clicked. */
+  public void setOnCloseIconClickListener(OnClickListener listener) {
+    this.onCloseIconClickListener = listener;
+  }
+
+  /**
+   * Call this chip's {@link #onCloseIconClickListener}, if it is defined. Performs all normal
+   * actions associated with clicking: reporting accessibility event, playing a sound, etc.
+   *
+   * @return True there was an assigned {@link #onCloseIconClickListener} that was called, false
+   *     otherwise is returned.
+   */
+  @CallSuper
+  public boolean performCloseIconClick() {
+    playSoundEffect(SoundEffectConstants.CLICK);
+
+    boolean result;
+    if (onCloseIconClickListener != null) {
+      onCloseIconClickListener.onClick(this);
+      result = true;
+    } else {
+      result = false;
+    }
+
+    touchHelper.sendEventForVirtualView(
+        CLOSE_ICON_VIRTUAL_ID, AccessibilityEvent.TYPE_VIEW_CLICKED);
+    return result;
+  }
+
+  @SuppressLint("ClickableViewAccessibility") // Taken from the support library
+  @Override
+  public boolean onTouchEvent(MotionEvent event) {
+    boolean handled = false;
+
+    int action = event.getActionMasked();
+    boolean eventInCloseIcon = getCloseIconTouchBounds().contains(event.getX(), event.getY());
+    switch (action) {
+      case MotionEvent.ACTION_DOWN:
+        if (eventInCloseIcon) {
+          setCloseIconPressed(true);
+          handled = true;
+        }
+        break;
+      case MotionEvent.ACTION_MOVE:
+        if (closeIconPressed) {
+          if (!eventInCloseIcon) {
+            setCloseIconPressed(false);
+          }
+          handled = true;
+        }
+        break;
+      case MotionEvent.ACTION_UP:
+        if (closeIconPressed) {
+          performCloseIconClick();
+          handled = true;
+        }
+        // Fall-through.
+      case MotionEvent.ACTION_CANCEL:
+        setCloseIconPressed(false);
+        break;
+      default:
+        break;
+    }
+    return handled || super.onTouchEvent(event);
+  }
+
+  @Override
+  public boolean onHoverEvent(MotionEvent event) {
+    int action = event.getActionMasked();
+    switch (action) {
+      case MotionEvent.ACTION_HOVER_MOVE:
+        setCloseIconHovered(getCloseIconTouchBounds().contains(event.getX(), event.getY()));
+        break;
+      case MotionEvent.ACTION_HOVER_EXIT:
+        setCloseIconHovered(false);
+        break;
+      default:
+        break;
+    }
+    return super.onHoverEvent(event);
+  }
+
+  @Override
+  protected boolean dispatchHoverEvent(MotionEvent event) {
+    return touchHelper.dispatchHoverEvent(event) || super.dispatchHoverEvent(event);
+  }
+
+  @Override
+  protected void onFocusChanged(boolean focused, int direction, Rect previouslyFocusedRect) {
+    if (focused) {
+      // If we've gained focus from another view, always focus the chip first.
+      setFocusedVirtualView(ExploreByTouchHelper.HOST_ID);
+    } else {
+      setFocusedVirtualView(ExploreByTouchHelper.INVALID_ID);
+    }
+    invalidate();
+
+    super.onFocusChanged(focused, direction, previouslyFocusedRect);
+  }
+
+  @Override
+  public boolean onKeyDown(int keyCode, KeyEvent event) {
+    // We need to handle focus change within the Chip because we are simulating multiple Views. The
+    // left/right arrow keys will move between the chip and the close icon. Focus
+    // up/down/forward/back jumps out of the Chip to the next focusable View in the hierarchy.
+    boolean focusChanged = false;
+    switch (event.getKeyCode()) {
+      case KeyEvent.KEYCODE_DPAD_LEFT:
+        if (event.hasNoModifiers()) {
+          focusChanged = moveFocus(ViewUtils.isLayoutRtl(this));
+        }
+        break;
+      case KeyEvent.KEYCODE_DPAD_RIGHT:
+        if (event.hasNoModifiers()) {
+          focusChanged = moveFocus(!ViewUtils.isLayoutRtl(this));
+        }
+        break;
+      case KeyEvent.KEYCODE_DPAD_CENTER:
+      case KeyEvent.KEYCODE_ENTER:
+        switch (focusedVirtualView) {
+          case ExploreByTouchHelper.HOST_ID:
+            performClick();
+            return true;
+          case CLOSE_ICON_VIRTUAL_ID:
+            performCloseIconClick();
+            return true;
+          case ExploreByTouchHelper.INVALID_ID:
+          default:
+            break;
+        }
+        break;
+      case KeyEvent.KEYCODE_TAB:
+        int focusChangeDirection = 0;
+        if (event.hasNoModifiers()) {
+          focusChangeDirection = View.FOCUS_FORWARD;
+        } else if (event.hasModifiers(KeyEvent.META_SHIFT_ON)) {
+          focusChangeDirection = View.FOCUS_BACKWARD;
+        }
+        if (focusChangeDirection != 0) {
+          final ViewParent parent = getParent();
+          // Move focus out of this view.
+          View nextFocus = this;
+          do {
+            nextFocus = nextFocus.focusSearch(focusChangeDirection);
+          } while (nextFocus != null && nextFocus != this && nextFocus.getParent() == parent);
+          if (nextFocus != null) {
+            nextFocus.requestFocus();
+            return true;
+          }
+        }
+        break;
+      default:
+        break;
+    }
+    if (focusChanged) {
+      invalidate();
+      return true;
+    } else {
+      return super.onKeyDown(keyCode, event);
+    }
+  }
+
+  private boolean moveFocus(boolean positive) {
+    ensureFocus();
+    boolean focusChanged = false;
+    if (positive) {
+      if (focusedVirtualView == ExploreByTouchHelper.HOST_ID) {
+        setFocusedVirtualView(CLOSE_ICON_VIRTUAL_ID);
+        focusChanged = true;
+      }
+    } else {
+      if (focusedVirtualView == CLOSE_ICON_VIRTUAL_ID) {
+        setFocusedVirtualView(ExploreByTouchHelper.HOST_ID);
+        focusChanged = true;
+      }
+    }
+    return focusChanged;
+  }
+
+  private void ensureFocus() {
+    if (focusedVirtualView == ExploreByTouchHelper.INVALID_ID) {
+      setFocusedVirtualView(ExploreByTouchHelper.HOST_ID);
+    }
+  }
+
+  @Override
+  public void getFocusedRect(Rect r) {
+    if (focusedVirtualView == CLOSE_ICON_VIRTUAL_ID) {
+      r.set(getCloseIconTouchBoundsInt());
+    } else {
+      super.getFocusedRect(r);
+    }
+  }
+
+  private void setFocusedVirtualView(@VirtualId int virtualView) {
+    if (focusedVirtualView != virtualView) {
+      if (focusedVirtualView == CLOSE_ICON_VIRTUAL_ID) {
+        setCloseIconFocused(false);
+      }
+      focusedVirtualView = virtualView;
+      if (virtualView == CLOSE_ICON_VIRTUAL_ID) {
+        setCloseIconFocused(true);
+      }
+    }
+  }
+
+  private void setCloseIconPressed(boolean pressed) {
+    if (closeIconPressed != pressed) {
+      closeIconPressed = pressed;
+      refreshDrawableState();
+    }
+  }
+
+  private void setCloseIconHovered(boolean hovered) {
+    if (closeIconHovered != hovered) {
+      closeIconHovered = hovered;
+      refreshDrawableState();
+    }
+  }
+
+  private void setCloseIconFocused(boolean focused) {
+    if (closeIconFocused != focused) {
+      closeIconFocused = focused;
+      refreshDrawableState();
+    }
+  }
+
+  @Override
+  protected void drawableStateChanged() {
+    super.drawableStateChanged();
+
+    boolean changed = false;
+
+    if (chipDrawable != null && chipDrawable.isCloseIconStateful()) {
+      changed = chipDrawable.setCloseIconState(createCloseIconDrawableState());
+    }
+
+    if (changed) {
+      invalidate();
+    }
+  }
+
+  private int[] createCloseIconDrawableState() {
+    int count = 0;
+    if (isEnabled()) {
+      count++;
+    }
+    if (closeIconFocused) {
+      count++;
+    }
+    if (closeIconHovered) {
+      count++;
+    }
+    if (closeIconPressed) {
+      count++;
+    }
+    if (isChecked()) {
+      count++;
+    }
+
+    int[] stateSet = new int[count];
+    int i = 0;
+
+    if (isEnabled()) {
+      stateSet[i] = android.R.attr.state_enabled;
+      i++;
+    }
+    if (closeIconFocused) {
+      stateSet[i] = android.R.attr.state_focused;
+      i++;
+    }
+    if (closeIconHovered) {
+      stateSet[i] = android.R.attr.state_hovered;
+      i++;
+    }
+    if (closeIconPressed) {
+      stateSet[i] = android.R.attr.state_pressed;
+      i++;
+    }
+    if (isChecked()) {
+      stateSet[i] = android.R.attr.state_selected;
+      i++;
+    }
+    return stateSet;
+  }
+
+  private boolean hasCloseIcon() {
+    return chipDrawable != null && chipDrawable.getCloseIcon() != null;
+  }
+
+  private RectF getCloseIconTouchBounds() {
+    rectF.setEmpty();
+
+    if (hasCloseIcon()) {
+      // noinspection ConstantConditions
+      chipDrawable.getCloseIconTouchBounds(rectF);
+    }
+
+    return rectF;
+  }
+
+  private Rect getCloseIconTouchBoundsInt() {
+    RectF bounds = getCloseIconTouchBounds();
+    rect.set((int) bounds.left, (int) bounds.top, (int) bounds.right, (int) bounds.bottom);
+    return rect;
+  }
+
+  @Override
+  @TargetApi(VERSION_CODES.N)
+  public PointerIcon onResolvePointerIcon(MotionEvent event, int pointerIndex) {
+    if (getCloseIconTouchBounds().contains(event.getX(), event.getY()) && isEnabled()) {
+      return PointerIcon.getSystemIcon(getContext(), PointerIcon.TYPE_HAND);
+    }
+    return null;
+  }
+
+  /** Provides a virtual view hierarchy for the close icon. */
+  private class ChipTouchHelper extends ExploreByTouchHelper {
+
+    ChipTouchHelper(Chip view) {
+      super(view);
+    }
+
+    @Override
+    protected int getVirtualViewAt(float x, float y) {
+      return (hasCloseIcon() && getCloseIconTouchBounds().contains(x, y))
+          ? CLOSE_ICON_VIRTUAL_ID
+          : HOST_ID;
+    }
+
+    @Override
+    protected void getVisibleVirtualViews(List<Integer> virtualViewIds) {
+      if (hasCloseIcon()) {
+        virtualViewIds.add(CLOSE_ICON_VIRTUAL_ID);
+      }
+    }
+
+    @Override
+    protected void onPopulateNodeForVirtualView(
+        int virtualViewId, AccessibilityNodeInfoCompat node) {
+      if (hasCloseIcon()) {
+        node.setContentDescription(
+            getContext().getString(R.string.mtrl_chip_close_icon_content_description));
+        node.setBoundsInParent(getCloseIconTouchBoundsInt());
+        node.addAction(AccessibilityActionCompat.ACTION_CLICK);
+        node.setEnabled(isEnabled());
+      } else {
+        node.setContentDescription("");
+        node.setBoundsInParent(EMPTY_BOUNDS);
+      }
+    }
+
+    @Override
+    protected void onPopulateNodeForHost(AccessibilityNodeInfoCompat node) {
+      node.setCheckable(chipDrawable != null && chipDrawable.isCheckable());
+      node.setClassName(Chip.class.getName());
+      node.setContentDescription(
+          Chip.class.getSimpleName()
+              + ". "
+              + (chipDrawable != null ? chipDrawable.getChipText() : ""));
+    }
+
+    @Override
+    protected boolean onPerformActionForVirtualView(
+        int virtualViewId, int action, Bundle arguments) {
+      if (action == AccessibilityNodeInfoCompat.ACTION_CLICK
+          && virtualViewId == CLOSE_ICON_VIRTUAL_ID) {
+        return performCloseIconClick();
+      }
+      return false;
+    }
+  }
+
+  // Getters and setters for attributes.
+
+  @Nullable
+  public ColorStateList getChipBackgroundColor() {
+    return chipDrawable != null ? chipDrawable.getChipBackgroundColor() : null;
+  }
+
+  public void setChipBackgroundColorResource(@ColorRes int id) {
+    if (chipDrawable != null) {
+      chipDrawable.setChipBackgroundColorResource(id);
+    }
+  }
+
+  public void setChipBackgroundColor(@Nullable ColorStateList chipBackgroundColor) {
+    if (chipDrawable != null) {
+      chipDrawable.setChipBackgroundColor(chipBackgroundColor);
+    }
+  }
+
+  public float getChipMinHeight() {
+    return chipDrawable != null ? chipDrawable.getChipMinHeight() : 0;
+  }
+
+  public void setChipMinHeightResource(@DimenRes int id) {
+    if (chipDrawable != null) {
+      chipDrawable.setChipMinHeightResource(id);
+    }
+  }
+
+  public void setChipMinHeight(float minHeight) {
+    if (chipDrawable != null) {
+      chipDrawable.setChipMinHeight(minHeight);
+    }
+  }
+
+  public float getChipCornerRadius() {
+    return chipDrawable != null ? chipDrawable.getChipCornerRadius() : 0;
+  }
+
+  public void setChipCornerRadiusResource(@DimenRes int id) {
+    if (chipDrawable != null) {
+      chipDrawable.setChipCornerRadiusResource(id);
+    }
+  }
+
+  public void setChipCornerRadius(float chipCornerRadius) {
+    if (chipDrawable != null) {
+      chipDrawable.setChipCornerRadius(chipCornerRadius);
+    }
+  }
+
+  @Nullable
+  public ColorStateList getChipStrokeColor() {
+    return chipDrawable != null ? chipDrawable.getChipStrokeColor() : null;
+  }
+
+  public void setChipStrokeColorResource(@ColorRes int id) {
+    if (chipDrawable != null) {
+      chipDrawable.setChipStrokeColorResource(id);
+    }
+  }
+
+  public void setChipStrokeColor(@Nullable ColorStateList chipStrokeColor) {
+    if (chipDrawable != null) {
+      chipDrawable.setChipStrokeColor(chipStrokeColor);
+    }
+  }
+
+  public float getChipStrokeWidth() {
+    return chipDrawable != null ? chipDrawable.getChipStrokeWidth() : 0;
+  }
+
+  public void setChipStrokeWidthResource(@DimenRes int id) {
+    if (chipDrawable != null) {
+      chipDrawable.setChipStrokeWidthResource(id);
+    }
+  }
+
+  public void setChipStrokeWidth(float chipStrokeWidth) {
+    if (chipDrawable != null) {
+      chipDrawable.setChipStrokeWidth(chipStrokeWidth);
+    }
+  }
+
+  @Nullable
+  public ColorStateList getRippleColor() {
+    return chipDrawable != null ? chipDrawable.getRippleColor() : null;
+  }
+
+  public void setRippleColorResource(@ColorRes int id) {
+    if (chipDrawable != null) {
+      chipDrawable.setRippleColorResource(id);
+    }
+  }
+
+  public void setRippleColor(@Nullable ColorStateList rippleColor) {
+    if (chipDrawable != null) {
+      chipDrawable.setRippleColor(rippleColor);
+    }
+  }
+
+  @Nullable
+  public CharSequence getChipText() {
+    return chipDrawable != null ? chipDrawable.getChipText() : null;
+  }
+
+  public void setChipTextResource(@StringRes int id) {
+    if (chipDrawable != null) {
+      chipDrawable.setChipTextResource(id);
+    }
+  }
+
+  public void setChipText(@Nullable CharSequence chipText) {
+    if (chipDrawable != null) {
+      chipDrawable.setChipText(chipText);
+    }
+  }
+
+  @Nullable
+  public TextAppearance getTextAppearance() {
+    return chipDrawable != null ? chipDrawable.getTextAppearance() : null;
+  }
+
+  public void setTextAppearanceResource(@StyleRes int id) {
+    if (chipDrawable != null) {
+      chipDrawable.setTextAppearanceResource(id);
+    }
+  }
+
+  public void setTextAppearance(@Nullable TextAppearance textAppearance) {
+    if (chipDrawable != null) {
+      chipDrawable.setTextAppearance(textAppearance);
+    }
+  }
+
+  public boolean isChipIconEnabled() {
+    return chipDrawable != null && chipDrawable.isChipIconEnabled();
+  }
+
+  public void setChipIconEnabledResource(@BoolRes int id) {
+    if (chipDrawable != null) {
+      chipDrawable.setChipIconEnabledResource(id);
+    }
+  }
+
+  public void setChipIconEnabled(boolean chipIconEnabled) {
+    if (chipDrawable != null) {
+      chipDrawable.setChipIconEnabled(chipIconEnabled);
+    }
+  }
+
+  @Nullable
+  public Drawable getChipIcon() {
+    return chipDrawable != null ? chipDrawable.getChipIcon() : null;
+  }
+
+  public void setChipIconResource(@DrawableRes int id) {
+    if (chipDrawable != null) {
+      chipDrawable.setChipIconResource(id);
+    }
+  }
+
+  public void setChipIcon(@Nullable Drawable chipIcon) {
+    if (chipDrawable != null) {
+      chipDrawable.setChipIcon(chipIcon);
+    }
+  }
+
+  public float getChipIconSize() {
+    return chipDrawable != null ? chipDrawable.getChipIconSize() : 0;
+  }
+
+  public void setChipIconSizeResource(@DimenRes int id) {
+    if (chipDrawable != null) {
+      chipDrawable.setChipIconSizeResource(id);
+    }
+  }
+
+  public void setChipIconSize(float chipIconSize) {
+    if (chipDrawable != null) {
+      chipDrawable.setChipIconSize(chipIconSize);
+    }
+  }
+
+  public boolean isCloseIconEnabled() {
+    return chipDrawable != null && chipDrawable.isCloseIconEnabled();
+  }
+
+  public void setCloseIconEnabledResource(@BoolRes int id) {
+    if (chipDrawable != null) {
+      chipDrawable.setCloseIconEnabledResource(id);
+    }
+  }
+
+  public void setCloseIconEnabled(boolean closeIconEnabled) {
+    if (chipDrawable != null) {
+      chipDrawable.setCloseIconEnabled(closeIconEnabled);
+    }
+  }
+
+  @Nullable
+  public Drawable getCloseIcon() {
+    return chipDrawable != null ? chipDrawable.getCloseIcon() : null;
+  }
+
+  public void setCloseIconResource(@DrawableRes int id) {
+    if (chipDrawable != null) {
+      chipDrawable.setCloseIconResource(id);
+    }
+  }
+
+  public void setCloseIcon(@Nullable Drawable closeIcon) {
+    if (chipDrawable != null) {
+      chipDrawable.setCloseIcon(closeIcon);
+    }
+  }
+
+  @Nullable
+  public ColorStateList getCloseIconTint() {
+    return chipDrawable != null ? chipDrawable.getCloseIconTint() : null;
+  }
+
+  public void setCloseIconTintResource(@ColorRes int id) {
+    if (chipDrawable != null) {
+      chipDrawable.setCloseIconTintResource(id);
+    }
+  }
+
+  public void setCloseIconTint(@Nullable ColorStateList closeIconTint) {
+    if (chipDrawable != null) {
+      chipDrawable.setCloseIconTint(closeIconTint);
+    }
+  }
+
+  public float getCloseIconSize() {
+    return chipDrawable != null ? chipDrawable.getCloseIconSize() : 0;
+  }
+
+  public void setCloseIconSizeResource(@DimenRes int id) {
+    if (chipDrawable != null) {
+      chipDrawable.setCloseIconSizeResource(id);
+    }
+  }
+
+  public void setCloseIconSize(float closeIconSize) {
+    if (chipDrawable != null) {
+      chipDrawable.setCloseIconSize(closeIconSize);
+    }
+  }
+
+  public boolean isCheckable() {
+    return chipDrawable != null && chipDrawable.isCheckable();
+  }
+
+  public void setCheckableResource(@BoolRes int id) {
+    if (chipDrawable != null) {
+      chipDrawable.setCheckableResource(id);
+    }
+  }
+
+  public void setCheckable(boolean checkable) {
+    if (chipDrawable != null) {
+      chipDrawable.setCheckable(checkable);
+    }
+  }
+
+  public boolean isCheckedIconEnabled() {
+    return chipDrawable != null && chipDrawable.isCheckedIconEnabled();
+  }
+
+  public void setCheckedIconEnabledResource(@BoolRes int id) {
+    if (chipDrawable != null) {
+      chipDrawable.setCheckedIconEnabledResource(id);
+    }
+  }
+
+  public void setCheckedIconEnabled(boolean checkedIconEnabled) {
+    if (chipDrawable != null) {
+      chipDrawable.setCheckedIconEnabled(checkedIconEnabled);
+    }
+  }
+
+  @Nullable
+  public Drawable getCheckedIcon() {
+    return chipDrawable != null ? chipDrawable.getCheckedIcon() : null;
+  }
+
+  public void setCheckedIconResource(@DrawableRes int id) {
+    if (chipDrawable != null) {
+      chipDrawable.setCheckedIconResource(id);
+    }
+  }
+
+  public void setCheckedIcon(@Nullable Drawable checkedIcon) {
+    if (chipDrawable != null) {
+      chipDrawable.setCheckedIcon(checkedIcon);
+    }
+  }
+
+  @Nullable
+  public MotionSpec getShowMotionSpec() {
+    return chipDrawable != null ? chipDrawable.getShowMotionSpec() : null;
+  }
+
+  public void setShowMotionSpecResource(@AnimatorRes int id) {
+    if (chipDrawable != null) {
+      chipDrawable.setShowMotionSpecResource(id);
+    }
+  }
+
+  public void setShowMotionSpec(@Nullable MotionSpec showMotionSpec) {
+    if (chipDrawable != null) {
+      chipDrawable.setShowMotionSpec(showMotionSpec);
+    }
+  }
+
+  @Nullable
+  public MotionSpec getHideMotionSpec() {
+    return chipDrawable != null ? chipDrawable.getHideMotionSpec() : null;
+  }
+
+  public void setHideMotionSpecResource(@AnimatorRes int id) {
+    if (chipDrawable != null) {
+      chipDrawable.setHideMotionSpecResource(id);
+    }
+  }
+
+  public void setHideMotionSpec(@Nullable MotionSpec hideMotionSpec) {
+    if (chipDrawable != null) {
+      chipDrawable.setHideMotionSpec(hideMotionSpec);
+    }
+  }
+
+  public float getChipStartPadding() {
+    return chipDrawable != null ? chipDrawable.getChipStartPadding() : 0;
+  }
+
+  public void setChipStartPaddingResource(@DimenRes int id) {
+    if (chipDrawable != null) {
+      chipDrawable.setChipStartPaddingResource(id);
+    }
+  }
+
+  public void setChipStartPadding(float chipStartPadding) {
+    if (chipDrawable != null) {
+      chipDrawable.setChipStartPadding(chipStartPadding);
+    }
+  }
+
+  public float getIconStartPadding() {
+    return chipDrawable != null ? chipDrawable.getIconStartPadding() : 0;
+  }
+
+  public void setIconStartPaddingResource(@DimenRes int id) {
+    if (chipDrawable != null) {
+      chipDrawable.setIconStartPaddingResource(id);
+    }
+  }
+
+  public void setIconStartPadding(float iconStartPadding) {
+    if (chipDrawable != null) {
+      chipDrawable.setIconStartPadding(iconStartPadding);
+    }
+  }
+
+  public float getIconEndPadding() {
+    return chipDrawable != null ? chipDrawable.getIconEndPadding() : 0;
+  }
+
+  public void setIconEndPaddingResource(@DimenRes int id) {
+    if (chipDrawable != null) {
+      chipDrawable.setIconEndPaddingResource(id);
+    }
+  }
+
+  public void setIconEndPadding(float iconEndPadding) {
+    if (chipDrawable != null) {
+      chipDrawable.setIconEndPadding(iconEndPadding);
+    }
+  }
+
+  public float getTextStartPadding() {
+    return chipDrawable != null ? chipDrawable.getTextStartPadding() : 0;
+  }
+
+  public void setTextStartPaddingResource(@DimenRes int id) {
+    if (chipDrawable != null) {
+      chipDrawable.setTextStartPaddingResource(id);
+    }
+  }
+
+  public void setTextStartPadding(float textStartPadding) {
+    if (chipDrawable != null) {
+      chipDrawable.setTextStartPadding(textStartPadding);
+    }
+  }
+
+  public float getTextEndPadding() {
+    return chipDrawable != null ? chipDrawable.getTextEndPadding() : 0;
+  }
+
+  public void setTextEndPaddingResource(@DimenRes int id) {
+    if (chipDrawable != null) {
+      chipDrawable.setTextEndPaddingResource(id);
+    }
+  }
+
+  public void setTextEndPadding(float textEndPadding) {
+    if (chipDrawable != null) {
+      chipDrawable.setTextEndPadding(textEndPadding);
+    }
+  }
+
+  public float getCloseIconStartPadding() {
+    return chipDrawable != null ? chipDrawable.getCloseIconStartPadding() : 0;
+  }
+
+  public void setCloseIconStartPaddingResource(@DimenRes int id) {
+    if (chipDrawable != null) {
+      chipDrawable.setCloseIconStartPaddingResource(id);
+    }
+  }
+
+  public void setCloseIconStartPadding(float closeIconStartPadding) {
+    if (chipDrawable != null) {
+      chipDrawable.setCloseIconStartPadding(closeIconStartPadding);
+    }
+  }
+
+  public float getCloseIconEndPadding() {
+    return chipDrawable != null ? chipDrawable.getCloseIconEndPadding() : 0;
+  }
+
+  public void setCloseIconEndPaddingResource(@DimenRes int id) {
+    if (chipDrawable != null) {
+      chipDrawable.setCloseIconEndPaddingResource(id);
+    }
+  }
+
+  public void setCloseIconEndPadding(float closeIconEndPadding) {
+    if (chipDrawable != null) {
+      chipDrawable.setCloseIconEndPadding(closeIconEndPadding);
+    }
+  }
+
+  public float getChipEndPadding() {
+    return chipDrawable != null ? chipDrawable.getChipEndPadding() : 0;
+  }
+
+  public void setChipEndPaddingResource(@DimenRes int id) {
+    if (chipDrawable != null) {
+      chipDrawable.setChipEndPaddingResource(id);
+    }
+  }
+
+  public void setChipEndPadding(float chipEndPadding) {
+    if (chipDrawable != null) {
+      chipDrawable.setChipEndPadding(chipEndPadding);
+    }
+  }
+}

--- a/support-chip/src/main/java/android/support/design/chip/ChipDrawable.java
+++ b/support-chip/src/main/java/android/support/design/chip/ChipDrawable.java
@@ -1,0 +1,1752 @@
+/*
+ * Copyright 2017 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package android.support.design.chip;
+
+import android.annotation.TargetApi;
+import android.content.Context;
+import android.content.res.ColorStateList;
+import android.content.res.Resources.NotFoundException;
+import android.content.res.TypedArray;
+import android.graphics.Canvas;
+import android.graphics.Color;
+import android.graphics.ColorFilter;
+import android.graphics.Outline;
+import android.graphics.Paint;
+import android.graphics.Paint.Align;
+import android.graphics.Paint.FontMetrics;
+import android.graphics.Paint.Style;
+import android.graphics.PixelFormat;
+import android.graphics.PointF;
+import android.graphics.PorterDuff.Mode;
+import android.graphics.PorterDuffColorFilter;
+import android.graphics.Rect;
+import android.graphics.RectF;
+import android.graphics.drawable.Drawable;
+import android.graphics.drawable.Drawable.Callback;
+import android.os.Build.VERSION_CODES;
+import android.support.annotation.AnimatorRes;
+import android.support.annotation.AttrRes;
+import android.support.annotation.BoolRes;
+import android.support.annotation.ColorInt;
+import android.support.annotation.ColorRes;
+import android.support.annotation.DimenRes;
+import android.support.annotation.DrawableRes;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.support.annotation.StringRes;
+import android.support.annotation.StyleRes;
+import android.support.annotation.XmlRes;
+import android.support.design.animation.MotionSpec;
+import android.support.design.canvas.CanvasCompat;
+import android.support.design.drawable.DrawableUtils;
+import android.support.design.internal.ThemeEnforcement;
+import android.support.design.resources.MaterialResources;
+import android.support.design.resources.TextAppearance;
+import android.support.design.ripple.RippleUtils;
+import android.support.v4.graphics.ColorUtils;
+import android.support.v4.graphics.drawable.DrawableCompat;
+import android.support.v4.graphics.drawable.TintAwareDrawable;
+import android.support.v4.text.BidiFormatter;
+import android.support.v7.content.res.AppCompatResources;
+import android.text.TextPaint;
+import android.text.TextUtils;
+import android.util.AttributeSet;
+import android.util.Xml;
+import android.view.View;
+
+import java.io.IOException;
+import java.lang.ref.WeakReference;
+import java.util.Arrays;
+
+import org.xmlpull.v1.XmlPullParser;
+import org.xmlpull.v1.XmlPullParserException;
+
+/**
+ * ChipDrawable contains all the layout and draw logic for {@link Chip}.
+ *
+ * <p>You can use ChipDrawable directly in contexts that require a Drawable. For example, an
+ * auto-complete enabled EditText can replace snippets of text with a ChipDrawable to represent it
+ * as a semantic entity. To create an instance of ChipDrawable, use {@link
+ * ChipDrawable#createFromResource(Context, int)} and pass in an XML resource in this form:
+ *
+ * <pre>{@code
+ * <chip xmlns:app="http://schemas.android.com/apk/res-auto"
+ *     app:chipText="Hello, World!"/>
+ * }</pre>
+ *
+ * <p>The basic attributes you can set are:
+ *
+ * <ul>
+ *   <li>{@link android.R.attr#checkable android:checkable} - If true, the chip can be toggled. If
+ *       false, the chip acts like a button.
+ *   <li>{@link R.attr#chipText app:chipText} - Sets the text of the chip.
+ *   <li>{@link R.attr#chipIcon app:chipIcon} - Sets the icon of the chip, or use @null to display
+ *       no icon. Usually on the left.
+ *   <li>{@link R.attr#checkedIcon app:checkedIcon} - Sets a custom icon to use when checked, or
+ *       use @null to display no icon. Usually on the left.
+ *   <li>{@link R.attr#closeIcon app:closeIcon} - Sets a custom icon that the user can click to
+ *       close, or use @null to display no icon. Usually on the right.
+ * </ul>
+ *
+ * <p>When used in this stand-alone mode, the host view must explicitly manage the ChipDrawable's
+ * state:
+ *
+ * <ul>
+ *   <li>{@link ChipDrawable#setBounds(int, int, int, int)}, taking into account {@link
+ *       ChipDrawable#getIntrinsicWidth()} and {@link ChipDrawable#getIntrinsicWidth()}.
+ *   <li>{@link ChipDrawable#draw(Canvas)}
+ *   <li>{@link ChipDrawable#setCallback(Callback)}, to support invalidations on the chip drawable
+ *       or any of its child drawables. This includes animations.
+ *   <li>{@link ChipDrawable#setState(int[])}, to support checking the chip, and
+ *       touch/mouse/keyboard interactions on the chip.
+ *   <li>{@link ChipDrawable#setCloseIconState(int[])}, to support touch, mouse, or keyboard
+ *       interactions on the close icon.
+ *   <li>{@link ChipDrawable#setHotspot(float, float)}
+ *   <li>{@link ChipDrawable#setLayoutDirection(int)}, to support RTL mode.
+ * </ul>
+ *
+ * <p>ChipDrawable's horizontal layout is as follows:
+ *
+ * <pre>
+ *   chipStartPadding     iconEndPadding     closeIconStartPadding         chipEndPadding
+ *    +                    +                                    +                      +
+ *    |                    |                                    |                      |
+ *    |  iconStartPadding  |  textStartPadding   textEndPadding | closeIconEndPadding  |
+ *    |   +                |    +                            +  |                  +   |
+ *    |   |                |    |                            |  |                  |   |
+ *    v   v                v    v                            v  v                  v   v
+ * +-----+----+-----------+----+----+---------------------+----+----+----------+----+-----+
+ * |     |    |       XX  |    |    |  XX   X  X  X  XXX  |    |    | X      X |    |     |
+ * |     |    |      XX   |    |    | X  X  X  X  X  X  X |    |    |  XX  XX  |    |     |
+ * |     |    |  XX XX    |    |    | X     XXXX  X  XXX  |    |    |    XX    |    |     |
+ * |     |    |   XXX     |    |    | X  X  X  X  X  X    |    |    |  XX  XX  |    |     |
+ * |     |    |    X      |    |    |  XX   X  X  X  X    |    |    | X      X |    |     |
+ * +-----+----+-----------+----+----+---------------------+----+----+----------+----+-----+
+ *                  ^                           ^                         ^
+ *                  |                           |                         |
+ *                  +                           +                         +
+ *             chipIconSize                  *dynamic*              closeIconSize
+ * </pre>
+ *
+ * <p>ChipDrawable contains three child drawables: {@link #chipIcon}, {@link #checkedIcon}, and
+ * {@link #closeIcon}. chipIcon and checkedIcon inherit the state of this drawable, but closeIcon
+ * contains its own state that you can set with {@link #setCloseIconState(int[])}.
+ *
+ * @see Chip
+ */
+public class ChipDrawable extends Drawable implements TintAwareDrawable, Callback {
+
+  private static final boolean DEBUG = false;
+  private static final int[] DEFAULT_STATE = new int[] {android.R.attr.state_enabled};
+
+  // Visuals
+  @Nullable private ColorStateList chipBackgroundColor;
+  private float chipMinHeight;
+  private float chipCornerRadius;
+  @Nullable private ColorStateList chipStrokeColor;
+  private float chipStrokeWidth;
+  @Nullable private ColorStateList rippleColor;
+
+  // Text
+  @Nullable private CharSequence chipText;
+  @Nullable private TextAppearance textAppearance;
+
+  // Chip icon
+  private boolean chipIconEnabled;
+  @Nullable private Drawable chipIcon;
+  private float chipIconSize;
+
+  // Close icon
+  private boolean closeIconEnabled;
+  @Nullable private Drawable closeIcon;
+  @Nullable private ColorStateList closeIconTint;
+  private float closeIconSize;
+
+  // Checkable
+  private boolean checkable;
+  private boolean checkedIconEnabled;
+  @Nullable private Drawable checkedIcon;
+
+  // Animations
+  @Nullable private MotionSpec showMotionSpec;
+  @Nullable private MotionSpec hideMotionSpec;
+
+  // The following attributes are adjustable padding on the chip, listed from start to end.
+
+  // Chip starts here.
+
+  /** Padding at the start of the chip, before the icon. */
+  private float chipStartPadding;
+  /** Padding at the start of the icon, after the start of the chip. If icon exists. */
+  private float iconStartPadding;
+
+  // Icon is here.
+
+  /** Padding at the end of the icon, before the text. If icon exists. */
+  private float iconEndPadding;
+  /** Padding at the start of the text, after the icon. */
+  private float textStartPadding;
+
+  // Text is here.
+
+  /** Padding at the end of the text, before the close icon. */
+  private float textEndPadding;
+  /** Padding at the start of the close icon, after the text. If close icon exists. */
+  private float closeIconStartPadding;
+
+  // Close icon is here.
+
+  /** Padding at the end of the close icon, before the end of the chip. If close icon exists. */
+  private float closeIconEndPadding;
+  /** Padding at the end of the chip, after the close icon. */
+  private float chipEndPadding;
+
+  // Chip ends here.
+
+  private final Context context;
+  private final TextPaint textPaint = new TextPaint(Paint.ANTI_ALIAS_FLAG);
+  private final Paint chipPaint = new Paint(Paint.ANTI_ALIAS_FLAG);
+  @Nullable private final Paint debugPaint;
+  private final FontMetrics fontMetrics = new FontMetrics();
+  private final RectF rectF = new RectF();
+  private final PointF pointF = new PointF();
+
+  @ColorInt private int currentChipBackgroundColor;
+  @ColorInt private int currentChipStrokeColor;
+  @ColorInt private int currentCompatRippleColor;
+  @ColorInt private int currentChipTextColor;
+  private boolean currentChecked;
+  @ColorInt private int currentTint;
+
+  private int alpha = 255;
+  @Nullable private ColorFilter colorFilter;
+  @Nullable private PorterDuffColorFilter tintFilter;
+  @Nullable private ColorStateList tint;
+  @Nullable private Mode tintMode = Mode.SRC_IN;
+  private int[] closeIconStateSet;
+  private boolean useCompatRipple;
+  @Nullable private ColorStateList compatRippleColor;
+  private WeakReference<Delegate> delegate = new WeakReference<>(null);
+  private boolean chipTextWidthDirty = true;
+  private float chipTextWidth;
+
+  /** Returns a ChipDrawable from the given attributes. */
+  public static ChipDrawable createFromAttributes(
+      Context context, AttributeSet attrs, @AttrRes int defStyleAttr, @StyleRes int defStyleRes) {
+    ChipDrawable chip = new ChipDrawable(context);
+    chip.loadFromAttributes(attrs, defStyleAttr, defStyleRes);
+    return chip;
+  }
+
+  /**
+   * Returns a ChipDrawable from the given XML resource. All attributes from {@link
+   * R.styleable#ChipDrawable} and a custom <code>style</code> attribute are supported. A chip
+   * resource may look like:
+   *
+   * <pre>{@code
+   * <chip
+   *     xmlns:app="http://schemas.android.com/apk/res-auto"
+   *     style="@style/Widget.MaterialComponents.Chip.Entry"
+   *     app:chipIcon="@drawable/custom_icon"/>
+   * }</pre>
+   */
+  public static ChipDrawable createFromResource(Context context, @XmlRes int id) {
+    try {
+      XmlPullParser parser = context.getResources().getXml(id);
+
+      int type;
+      do {
+        type = parser.next();
+      } while (type != XmlPullParser.START_TAG && type != XmlPullParser.END_DOCUMENT);
+      if (type != XmlPullParser.START_TAG) {
+        throw new XmlPullParserException("No start tag found");
+      }
+
+      if (!TextUtils.equals(parser.getName(), "chip")) {
+        throw new XmlPullParserException("Must have a <chip> start tag");
+      }
+
+      AttributeSet attrs = Xml.asAttributeSet(parser);
+      @StyleRes int style = attrs.getStyleAttribute();
+      if (style == 0) {
+        style = R.style.Widget_MaterialComponents_Chip_Entry;
+      }
+
+      return createFromAttributes(context, attrs, R.attr.chipStandaloneStyle, style);
+    } catch (XmlPullParserException | IOException e) {
+      NotFoundException exception =
+          new NotFoundException("Can't load chip resource ID #0x" + Integer.toHexString(id));
+      exception.initCause(e);
+      throw exception;
+    }
+  }
+
+  private ChipDrawable(Context context) {
+    this.context = context;
+
+    textPaint.density = context.getResources().getDisplayMetrics().density;
+    debugPaint = DEBUG ? new Paint(Paint.ANTI_ALIAS_FLAG) : null;
+    if (debugPaint != null) {
+      debugPaint.setStyle(Style.STROKE);
+    }
+
+    setState(DEFAULT_STATE);
+    setCloseIconState(DEFAULT_STATE);
+  }
+
+  private void loadFromAttributes(
+      AttributeSet attrs, @AttrRes int defStyleAttr, @StyleRes int defStyleRes) {
+    TypedArray a =
+        ThemeEnforcement.obtainStyledAttributes(
+            context, attrs, R.styleable.ChipDrawable, defStyleAttr, defStyleRes);
+
+    setChipBackgroundColor(
+        MaterialResources.getColorStateList(
+            context, a, R.styleable.ChipDrawable_chipBackgroundColor));
+    setChipMinHeight(a.getDimension(R.styleable.ChipDrawable_chipMinHeight, 0f));
+    setChipCornerRadius(a.getDimension(R.styleable.ChipDrawable_chipCornerRadius, 0f));
+    setChipStrokeColor(
+        MaterialResources.getColorStateList(context, a, R.styleable.ChipDrawable_chipStrokeColor));
+    setChipStrokeWidth(a.getDimension(R.styleable.ChipDrawable_chipStrokeWidth, 0f));
+    setRippleColor(
+        MaterialResources.getColorStateList(context, a, R.styleable.ChipDrawable_rippleColor));
+
+    setChipText(a.getText(R.styleable.ChipDrawable_chipText));
+    setTextAppearance(
+        MaterialResources.getTextAppearance(
+            context, a, R.styleable.ChipDrawable_android_textAppearance));
+
+    setChipIconEnabled(a.getBoolean(R.styleable.ChipDrawable_chipIconEnabled, false));
+    setChipIcon(MaterialResources.getDrawable(context, a, R.styleable.ChipDrawable_chipIcon));
+    setChipIconSize(a.getDimension(R.styleable.ChipDrawable_chipIconSize, 0f));
+
+    setCloseIconEnabled(a.getBoolean(R.styleable.ChipDrawable_closeIconEnabled, false));
+    setCloseIcon(MaterialResources.getDrawable(context, a, R.styleable.ChipDrawable_closeIcon));
+    setCloseIconTint(
+        MaterialResources.getColorStateList(context, a, R.styleable.ChipDrawable_closeIconTint));
+    setCloseIconSize(a.getDimension(R.styleable.ChipDrawable_closeIconSize, 0f));
+
+    setCheckable(a.getBoolean(R.styleable.ChipDrawable_android_checkable, false));
+    setCheckedIconEnabled(a.getBoolean(R.styleable.ChipDrawable_checkedIconEnabled, false));
+    setCheckedIcon(MaterialResources.getDrawable(context, a, R.styleable.ChipDrawable_checkedIcon));
+
+    setShowMotionSpec(
+        MotionSpec.createFromAttribute(context, a, R.styleable.ChipDrawable_showMotionSpec));
+    setHideMotionSpec(
+        MotionSpec.createFromAttribute(context, a, R.styleable.ChipDrawable_hideMotionSpec));
+
+    setChipStartPadding(a.getDimension(R.styleable.ChipDrawable_chipStartPadding, 0f));
+    setIconStartPadding(a.getDimension(R.styleable.ChipDrawable_iconStartPadding, 0f));
+    setIconEndPadding(a.getDimension(R.styleable.ChipDrawable_iconEndPadding, 0f));
+    setTextStartPadding(a.getDimension(R.styleable.ChipDrawable_textStartPadding, 0f));
+    setTextEndPadding(a.getDimension(R.styleable.ChipDrawable_textEndPadding, 0f));
+    setCloseIconStartPadding(a.getDimension(R.styleable.ChipDrawable_closeIconStartPadding, 0f));
+    setCloseIconEndPadding(a.getDimension(R.styleable.ChipDrawable_closeIconEndPadding, 0f));
+    setChipEndPadding(a.getDimension(R.styleable.ChipDrawable_chipEndPadding, 0f));
+
+    a.recycle();
+  }
+
+  /** Sets whether this ChipDrawable should draw its own compatibility ripples. */
+  public void setUseCompatRipple(boolean useCompatRipple) {
+    if (this.useCompatRipple != useCompatRipple) {
+      this.useCompatRipple = useCompatRipple;
+      updateCompatRippleColor();
+      onStateChange(getState());
+    }
+  }
+
+  /** Returns whether this ChipDrawable should draw its own compatibility ripples. */
+  public boolean getUseCompatRipple() {
+    return useCompatRipple;
+  }
+
+  /** Sets the View delegate that owns this ChipDrawable. */
+  public void setDelegate(@Nullable Delegate delegate) {
+    this.delegate = new WeakReference<>(delegate);
+  }
+
+  /** Attempts to call {@link Delegate#onChipDrawableSizeChange()} on the delegate. */
+  protected void onSizeChange() {
+    Delegate delegate = this.delegate.get();
+    if (delegate != null) {
+      delegate.onChipDrawableSizeChange();
+    }
+  }
+
+  /**
+   * Returns the chip's ChipDrawable-absolute bounds (top-left is <code>
+   * [ChipDrawable.getBounds().left, ChipDrawable.getBounds().top]</code>).
+   */
+  public void getChipTouchBounds(RectF bounds) {
+    calculateChipTouchBounds(getBounds(), bounds);
+  }
+
+  /**
+   * Returns the close icon's ChipDrawable-absolute bounds (top-left is <code>
+   * [ChipDrawable.getBounds().left, ChipDrawable.getBounds().top]</code>).
+   */
+  public void getCloseIconTouchBounds(RectF bounds) {
+    calculateCloseIconTouchBounds(getBounds(), bounds);
+  }
+
+  /** Returns the width at which the chip would like to be laid out. */
+  @Override
+  public int getIntrinsicWidth() {
+    return (int)
+        (chipStartPadding
+            + calculateChipIconWidth()
+            + textStartPadding
+            + getChipTextWidth()
+            + textEndPadding
+            + calculateCloseIconWidth()
+            + chipEndPadding);
+  }
+
+  /** Returns the height at which the chip would like to be laid out. */
+  @Override
+  public int getIntrinsicHeight() {
+    return (int) chipMinHeight;
+  }
+
+  /** Returns whether we will show the chip icon. */
+  private boolean showsChipIcon() {
+    return chipIconEnabled && chipIcon != null;
+  }
+
+  /** Returns whether we will show the checked icon. */
+  private boolean showsCheckedIcon() {
+    return checkedIconEnabled && checkedIcon != null && currentChecked;
+  }
+
+  /** Returns whether we will show the close icon. */
+  private boolean showsCloseIcon() {
+    return closeIconEnabled && closeIcon != null;
+  }
+
+  /** Returns whether we can show the checked icon if our drawable state changes. */
+  private boolean canShowCheckedIcon() {
+    return checkedIconEnabled && checkedIcon != null && checkable;
+  }
+
+  /** Returns the width of the chip icon plus padding, which only apply if the chip icon exists. */
+  private float calculateChipIconWidth() {
+    if (showsChipIcon() || (showsCheckedIcon())) {
+      return iconStartPadding + chipIconSize + iconEndPadding;
+    }
+    return 0f;
+  }
+
+  private float getChipTextWidth() {
+    if (!chipTextWidthDirty) {
+      return chipTextWidth;
+    }
+
+    chipTextWidth = calculateChipTextWidth(chipText);
+
+    chipTextWidthDirty = false;
+    return chipTextWidth;
+  }
+
+  private float calculateChipTextWidth(@Nullable CharSequence charSequence) {
+    if (charSequence == null) {
+      return 0f;
+    }
+
+    return textPaint.measureText(charSequence, 0, charSequence.length());
+  }
+
+  /**
+   * Returns the width of the chip close icon plus padding, which only apply if the chip close icon
+   * exists.
+   */
+  private float calculateCloseIconWidth() {
+    if (showsCloseIcon()) {
+      return closeIconStartPadding + closeIconSize + closeIconEndPadding;
+    }
+    return 0f;
+  }
+
+  @Override
+  public void draw(@NonNull Canvas canvas) {
+    Rect bounds = getBounds();
+    if (bounds.isEmpty() || getAlpha() == 0) {
+      return;
+    }
+
+    int saveCount = 0;
+    if (alpha < 255) {
+      saveCount =
+          CanvasCompat.saveLayerAlpha(
+              canvas, bounds.left, bounds.top, bounds.right, bounds.bottom, alpha);
+    }
+
+    // 1. Draw chip background.
+    drawChipBackground(canvas, bounds);
+
+    // 2. Draw chip stroke.
+    drawChipStroke(canvas, bounds);
+
+    // 3. Draw compat ripple.
+    drawCompatRipple(canvas, bounds);
+
+    // 4. Draw chip icon.
+    drawChipIcon(canvas, bounds);
+
+    // 5. Draw checked icon.
+    drawCheckedIcon(canvas, bounds);
+
+    // 6. Draw chip text.
+    drawChipText(canvas, bounds);
+
+    // 7. Draw close icon.
+    drawCloseIcon(canvas, bounds);
+
+    // Debug.
+    drawDebug(canvas, bounds);
+
+    if (alpha < 255) {
+      canvas.restoreToCount(saveCount);
+    }
+  }
+
+  private void drawChipBackground(@NonNull Canvas canvas, Rect bounds) {
+    chipPaint.setColor(currentChipBackgroundColor);
+    chipPaint.setStyle(Style.FILL);
+    chipPaint.setColorFilter(getTintColorFilter());
+    rectF.set(bounds);
+    canvas.drawRoundRect(rectF, chipCornerRadius, chipCornerRadius, chipPaint);
+  }
+
+  /**
+   * Draws the chip stroke. Draw the stroke <code>chipStrokeWidth / 2f</code> away from the edges so
+   * that the stroke perfectly fills the bounds of the chip.
+   */
+  private void drawChipStroke(@NonNull Canvas canvas, Rect bounds) {
+    if (chipStrokeWidth > 0) {
+      chipPaint.setColor(currentChipStrokeColor);
+      chipPaint.setStyle(Style.STROKE);
+      chipPaint.setColorFilter(getTintColorFilter());
+      rectF.set(
+          bounds.left + chipStrokeWidth / 2f,
+          bounds.top + chipStrokeWidth / 2f,
+          bounds.right - chipStrokeWidth / 2f,
+          bounds.bottom - chipStrokeWidth / 2f);
+      // We need to adjust stroke's corner radius so that the corners of the background are not
+      // drawn outside stroke
+      float strokeCornerRadius = chipCornerRadius - chipStrokeWidth / 2f;
+      canvas.drawRoundRect(rectF, strokeCornerRadius, strokeCornerRadius, chipPaint);
+    }
+  }
+
+  private void drawCompatRipple(@NonNull Canvas canvas, Rect bounds) {
+    chipPaint.setColor(currentCompatRippleColor);
+    chipPaint.setStyle(Style.FILL);
+    rectF.set(bounds);
+    canvas.drawRoundRect(rectF, chipCornerRadius, chipCornerRadius, chipPaint);
+  }
+
+  private void drawChipIcon(@NonNull Canvas canvas, Rect bounds) {
+    if (showsChipIcon()) {
+      calculateChipIconBounds(bounds, rectF);
+      float tx = rectF.left;
+      float ty = rectF.top;
+
+      canvas.translate(tx, ty);
+
+      chipIcon.setBounds(0, 0, (int) rectF.width(), (int) rectF.height());
+      chipIcon.draw(canvas);
+
+      canvas.translate(-tx, -ty);
+    }
+  }
+
+  private void drawCheckedIcon(@NonNull Canvas canvas, Rect bounds) {
+    if (showsCheckedIcon()) {
+      calculateChipIconBounds(bounds, rectF);
+      float tx = rectF.left;
+      float ty = rectF.top;
+
+      canvas.translate(tx, ty);
+
+      checkedIcon.setBounds(0, 0, (int) rectF.width(), (int) rectF.height());
+      checkedIcon.draw(canvas);
+
+      canvas.translate(-tx, -ty);
+    }
+  }
+
+  /** Draws the chip text, which should appear centered vertically in the chip. */
+  private void drawChipText(@NonNull Canvas canvas, Rect bounds) {
+    if (chipText != null) {
+      // TODO: Bounds may be smaller than intrinsic size. Ellipsize, clip, or multiline the text.
+      Align align = calculateChipTextOrigin(bounds, pointF);
+      calculateChipTextBounds(bounds, rectF);
+
+      if (textAppearance != null) {
+        textPaint.drawableState = getState();
+        textAppearance.updateDrawState(context, textPaint);
+      }
+      textPaint.setTextAlign(align);
+
+      boolean clip = getChipTextWidth() > rectF.width();
+      int saveCount = 0;
+      if (clip) {
+        saveCount = canvas.save();
+        canvas.clipRect(rectF);
+      }
+      canvas.drawText(chipText, 0, chipText.length(), pointF.x, pointF.y, textPaint);
+      if (clip) {
+        canvas.restoreToCount(saveCount);
+      }
+    }
+  }
+
+  private void drawCloseIcon(@NonNull Canvas canvas, Rect bounds) {
+    if (showsCloseIcon()) {
+      calculateCloseIconBounds(bounds, rectF);
+      float tx = rectF.left;
+      float ty = rectF.top;
+
+      canvas.translate(tx, ty);
+
+      closeIcon.setBounds(0, 0, (int) rectF.width(), (int) rectF.height());
+      closeIcon.draw(canvas);
+
+      canvas.translate(-tx, -ty);
+    }
+  }
+
+  private void drawDebug(@NonNull Canvas canvas, Rect bounds) {
+    if (debugPaint != null) {
+      debugPaint.setColor(ColorUtils.setAlphaComponent(Color.BLACK, 255 / 2));
+
+      // Background.
+      canvas.drawRect(bounds, debugPaint);
+
+      // Chip and checked icon.
+      if (showsChipIcon() || (showsCheckedIcon())) {
+        calculateChipIconBounds(bounds, rectF);
+        canvas.drawRect(rectF, debugPaint);
+      }
+
+      // Chip text.
+      if (chipText != null) {
+        canvas.drawLine(
+            bounds.left, bounds.exactCenterY(), bounds.right, bounds.exactCenterY(), debugPaint);
+      }
+
+      // Close icon.
+      if (showsCloseIcon()) {
+        calculateCloseIconBounds(bounds, rectF);
+        canvas.drawRect(rectF, debugPaint);
+      }
+
+      // Chip touch bounds.
+      debugPaint.setColor(ColorUtils.setAlphaComponent(Color.RED, 255 / 2));
+      calculateChipTouchBounds(bounds, rectF);
+      canvas.drawRect(rectF, debugPaint);
+
+      // Close icon touch bounds.
+      debugPaint.setColor(ColorUtils.setAlphaComponent(Color.GREEN, 255 / 2));
+      calculateCloseIconTouchBounds(bounds, rectF);
+      canvas.drawRect(rectF, debugPaint);
+    }
+  }
+
+  /**
+   * Calculates the chip icon's ChipDrawable-absolute bounds (top-left is <code>
+   * [ChipDrawable.getBounds().left, ChipDrawable.getBounds().top]</code>).
+   */
+  private void calculateChipIconBounds(Rect bounds, RectF outBounds) {
+    outBounds.setEmpty();
+
+    if (showsChipIcon() || showsCheckedIcon()) {
+      float offsetFromStart = chipStartPadding + iconStartPadding;
+
+      if (DrawableCompat.getLayoutDirection(this) == View.LAYOUT_DIRECTION_LTR) {
+        outBounds.left = bounds.left + offsetFromStart;
+        outBounds.right = outBounds.left + chipIconSize;
+      } else {
+        outBounds.right = bounds.right - offsetFromStart;
+        outBounds.left = outBounds.right - chipIconSize;
+      }
+
+      outBounds.top = bounds.exactCenterY() - chipIconSize / 2f;
+      outBounds.bottom = outBounds.top + chipIconSize;
+    }
+  }
+
+  /**
+   * Calculates the chip text's ChipDrawable-absolute bounds (top-left is <code>
+   * [ChipDrawable.getBounds().left, ChipDrawable.getBounds().top]</code>).
+   */
+  private Align calculateChipTextOrigin(Rect bounds, PointF pointF) {
+    pointF.set(0, 0);
+    Align align = Align.LEFT;
+
+    if (chipText != null) {
+      float offsetFromStart = chipStartPadding + calculateChipIconWidth() + textStartPadding;
+
+      if (DrawableCompat.getLayoutDirection(this) == View.LAYOUT_DIRECTION_LTR) {
+        pointF.x = bounds.left + offsetFromStart;
+        align = Align.LEFT;
+      } else {
+        pointF.x = bounds.right - offsetFromStart;
+        align = Align.RIGHT;
+      }
+
+      pointF.y = bounds.centerY() - calculateChipTextCenterFromBaseline();
+    }
+
+    return align;
+  }
+
+  /**
+   * Calculates the offset from the visual center of the chip text to its baseline.
+   *
+   * <p>To draw the chip text, we provide the origin to {@link Canvas#drawText(CharSequence, int,
+   * int, float, float, Paint)}. This origin always corresponds vertically to the text's baseline.
+   * Because we need to vertically center the text, we need to calculate this offset.
+   *
+   * <p>Note that chips that share the same font must have consistent text baselines despite having
+   * different text strings. This is why we calculate the vertical center using {@link
+   * Paint#getFontMetrics(FontMetrics)} rather than {@link Paint#getTextBounds(String, int, int,
+   * Rect)}.
+   */
+  private float calculateChipTextCenterFromBaseline() {
+    textPaint.getFontMetrics(fontMetrics);
+    return (fontMetrics.descent + fontMetrics.ascent) / 2f;
+  }
+
+  /**
+   * Calculates the chip text's ChipDrawable-absolute bounds (top-left is <code>
+   * [ChipDrawable.getBounds().left, ChipDrawable.getBounds().top]</code>).
+   */
+  private void calculateChipTextBounds(Rect bounds, RectF outBounds) {
+    outBounds.setEmpty();
+
+    if (chipText != null) {
+      float offsetFromStart = chipStartPadding + calculateChipIconWidth() + textStartPadding;
+      float offsetFromEnd = chipEndPadding + calculateCloseIconWidth() + textEndPadding;
+
+      if (DrawableCompat.getLayoutDirection(this) == View.LAYOUT_DIRECTION_LTR) {
+        outBounds.left = bounds.left + offsetFromStart;
+        outBounds.right = bounds.right - offsetFromEnd;
+      } else {
+        outBounds.left = bounds.left + offsetFromEnd;
+        outBounds.right = bounds.right - offsetFromStart;
+      }
+
+      // Top and bottom included for completion. Don't position the chip text vertically based on
+      // these bounds. Instead, use #calculateChipTextOrigin().
+      outBounds.top = bounds.top;
+      outBounds.bottom = bounds.bottom;
+    }
+  }
+
+  /**
+   * Calculates the close icon's ChipDrawable-absolute bounds (top-left is <code>
+   * [ChipDrawable.getBounds().left, ChipDrawable.getBounds().top]</code>).
+   */
+  private void calculateCloseIconBounds(Rect bounds, RectF outBounds) {
+    outBounds.setEmpty();
+
+    if (showsCloseIcon()) {
+      float offsetFromEnd = chipEndPadding + closeIconEndPadding;
+
+      if (DrawableCompat.getLayoutDirection(this) == View.LAYOUT_DIRECTION_LTR) {
+        outBounds.right = bounds.right - offsetFromEnd;
+        outBounds.left = outBounds.right - closeIconSize;
+      } else {
+        outBounds.left = bounds.left + offsetFromEnd;
+        outBounds.right = outBounds.left + closeIconSize;
+      }
+
+      outBounds.top = bounds.exactCenterY() - closeIconSize / 2f;
+      outBounds.bottom = outBounds.top + closeIconSize;
+    }
+  }
+
+  private void calculateChipTouchBounds(Rect bounds, RectF outBounds) {
+    outBounds.set(bounds);
+
+    if (showsCloseIcon()) {
+      float offsetFromEnd =
+          chipEndPadding
+              + closeIconEndPadding
+              + closeIconSize
+              + closeIconStartPadding
+              + textEndPadding;
+
+      if (DrawableCompat.getLayoutDirection(this) == View.LAYOUT_DIRECTION_LTR) {
+        outBounds.right = bounds.right - offsetFromEnd;
+      } else {
+        outBounds.left = bounds.left + offsetFromEnd;
+      }
+    }
+  }
+
+  private void calculateCloseIconTouchBounds(Rect bounds, RectF outBounds) {
+    outBounds.setEmpty();
+
+    if (showsCloseIcon()) {
+      float offsetFromEnd =
+          chipEndPadding
+              + closeIconEndPadding
+              + closeIconSize
+              + closeIconStartPadding
+              + textEndPadding;
+
+      if (DrawableCompat.getLayoutDirection(this) == View.LAYOUT_DIRECTION_LTR) {
+        outBounds.right = bounds.right;
+        outBounds.left = outBounds.right - offsetFromEnd;
+      } else {
+        outBounds.left = bounds.left;
+        outBounds.right = bounds.left + offsetFromEnd;
+      }
+
+      outBounds.top = bounds.top;
+      outBounds.bottom = bounds.bottom;
+    }
+  }
+
+  /**
+   * Indicates whether this chip drawable will change its appearance based on state.
+   *
+   * <p>The logic here and {@link #isCloseIconStateful()} must match {@link #onStateChange(int[],
+   * int[])}.
+   */
+  @Override
+  public boolean isStateful() {
+    return isStateful(chipBackgroundColor)
+        || isStateful(chipStrokeColor)
+        || (useCompatRipple && isStateful(compatRippleColor))
+        || isStateful(textAppearance)
+        || canShowCheckedIcon()
+        || isStateful(chipIcon)
+        || isStateful(checkedIcon)
+        || isStateful(tint);
+  }
+
+  /**
+   * Indicates whether the close icon drawable will change its appearance based on state.
+   *
+   * <p>The logic here and {@link #isStateful()} must match {@link #onStateChange(int[], int[])}.
+   */
+  public boolean isCloseIconStateful() {
+    return isStateful(closeIcon);
+  }
+
+  /**
+   * Specify a set of states for the close icon. This is a separate state set than the one used for
+   * the rest of the chip.
+   */
+  public boolean setCloseIconState(@NonNull int[] stateSet) {
+    if (!Arrays.equals(closeIconStateSet, stateSet)) {
+      closeIconStateSet = stateSet;
+      if (showsCloseIcon()) {
+        return onStateChange(getState(), stateSet);
+      }
+    }
+    return false;
+  }
+
+  /** Describes the current state of the close icon. */
+  @NonNull
+  public int[] getCloseIconState() {
+    return closeIconStateSet;
+  }
+
+  @Override
+  protected boolean onStateChange(int[] state) {
+    return onStateChange(state, getCloseIconState());
+  }
+
+  /**
+   * Changes appearance in response to the specified state.
+   *
+   * <p>The logic here must match {@link #isStateful()} and {@link #isCloseIconStateful()}.
+   */
+  private boolean onStateChange(int[] chipState, int[] closeIconState) {
+    boolean invalidate = super.onStateChange(chipState);
+    boolean sizeChanged = false;
+
+    int newChipBackgroundColor =
+        chipBackgroundColor != null
+            ? chipBackgroundColor.getColorForState(chipState, currentChipBackgroundColor)
+            : 0;
+    if (currentChipBackgroundColor != newChipBackgroundColor) {
+      currentChipBackgroundColor = newChipBackgroundColor;
+      invalidate = true;
+    }
+
+    int newChipStrokeColor =
+        chipStrokeColor != null
+            ? chipStrokeColor.getColorForState(chipState, currentChipStrokeColor)
+            : 0;
+    if (currentChipStrokeColor != newChipStrokeColor) {
+      currentChipStrokeColor = newChipStrokeColor;
+      invalidate = true;
+    }
+
+    int newCompatRippleColor =
+        compatRippleColor != null
+            ? compatRippleColor.getColorForState(chipState, currentCompatRippleColor)
+            : 0;
+    if (currentCompatRippleColor != newCompatRippleColor) {
+      currentCompatRippleColor = newCompatRippleColor;
+      if (useCompatRipple) {
+        invalidate = true;
+      }
+    }
+
+    int newChipTextColor =
+        textAppearance != null && textAppearance.textColor != null
+            ? textAppearance.textColor.getColorForState(chipState, currentChipTextColor)
+            : 0;
+    if (currentChipTextColor != newChipTextColor) {
+      currentChipTextColor = newChipTextColor;
+      invalidate = true;
+    }
+
+    boolean newChecked = hasState(getState(), android.R.attr.state_checked) && checkable;
+    if (currentChecked != newChecked && checkedIcon != null) {
+      float oldChipIconWidth = calculateChipIconWidth();
+      currentChecked = newChecked;
+      float newChipIconWidth = calculateChipIconWidth();
+      invalidate = true;
+
+      if (oldChipIconWidth != newChipIconWidth) {
+        sizeChanged = true;
+      }
+    }
+
+    int newTint = tint != null ? tint.getColorForState(chipState, currentTint) : 0;
+    if (currentTint != newTint) {
+      currentTint = newTint;
+      tintFilter = DrawableUtils.updateTintFilter(this, tint, tintMode);
+      invalidate = true;
+    }
+
+    if (isStateful(chipIcon)) {
+      invalidate |= chipIcon.setState(chipState);
+    }
+    if (isStateful(checkedIcon)) {
+      invalidate |= checkedIcon.setState(chipState);
+    }
+    if (isStateful(closeIcon)) {
+      invalidate |= closeIcon.setState(closeIconState);
+    }
+
+    if (invalidate) {
+      invalidateSelf();
+    }
+    if (sizeChanged) {
+      onSizeChange();
+    }
+    return invalidate;
+  }
+
+  private static boolean isStateful(@Nullable ColorStateList colorStateList) {
+    return colorStateList != null && colorStateList.isStateful();
+  }
+
+  private static boolean isStateful(@Nullable Drawable drawable) {
+    return drawable != null && drawable.isStateful();
+  }
+
+  private static boolean isStateful(@Nullable TextAppearance textAppearance) {
+    return textAppearance != null
+        && textAppearance.textColor != null
+        && textAppearance.textColor.isStateful();
+  }
+
+  @Override
+  @TargetApi(VERSION_CODES.M)
+  public boolean onLayoutDirectionChanged(int layoutDirection) {
+    boolean invalidate = super.onLayoutDirectionChanged(layoutDirection);
+
+    if (showsChipIcon()) {
+      invalidate |= chipIcon.setLayoutDirection(layoutDirection);
+    }
+    if (showsCheckedIcon()) {
+      invalidate |= checkedIcon.setLayoutDirection(layoutDirection);
+    }
+    if (showsCloseIcon()) {
+      invalidate |= closeIcon.setLayoutDirection(layoutDirection);
+    }
+
+    if (invalidate) {
+      invalidateSelf();
+    }
+    return true;
+  }
+
+  @Override
+  protected boolean onLevelChange(int level) {
+    boolean invalidate = super.onLevelChange(level);
+
+    if (showsChipIcon()) {
+      invalidate |= chipIcon.setLevel(level);
+    }
+    if (showsCheckedIcon()) {
+      invalidate |= checkedIcon.setLevel(level);
+    }
+    if (showsCloseIcon()) {
+      invalidate |= closeIcon.setLevel(level);
+    }
+
+    if (invalidate) {
+      invalidateSelf();
+    }
+    return invalidate;
+  }
+
+  @Override
+  public boolean setVisible(boolean visible, boolean restart) {
+    boolean invalidate = super.setVisible(visible, restart);
+
+    if (showsChipIcon()) {
+      invalidate |= chipIcon.setVisible(visible, restart);
+    }
+    if (showsCheckedIcon()) {
+      invalidate |= checkedIcon.setVisible(visible, restart);
+    }
+    if (showsCloseIcon()) {
+      invalidate |= closeIcon.setVisible(visible, restart);
+    }
+
+    if (invalidate) {
+      invalidateSelf();
+    }
+    return invalidate;
+  }
+
+  /**
+   * Sets the alpha of this ChipDrawable. This will drastically decrease draw performance. You are
+   * highly encouraged to use {@link View#setAlpha(float)} instead.
+   */
+  @Override
+  public void setAlpha(int alpha) {
+    if (this.alpha != alpha) {
+      this.alpha = alpha;
+      invalidateSelf();
+    }
+  }
+
+  @Override
+  public int getAlpha() {
+    return alpha;
+  }
+
+  @Override
+  public void setColorFilter(@Nullable ColorFilter colorFilter) {
+    if (this.colorFilter != colorFilter) {
+      this.colorFilter = colorFilter;
+      invalidateSelf();
+    }
+  }
+
+  @Nullable
+  @Override
+  public ColorFilter getColorFilter() {
+    return colorFilter;
+  }
+
+  @Override
+  public void setTintList(@Nullable ColorStateList tint) {
+    if (this.tint != tint) {
+      this.tint = tint;
+      onStateChange(getState());
+    }
+  }
+
+  @Override
+  public void setTintMode(@NonNull Mode tintMode) {
+    if (this.tintMode != tintMode) {
+      this.tintMode = tintMode;
+      tintFilter = DrawableUtils.updateTintFilter(this, tint, tintMode);
+      invalidateSelf();
+    }
+  }
+
+  @Override
+  public int getOpacity() {
+    return PixelFormat.TRANSLUCENT;
+  }
+
+  @Override
+  @TargetApi(VERSION_CODES.LOLLIPOP)
+  public void getOutline(@NonNull Outline outline) {
+    Rect bounds = getBounds();
+    if (!bounds.isEmpty()) {
+      outline.setRoundRect(bounds, chipCornerRadius);
+    } else {
+      outline.setRoundRect(0, 0, getIntrinsicWidth(), getIntrinsicHeight(), chipCornerRadius);
+    }
+
+    outline.setAlpha(getAlpha() / 255f);
+  }
+
+  @Override
+  public void invalidateDrawable(@NonNull Drawable who) {
+    Callback callback = getCallback();
+    if (callback != null) {
+      callback.invalidateDrawable(this);
+    }
+  }
+
+  @Override
+  public void scheduleDrawable(@NonNull Drawable who, @NonNull Runnable what, long when) {
+    Callback callback = getCallback();
+    if (callback != null) {
+      callback.scheduleDrawable(this, what, when);
+    }
+  }
+
+  @Override
+  public void unscheduleDrawable(@NonNull Drawable who, @NonNull Runnable what) {
+    Callback callback = getCallback();
+    if (callback != null) {
+      callback.unscheduleDrawable(this, what);
+    }
+  }
+
+  private void unapplyChildDrawable(@Nullable Drawable drawable) {
+    if (drawable != null) {
+      drawable.setCallback(null);
+    }
+  }
+
+  /** Note: This should not change the size of the drawable. */
+  private void applyChildDrawable(@Nullable Drawable drawable) {
+    if (drawable != null) {
+      drawable.setCallback(this);
+      DrawableCompat.setLayoutDirection(drawable, DrawableCompat.getLayoutDirection(this));
+      drawable.setLevel(getLevel());
+      drawable.setVisible(isVisible(), false);
+
+      if (drawable == closeIcon) {
+        if (drawable.isStateful()) {
+          drawable.setState(getCloseIconState());
+        }
+        DrawableCompat.setTintList(drawable, closeIconTint);
+      } else {
+        if (drawable.isStateful()) {
+          drawable.setState(getState());
+        }
+      }
+    }
+  }
+
+  /**
+   * Returns the color filter used for tinting this ChipDrawable. {@link
+   * #setColorFilter(ColorFilter)} takes priority over {@link #setTintList(ColorStateList)}.
+   */
+  @Nullable
+  private ColorFilter getTintColorFilter() {
+    return colorFilter != null ? colorFilter : tintFilter;
+  }
+
+  private void updateCompatRippleColor() {
+    compatRippleColor =
+        useCompatRipple ? RippleUtils.convertToRippleDrawableColor(rippleColor) : null;
+  }
+
+  /** Returns whether the drawable state set contains the given state. */
+  private static boolean hasState(@Nullable int[] stateSet, @AttrRes int state) {
+    if (stateSet == null) {
+      return false;
+    }
+
+    for (int s : stateSet) {
+      if (s == state) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /** Delegate interface to be implemented by Views that own a ChipDrawable. */
+  public interface Delegate {
+
+    /** Handles a change in the ChipDrawable's size. */
+    void onChipDrawableSizeChange();
+  }
+
+  // Getters and setters for attributes.
+
+  @Nullable
+  public ColorStateList getChipBackgroundColor() {
+    return chipBackgroundColor;
+  }
+
+  public void setChipBackgroundColorResource(@ColorRes int id) {
+    setChipBackgroundColor(AppCompatResources.getColorStateList(context, id));
+  }
+
+  public void setChipBackgroundColor(@Nullable ColorStateList chipBackgroundColor) {
+    if (this.chipBackgroundColor != chipBackgroundColor) {
+      this.chipBackgroundColor = chipBackgroundColor;
+      onStateChange(getState());
+    }
+  }
+
+  public float getChipMinHeight() {
+    return chipMinHeight;
+  }
+
+  public void setChipMinHeightResource(@DimenRes int id) {
+    setChipMinHeight(context.getResources().getDimension(id));
+  }
+
+  public void setChipMinHeight(float chipMinHeight) {
+    if (this.chipMinHeight != chipMinHeight) {
+      this.chipMinHeight = chipMinHeight;
+      invalidateSelf();
+      onSizeChange();
+    }
+  }
+
+  public float getChipCornerRadius() {
+    return chipCornerRadius;
+  }
+
+  public void setChipCornerRadiusResource(@DimenRes int id) {
+    setChipCornerRadius(context.getResources().getDimension(id));
+  }
+
+  public void setChipCornerRadius(float chipCornerRadius) {
+    if (this.chipCornerRadius != chipCornerRadius) {
+      this.chipCornerRadius = chipCornerRadius;
+      invalidateSelf();
+    }
+  }
+
+  @Nullable
+  public ColorStateList getChipStrokeColor() {
+    return chipStrokeColor;
+  }
+
+  public void setChipStrokeColorResource(@ColorRes int id) {
+    setChipStrokeColor(AppCompatResources.getColorStateList(context, id));
+  }
+
+  public void setChipStrokeColor(@Nullable ColorStateList chipStrokeColor) {
+    if (this.chipStrokeColor != chipStrokeColor) {
+      this.chipStrokeColor = chipStrokeColor;
+      onStateChange(getState());
+    }
+  }
+
+  public float getChipStrokeWidth() {
+    return chipStrokeWidth;
+  }
+
+  public void setChipStrokeWidthResource(@DimenRes int id) {
+    setChipStrokeWidth(context.getResources().getDimension(id));
+  }
+
+  public void setChipStrokeWidth(float chipStrokeWidth) {
+    if (this.chipStrokeWidth != chipStrokeWidth) {
+      this.chipStrokeWidth = chipStrokeWidth;
+
+      chipPaint.setStrokeWidth(chipStrokeWidth);
+
+      invalidateSelf();
+    }
+  }
+
+  @Nullable
+  public ColorStateList getRippleColor() {
+    return rippleColor;
+  }
+
+  public void setRippleColorResource(@ColorRes int id) {
+    setRippleColor(AppCompatResources.getColorStateList(context, id));
+  }
+
+  public void setRippleColor(@Nullable ColorStateList rippleColor) {
+    if (this.rippleColor != rippleColor) {
+      this.rippleColor = rippleColor;
+      updateCompatRippleColor();
+      onStateChange(getState());
+    }
+  }
+
+  @Nullable
+  public CharSequence getChipText() {
+    return chipText;
+  }
+
+  public void setChipTextResource(@StringRes int id) {
+    setChipText(context.getResources().getString(id));
+  }
+
+  public void setChipText(@Nullable CharSequence chipText) {
+    if (this.chipText != chipText) {
+      this.chipText = BidiFormatter.getInstance().unicodeWrap(chipText);
+      chipTextWidthDirty = true;
+
+      invalidateSelf();
+      onSizeChange();
+    }
+  }
+
+  @Nullable
+  public TextAppearance getTextAppearance() {
+    return textAppearance;
+  }
+
+  public void setTextAppearanceResource(@StyleRes int id) {
+    setTextAppearance(new TextAppearance(context, id));
+  }
+
+  public void setTextAppearance(@Nullable TextAppearance textAppearance) {
+    if (this.textAppearance != textAppearance) {
+      this.textAppearance = textAppearance;
+
+      if (textAppearance != null) {
+        textAppearance.updateMeasureState(context, textPaint);
+        chipTextWidthDirty = true;
+      }
+
+      onStateChange(getState());
+      onSizeChange();
+    }
+  }
+
+  public boolean isChipIconEnabled() {
+    return chipIconEnabled;
+  }
+
+  public void setChipIconEnabledResource(@BoolRes int id) {
+    setChipIconEnabled(context.getResources().getBoolean(id));
+  }
+
+  public void setChipIconEnabled(boolean chipIconEnabled) {
+    if (this.chipIconEnabled != chipIconEnabled) {
+      boolean oldShowsChipIcon = showsChipIcon();
+      this.chipIconEnabled = chipIconEnabled;
+      boolean newShowsChipIcon = showsChipIcon();
+
+      boolean changed = oldShowsChipIcon != newShowsChipIcon;
+      if (changed) {
+        if (newShowsChipIcon) {
+          applyChildDrawable(chipIcon);
+        } else {
+          unapplyChildDrawable(chipIcon);
+        }
+
+        invalidateSelf();
+        onSizeChange();
+      }
+    }
+  }
+
+  @Nullable
+  public Drawable getChipIcon() {
+    return chipIcon;
+  }
+
+  public void setChipIconResource(@DrawableRes int id) {
+    setChipIcon(AppCompatResources.getDrawable(context, id));
+  }
+
+  public void setChipIcon(@Nullable Drawable chipIcon) {
+    Drawable oldChipIcon = this.chipIcon;
+    if (oldChipIcon != chipIcon) {
+      float oldChipIconWidth = calculateChipIconWidth();
+      this.chipIcon = chipIcon;
+      float newChipIconWidth = calculateChipIconWidth();
+
+      unapplyChildDrawable(oldChipIcon);
+      if (showsChipIcon()) {
+        applyChildDrawable(this.chipIcon);
+      }
+
+      invalidateSelf();
+      if (oldChipIconWidth != newChipIconWidth) {
+        onSizeChange();
+      }
+    }
+  }
+
+  public float getChipIconSize() {
+    return chipIconSize;
+  }
+
+  public void setChipIconSizeResource(@DimenRes int id) {
+    setChipIconSize(context.getResources().getDimension(id));
+  }
+
+  public void setChipIconSize(float chipIconSize) {
+    if (this.chipIconSize != chipIconSize) {
+      float oldChipIconWidth = calculateChipIconWidth();
+      this.chipIconSize = chipIconSize;
+      float newChipIconWidth = calculateChipIconWidth();
+
+      invalidateSelf();
+      if (oldChipIconWidth != newChipIconWidth) {
+        onSizeChange();
+      }
+    }
+  }
+
+  public boolean isCloseIconEnabled() {
+    return closeIconEnabled;
+  }
+
+  public void setCloseIconEnabledResource(@BoolRes int id) {
+    setCloseIconEnabled(context.getResources().getBoolean(id));
+  }
+
+  public void setCloseIconEnabled(boolean closeIconEnabled) {
+    if (this.closeIconEnabled != closeIconEnabled) {
+      boolean oldShowsCloseIcon = showsCloseIcon();
+      this.closeIconEnabled = closeIconEnabled;
+      boolean newShowsCloseIcon = showsCloseIcon();
+
+      boolean changed = oldShowsCloseIcon != newShowsCloseIcon;
+      if (changed) {
+        if (newShowsCloseIcon) {
+          applyChildDrawable(closeIcon);
+        } else {
+          unapplyChildDrawable(closeIcon);
+        }
+
+        invalidateSelf();
+        onSizeChange();
+      }
+    }
+  }
+
+  @Nullable
+  public Drawable getCloseIcon() {
+    return closeIcon;
+  }
+
+  public void setCloseIconResource(@DrawableRes int id) {
+    setCloseIcon(AppCompatResources.getDrawable(context, id));
+  }
+
+  public void setCloseIcon(@Nullable Drawable closeIcon) {
+    Drawable oldCloseIcon = this.closeIcon != null ? DrawableCompat.unwrap(this.closeIcon) : null;
+    if (oldCloseIcon != closeIcon) {
+      float oldCloseIconWidth = calculateCloseIconWidth();
+      this.closeIcon = closeIcon != null ? DrawableCompat.wrap(closeIcon).mutate() : null;
+      float newCloseIconWidth = calculateCloseIconWidth();
+
+      unapplyChildDrawable(oldCloseIcon);
+      if (showsCloseIcon()) {
+        applyChildDrawable(this.closeIcon);
+      }
+
+      invalidateSelf();
+      if (oldCloseIconWidth != newCloseIconWidth) {
+        onSizeChange();
+      }
+    }
+  }
+
+  @Nullable
+  public ColorStateList getCloseIconTint() {
+    return closeIconTint;
+  }
+
+  public void setCloseIconTintResource(@ColorRes int id) {
+    setCloseIconTint(AppCompatResources.getColorStateList(context, id));
+  }
+
+  public void setCloseIconTint(@Nullable ColorStateList closeIconTint) {
+    if (this.closeIconTint != closeIconTint) {
+      this.closeIconTint = closeIconTint;
+
+      if (showsCloseIcon()) {
+        DrawableCompat.setTintList(closeIcon, closeIconTint);
+      }
+
+      onStateChange(getState());
+    }
+  }
+
+  public float getCloseIconSize() {
+    return closeIconSize;
+  }
+
+  public void setCloseIconSizeResource(@DimenRes int id) {
+    setCloseIconSize(context.getResources().getDimension(id));
+  }
+
+  public void setCloseIconSize(float closeIconSize) {
+    if (this.closeIconSize != closeIconSize) {
+      this.closeIconSize = closeIconSize;
+      invalidateSelf();
+      if (showsCloseIcon()) {
+        onSizeChange();
+      }
+    }
+  }
+
+  public boolean isCheckable() {
+    return checkable;
+  }
+
+  public void setCheckableResource(@BoolRes int id) {
+    setCheckable(context.getResources().getBoolean(id));
+  }
+
+  public void setCheckable(boolean checkable) {
+    if (this.checkable != checkable) {
+      this.checkable = checkable;
+
+      float oldChipIconWidth = calculateChipIconWidth();
+      if (!checkable && currentChecked) {
+        currentChecked = false;
+      }
+      float newChipIconWidth = calculateChipIconWidth();
+
+      invalidateSelf();
+      if (oldChipIconWidth != newChipIconWidth) {
+        onSizeChange();
+      }
+    }
+  }
+
+  public boolean isCheckedIconEnabled() {
+    return checkedIconEnabled;
+  }
+
+  public void setCheckedIconEnabledResource(@BoolRes int id) {
+    setCheckedIconEnabled(context.getResources().getBoolean(id));
+  }
+
+  public void setCheckedIconEnabled(boolean checkedIconEnabled) {
+    if (this.checkedIconEnabled != checkedIconEnabled) {
+      boolean oldShowsCheckedIcon = showsCheckedIcon();
+      this.checkedIconEnabled = checkedIconEnabled;
+      boolean newShowsCheckedIcon = showsCheckedIcon();
+
+      boolean changed = oldShowsCheckedIcon != newShowsCheckedIcon;
+      if (changed) {
+        if (newShowsCheckedIcon) {
+          applyChildDrawable(checkedIcon);
+        } else {
+          unapplyChildDrawable(checkedIcon);
+        }
+
+        invalidateSelf();
+        onSizeChange();
+      }
+    }
+  }
+
+  @Nullable
+  public Drawable getCheckedIcon() {
+    return checkedIcon;
+  }
+
+  public void setCheckedIconResource(@DrawableRes int id) {
+    setCheckedIcon(AppCompatResources.getDrawable(context, id));
+  }
+
+  public void setCheckedIcon(@Nullable Drawable checkedIcon) {
+    Drawable oldCheckedIcon = this.checkedIcon;
+    if (oldCheckedIcon != checkedIcon) {
+      float oldChipIconWidth = calculateChipIconWidth();
+      this.checkedIcon = checkedIcon;
+      float newChipIconWidth = calculateChipIconWidth();
+
+      unapplyChildDrawable(this.checkedIcon);
+      applyChildDrawable(this.checkedIcon);
+
+      invalidateSelf();
+      if (oldChipIconWidth != newChipIconWidth) {
+        onSizeChange();
+      }
+    }
+  }
+
+  @Nullable
+  public MotionSpec getShowMotionSpec() {
+    return showMotionSpec;
+  }
+
+  public void setShowMotionSpecResource(@AnimatorRes int id) {
+    setShowMotionSpec(MotionSpec.createFromResource(context, id));
+  }
+
+  public void setShowMotionSpec(@Nullable MotionSpec showMotionSpec) {
+    this.showMotionSpec = showMotionSpec;
+  }
+
+  @Nullable
+  public MotionSpec getHideMotionSpec() {
+    return hideMotionSpec;
+  }
+
+  public void setHideMotionSpecResource(@AnimatorRes int id) {
+    setHideMotionSpec(MotionSpec.createFromResource(context, id));
+  }
+
+  public void setHideMotionSpec(@Nullable MotionSpec hideMotionSpec) {
+    this.hideMotionSpec = hideMotionSpec;
+  }
+
+  public float getChipStartPadding() {
+    return chipStartPadding;
+  }
+
+  public void setChipStartPaddingResource(@DimenRes int id) {
+    setChipStartPadding(context.getResources().getDimension(id));
+  }
+
+  public void setChipStartPadding(float chipStartPadding) {
+    if (this.chipStartPadding != chipStartPadding) {
+      this.chipStartPadding = chipStartPadding;
+      invalidateSelf();
+      onSizeChange();
+    }
+  }
+
+  public float getIconStartPadding() {
+    return iconStartPadding;
+  }
+
+  public void setIconStartPaddingResource(@DimenRes int id) {
+    setIconStartPadding(context.getResources().getDimension(id));
+  }
+
+  public void setIconStartPadding(float iconStartPadding) {
+    if (this.iconStartPadding != iconStartPadding) {
+      float oldChipIconWidth = calculateChipIconWidth();
+      this.iconStartPadding = iconStartPadding;
+      float newChipIconWidth = calculateChipIconWidth();
+
+      invalidateSelf();
+      if (oldChipIconWidth != newChipIconWidth) {
+        onSizeChange();
+      }
+    }
+  }
+
+  public float getIconEndPadding() {
+    return iconEndPadding;
+  }
+
+  public void setIconEndPaddingResource(@DimenRes int id) {
+    setIconEndPadding(context.getResources().getDimension(id));
+  }
+
+  public void setIconEndPadding(float iconEndPadding) {
+    if (this.iconEndPadding != iconEndPadding) {
+      float oldChipIconWidth = calculateChipIconWidth();
+      this.iconEndPadding = iconEndPadding;
+      float newChipIconWidth = calculateChipIconWidth();
+
+      invalidateSelf();
+      if (oldChipIconWidth != newChipIconWidth) {
+        onSizeChange();
+      }
+    }
+  }
+
+  public float getTextStartPadding() {
+    return textStartPadding;
+  }
+
+  public void setTextStartPaddingResource(@DimenRes int id) {
+    setTextStartPadding(context.getResources().getDimension(id));
+  }
+
+  public void setTextStartPadding(float textStartPadding) {
+    if (this.textStartPadding != textStartPadding) {
+      this.textStartPadding = textStartPadding;
+      invalidateSelf();
+      onSizeChange();
+    }
+  }
+
+  public float getTextEndPadding() {
+    return textEndPadding;
+  }
+
+  public void setTextEndPaddingResource(@DimenRes int id) {
+    setTextEndPadding(context.getResources().getDimension(id));
+  }
+
+  public void setTextEndPadding(float textEndPadding) {
+    if (this.textEndPadding != textEndPadding) {
+      this.textEndPadding = textEndPadding;
+      invalidateSelf();
+      onSizeChange();
+    }
+  }
+
+  public float getCloseIconStartPadding() {
+    return closeIconStartPadding;
+  }
+
+  public void setCloseIconStartPaddingResource(@DimenRes int id) {
+    setCloseIconStartPadding(context.getResources().getDimension(id));
+  }
+
+  public void setCloseIconStartPadding(float closeIconStartPadding) {
+    if (this.closeIconStartPadding != closeIconStartPadding) {
+      this.closeIconStartPadding = closeIconStartPadding;
+      invalidateSelf();
+      if (showsCloseIcon()) {
+        onSizeChange();
+      }
+    }
+  }
+
+  public float getCloseIconEndPadding() {
+    return closeIconEndPadding;
+  }
+
+  public void setCloseIconEndPaddingResource(@DimenRes int id) {
+    setCloseIconEndPadding(context.getResources().getDimension(id));
+  }
+
+  public void setCloseIconEndPadding(float closeIconEndPadding) {
+    if (this.closeIconEndPadding != closeIconEndPadding) {
+      this.closeIconEndPadding = closeIconEndPadding;
+      invalidateSelf();
+      if (showsCloseIcon()) {
+        onSizeChange();
+      }
+    }
+  }
+
+  public float getChipEndPadding() {
+    return chipEndPadding;
+  }
+
+  public void setChipEndPaddingResource(@DimenRes int id) {
+    setChipEndPadding(context.getResources().getDimension(id));
+  }
+
+  public void setChipEndPadding(float chipEndPadding) {
+    if (this.chipEndPadding != chipEndPadding) {
+      this.chipEndPadding = chipEndPadding;
+      invalidateSelf();
+      onSizeChange();
+    }
+  }
+}

--- a/support-chip/src/main/java/android/support/design/drawable/DrawableUtils.java
+++ b/support-chip/src/main/java/android/support/design/drawable/DrawableUtils.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2017 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package android.support.design.drawable;
+
+import android.content.res.ColorStateList;
+import android.graphics.Color;
+import android.graphics.PorterDuff;
+import android.graphics.PorterDuffColorFilter;
+import android.graphics.drawable.Drawable;
+import android.support.annotation.Nullable;
+import android.support.annotation.RestrictTo;
+import android.support.annotation.RestrictTo.Scope;
+
+/** Utils class for Drawables. */
+@RestrictTo(Scope.LIBRARY_GROUP)
+public class DrawableUtils {
+
+  private DrawableUtils() {}
+
+  /** Returns a tint filter for the given tint and mode. */
+  @Nullable
+  public static PorterDuffColorFilter updateTintFilter(
+      Drawable drawable, @Nullable ColorStateList tint, @Nullable PorterDuff.Mode tintMode) {
+    if (tint == null || tintMode == null) {
+      return null;
+    }
+
+    final int color = tint.getColorForState(drawable.getState(), Color.TRANSPARENT);
+    return new PorterDuffColorFilter(color, tintMode);
+  }
+}

--- a/support-chip/src/main/java/android/support/design/internal/ThemeEnforcement.java
+++ b/support-chip/src/main/java/android/support/design/internal/ThemeEnforcement.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright (C) 2017 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package android.support.design.internal;
+
+import android.annotation.SuppressLint;
+import android.content.Context;
+import android.content.res.TypedArray;
+import android.support.annotation.AttrRes;
+import android.support.annotation.RestrictTo;
+import android.support.annotation.StyleRes;
+import android.support.annotation.StyleableRes;
+import android.support.design.chip.R;
+import android.support.v7.widget.TintTypedArray;
+import android.util.AttributeSet;
+
+import static android.support.annotation.RestrictTo.Scope.LIBRARY_GROUP;
+
+/**
+ * Utility methods to check Theme compatibility with components.
+ *
+ * @hide
+ */
+@RestrictTo(LIBRARY_GROUP)
+public final class ThemeEnforcement {
+
+  private static final int[] APPCOMPAT_CHECK_ATTRS = {R.attr.colorPrimary};
+  private static final String APPCOMPAT_THEME_NAME = "Theme.AppCompat";
+
+  private static final int[] MATERIAL_CHECK_ATTRS = {R.attr.colorSecondaryLight};
+  private static final String MATERIAL_THEME_NAME = "Theme.MaterialComponents";
+
+  private ThemeEnforcement() {}
+
+  /**
+   * Safely retrieve styled attribute information in this Context's theme, after checking whether
+   * the theme is compatible with the component's given style.
+   *
+   * <p>Set a component's {@link R.attr#enforceMaterialTheme enforceMaterialTheme} attribute to
+   * <code>true</code> to ensure that the Context's theme must inherit from {@link
+   * R.style#Theme_MaterialComponents Theme.MaterialComponents}. For example, you'll want to do this
+   * if the component uses a new attribute defined in <code>Theme.MaterialComponents</code> like
+   * {@link R.attr#colorSecondaryLight colorSecondaryLight}.
+   */
+  public static TypedArray obtainStyledAttributes(
+      Context context,
+      AttributeSet set,
+      @StyleableRes int[] attrs,
+      @AttrRes int defStyleAttr,
+      @StyleRes int defStyleRes) {
+    // First, check for a compatible theme.
+    checkCompatibleTheme(context, set, defStyleAttr, defStyleRes);
+
+    // Then, safely retrieve the styled attribute information.
+    return context.obtainStyledAttributes(set, attrs, defStyleAttr, defStyleRes);
+  }
+
+  /**
+   * Safely retrieve styled attribute information in this Context's theme using {@link
+   * TintTypedArray}, after checking whether the theme is compatible with
+   * the component's given style.
+   *
+   * <p>Set a component's {@link R.attr#enforceMaterialTheme enforceMaterialTheme} attribute to
+   * <code>true</code> to ensure that the Context's theme must inherit from {@link
+   * R.style#Theme_MaterialComponents Theme.MaterialComponents}. For example, you'll want to do this
+   * if the component uses a new attribute defined in <code>Theme.MaterialComponents</code> like
+   * {@link R.attr#colorSecondaryLight colorSecondaryLight}.
+   *
+   * <p>New components should prefer to use {@link #obtainStyledAttributes(Context, AttributeSet,
+   * int[], int, int)}, and use {@link android.support.design.resources.MaterialResources} as a
+   * replacement for the functionality in {@link TintTypedArray}.
+   */
+  @SuppressLint("RestrictedApi") // Taken from the support library
+  public static TintTypedArray obtainTintedStyledAttributes(
+      Context context,
+      AttributeSet set,
+      @StyleableRes int[] attrs,
+      @AttrRes int defStyleAttr,
+      @StyleRes int defStyleRes) {
+    // First, check for a compatible theme.
+    checkCompatibleTheme(context, set, defStyleAttr, defStyleRes);
+
+    // Then, safely retrieve the styled attribute information.
+    return TintTypedArray.obtainStyledAttributes(context, set, attrs, defStyleAttr, defStyleRes);
+  }
+
+  private static void checkCompatibleTheme(
+      Context context, AttributeSet set, @AttrRes int defStyleAttr, @StyleRes int defStyleRes) {
+    TypedArray a =
+        context.obtainStyledAttributes(
+            set, R.styleable.ThemeEnforcement, defStyleAttr, defStyleRes);
+    boolean enforceMaterialTheme =
+        a.getBoolean(R.styleable.ThemeEnforcement_enforceMaterialTheme, false);
+    a.recycle();
+
+    if (enforceMaterialTheme) {
+      checkMaterialTheme(context);
+    }
+    checkAppCompatTheme(context);
+  }
+
+  public static void checkAppCompatTheme(Context context) {
+    checkTheme(context, APPCOMPAT_CHECK_ATTRS, APPCOMPAT_THEME_NAME);
+  }
+
+  public static void checkMaterialTheme(Context context) {
+    checkTheme(context, MATERIAL_CHECK_ATTRS, MATERIAL_THEME_NAME);
+  }
+
+  public static boolean isAppCompatTheme(Context context) {
+    return isTheme(context, APPCOMPAT_CHECK_ATTRS);
+  }
+
+  public static boolean isMaterialTheme(Context context) {
+    return isTheme(context, MATERIAL_CHECK_ATTRS);
+  }
+
+  private static boolean isTheme(Context context, int[] themeAttributes) {
+    TypedArray a = context.obtainStyledAttributes(themeAttributes);
+    final boolean success = a.hasValue(0);
+    a.recycle();
+
+    return success;
+  }
+
+  private static void checkTheme(Context context, int[] themeAttributes, String themeName) {
+    if (!isTheme(context, themeAttributes)) {
+      throw new IllegalArgumentException(
+          "The style on this component requires your app theme to be "
+              + themeName
+              + " (or a descendant).");
+    }
+  }
+}

--- a/support-chip/src/main/java/android/support/design/internal/ViewUtils.java
+++ b/support-chip/src/main/java/android/support/design/internal/ViewUtils.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2015 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package android.support.design.internal;
+
+import android.graphics.PorterDuff;
+import android.support.annotation.RestrictTo;
+import android.support.v4.view.ViewCompat;
+import android.view.View;
+
+import static android.support.annotation.RestrictTo.Scope.LIBRARY_GROUP;
+
+/**
+ * Utils class for custom views.
+ *
+ * @hide
+ */
+@RestrictTo(LIBRARY_GROUP)
+public class ViewUtils {
+  public static PorterDuff.Mode parseTintMode(int value, PorterDuff.Mode defaultMode) {
+    switch (value) {
+      case 3:
+        return PorterDuff.Mode.SRC_OVER;
+      case 5:
+        return PorterDuff.Mode.SRC_IN;
+      case 9:
+        return PorterDuff.Mode.SRC_ATOP;
+      case 14:
+        return PorterDuff.Mode.MULTIPLY;
+      case 15:
+        return PorterDuff.Mode.SCREEN;
+      case 16:
+        return PorterDuff.Mode.ADD;
+      default:
+        return defaultMode;
+    }
+  }
+
+  public static boolean isLayoutRtl(View view) {
+    return ViewCompat.getLayoutDirection(view) == ViewCompat.LAYOUT_DIRECTION_RTL;
+  }
+}

--- a/support-chip/src/main/java/android/support/design/resources/MaterialResources.java
+++ b/support-chip/src/main/java/android/support/design/resources/MaterialResources.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright (C) 2017 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package android.support.design.resources;
+
+import android.content.Context;
+import android.content.res.ColorStateList;
+import android.content.res.TypedArray;
+import android.graphics.drawable.Drawable;
+import android.support.annotation.Nullable;
+import android.support.annotation.RestrictTo;
+import android.support.annotation.StyleableRes;
+import android.support.v7.content.res.AppCompatResources;
+
+import static android.support.annotation.RestrictTo.Scope.LIBRARY_GROUP;
+
+/** Utility methods to resolve resources for components. */
+@RestrictTo(LIBRARY_GROUP)
+public class MaterialResources {
+
+  private MaterialResources() {}
+
+  /**
+   * Returns the {@link ColorStateList} from the given attributes. The resource can include
+   * themeable attributes, regardless of API level.
+   */
+  @Nullable
+  public static ColorStateList getColorStateList(
+      Context context, TypedArray attributes, @StyleableRes int index) {
+    if (attributes.hasValue(index)) {
+      int resourceId = attributes.getResourceId(index, 0);
+      if (resourceId != 0) {
+        ColorStateList value = AppCompatResources.getColorStateList(context, resourceId);
+        if (value != null) {
+          return value;
+        }
+      }
+    }
+    return attributes.getColorStateList(index);
+  }
+
+  /**
+   * Returns the drawable object from the given attributes.
+   *
+   * <p>This method supports inflation of {@code <vector>} and {@code <animated-vector>} resources
+   * on devices where platform support is not available.
+   */
+  @Nullable
+  public static Drawable getDrawable(
+      Context context, TypedArray attributes, @StyleableRes int index) {
+    if (attributes.hasValue(index)) {
+      int resourceId = attributes.getResourceId(index, 0);
+      if (resourceId != 0) {
+        Drawable value = AppCompatResources.getDrawable(context, resourceId);
+        if (value != null) {
+          return value;
+        }
+      }
+    }
+    return attributes.getDrawable(index);
+  }
+
+  /**
+   * Returns a TextAppearanceSpan object from the given attributes.
+   *
+   * <p>You only need this if you are drawing text manually. Normally, TextView takes care of this.
+   */
+  @Nullable
+  public static TextAppearance getTextAppearance(
+      Context context, TypedArray attributes, @StyleableRes int index) {
+    if (attributes.hasValue(index)) {
+      int resourceId = attributes.getResourceId(index, 0);
+      if (resourceId != 0) {
+        return new TextAppearance(context, resourceId);
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Returns the @StyleableRes index that contains value in the attributes array. If both indices
+   * contain values, the first given index takes precedence and is returned.
+   */
+  @StyleableRes
+  static int getIndexWithValue(TypedArray attributes, @StyleableRes int a, @StyleableRes int b) {
+    if (attributes.hasValue(a)) {
+      return a;
+    }
+    return b;
+  }
+}

--- a/support-chip/src/main/java/android/support/design/resources/TextAppearance.java
+++ b/support-chip/src/main/java/android/support/design/resources/TextAppearance.java
@@ -1,0 +1,192 @@
+/*
+ * Copyright 2017 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package android.support.design.resources;
+
+import android.annotation.SuppressLint;
+import android.content.Context;
+import android.content.res.ColorStateList;
+import android.content.res.Resources;
+import android.content.res.TypedArray;
+import android.graphics.Color;
+import android.graphics.Typeface;
+import android.support.annotation.FontRes;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.support.annotation.StyleRes;
+import android.support.design.chip.R;
+import android.support.v4.content.res.ResourcesCompat;
+import android.text.TextPaint;
+import android.util.Log;
+
+/** Utility class that contains the data from parsing a TextAppearance style resource. */
+@SuppressLint("PrivateResource") // Taken from the support library
+public class TextAppearance {
+
+  private static final String TAG = "TextAppearance";
+
+  // Enums from AppCompatTextHelper.
+  private static final int TYPEFACE_SANS = 1;
+  private static final int TYPEFACE_SERIF = 2;
+  private static final int TYPEFACE_MONOSPACE = 3;
+
+  public final float textSize;
+  @Nullable public final ColorStateList textColor;
+  @Nullable public final ColorStateList textColorHint;
+  @Nullable public final ColorStateList textColorLink;
+  public final int textStyle;
+  public final int typeface;
+  @Nullable public final String fontFamily;
+  public final boolean textAllCaps;
+  @Nullable public final ColorStateList shadowColor;
+  public final float shadowDx;
+  public final float shadowDy;
+  public final float shadowRadius;
+
+  @FontRes private final int fontFamilyResourceId;
+
+  private boolean fontResolved = false;
+  @Nullable private Typeface font;
+
+  /** Parses the given TextAppearance style resource. */
+  public TextAppearance(Context context, @StyleRes int id) {
+    TypedArray a = context.obtainStyledAttributes(id, R.styleable.TextAppearance);
+
+    textSize = a.getDimension(R.styleable.TextAppearance_android_textSize, 0f);
+    textColor =
+        MaterialResources.getColorStateList(
+            context, a, R.styleable.TextAppearance_android_textColor);
+    textColorHint =
+        MaterialResources.getColorStateList(
+            context, a, R.styleable.TextAppearance_android_textColorHint);
+    textColorLink =
+        MaterialResources.getColorStateList(
+            context, a, R.styleable.TextAppearance_android_textColorLink);
+    textStyle = a.getInt(R.styleable.TextAppearance_android_textStyle, Typeface.NORMAL);
+    typeface = a.getInt(R.styleable.TextAppearance_android_typeface, TYPEFACE_SANS);
+    int fontFamilyIndex =
+        MaterialResources.getIndexWithValue(
+            a,
+            R.styleable.TextAppearance_fontFamily,
+            R.styleable.TextAppearance_android_fontFamily);
+    fontFamilyResourceId = a.getResourceId(fontFamilyIndex, 0);
+    fontFamily = a.getString(fontFamilyIndex);
+    textAllCaps = a.getBoolean(R.styleable.TextAppearance_textAllCaps, false);
+    shadowColor =
+        MaterialResources.getColorStateList(
+            context, a, R.styleable.TextAppearance_android_shadowColor);
+    shadowDx = a.getFloat(R.styleable.TextAppearance_android_shadowDx, 0);
+    shadowDy = a.getFloat(R.styleable.TextAppearance_android_shadowDy, 0);
+    shadowRadius = a.getFloat(R.styleable.TextAppearance_android_shadowRadius, 0);
+
+    a.recycle();
+  }
+
+  /**
+   * Returns the font Typeface resolved from the fontFamily, style, and typeface.
+   *
+   * @see android.support.v7.widget.AppCompatTextHelper
+   */
+  @NonNull
+  public Typeface getFont(Context context) {
+    if (fontResolved) {
+      return font;
+    }
+
+    // 1. Try resolving fontFamily as a font resource.
+    if (!context.isRestricted()) {
+      try {
+        font = ResourcesCompat.getFont(context, fontFamilyResourceId);
+        if (font != null) {
+          font = Typeface.create(font, textStyle);
+        }
+      } catch (UnsupportedOperationException | Resources.NotFoundException e) {
+        // Expected if it is not a font resource.
+      } catch (Exception e) {
+        Log.d(TAG, "Error loading font " + fontFamily, e);
+      }
+    }
+
+    // 2. Try resolving fontFamily as a string name.
+    if (font == null) {
+      font = Typeface.create(fontFamily, textStyle);
+    }
+
+    // 3. Try resolving typeface.
+    if (font == null) {
+      switch (typeface) {
+        case TYPEFACE_SANS:
+          font = Typeface.SANS_SERIF;
+          break;
+        case TYPEFACE_SERIF:
+          font = Typeface.SERIF;
+          break;
+        case TYPEFACE_MONOSPACE:
+          font = Typeface.MONOSPACE;
+          break;
+        default:
+          font = Typeface.DEFAULT;
+          break;
+      }
+      if (font != null) {
+        font = Typeface.create(font, textStyle);
+      }
+    }
+
+    fontResolved = true;
+    return font;
+  }
+
+  /**
+   * Applies the attributes that affect drawing from TextAppearance to the given TextPaint. Note
+   * that not all attributes can be applied to the TextPaint.
+   *
+   * @see android.text.style.TextAppearanceSpan#updateDrawState(TextPaint)
+   */
+  public void updateDrawState(Context context, TextPaint textPaint) {
+    updateMeasureState(context, textPaint);
+
+    textPaint.setColor(
+        textColor != null
+            ? textColor.getColorForState(textPaint.drawableState, textColor.getDefaultColor())
+            : Color.BLACK);
+    textPaint.setShadowLayer(
+        shadowRadius,
+        shadowDx,
+        shadowDy,
+        shadowColor != null
+            ? shadowColor.getColorForState(textPaint.drawableState, shadowColor.getDefaultColor())
+            : Color.TRANSPARENT);
+  }
+
+  /**
+   * Applies the attributes that affect measurement from TextAppearance to the given TextPaint. Note
+   * that not all attributes can be applied to the TextPaint.
+   *
+   * @see android.text.style.TextAppearanceSpan#updateMeasureState(TextPaint)
+   */
+  public void updateMeasureState(Context context, TextPaint textPaint) {
+    Typeface tf = getFont(context);
+
+    textPaint.setTypeface(tf);
+
+    int fake = textStyle & ~tf.getStyle();
+    textPaint.setFakeBoldText((fake & Typeface.BOLD) != 0);
+    textPaint.setTextSkewX((fake & Typeface.ITALIC) != 0 ? -0.25f : 0f);
+
+    textPaint.setTextSize(textSize);
+  }
+}

--- a/support-chip/src/main/java/android/support/design/ripple/RippleUtils.java
+++ b/support-chip/src/main/java/android/support/design/ripple/RippleUtils.java
@@ -1,0 +1,192 @@
+/*
+ * Copyright 2017 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package android.support.design.ripple;
+
+import android.annotation.TargetApi;
+import android.content.res.ColorStateList;
+import android.graphics.Color;
+import android.os.Build.VERSION;
+import android.os.Build.VERSION_CODES;
+import android.support.annotation.ColorInt;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.support.annotation.RestrictTo;
+import android.support.annotation.RestrictTo.Scope;
+import android.support.v4.graphics.ColorUtils;
+import android.util.StateSet;
+
+/** Utils class for ripples. */
+@RestrictTo(Scope.LIBRARY_GROUP)
+public class RippleUtils {
+
+  public static final boolean USE_FRAMEWORK_RIPPLE = VERSION.SDK_INT >= VERSION_CODES.LOLLIPOP;
+
+  private static final int[] PRESSED_STATE_SET = {
+    android.R.attr.state_pressed,
+  };
+  private static final int[] HOVERED_FOCUSED_STATE_SET = {
+    android.R.attr.state_hovered, android.R.attr.state_focused,
+  };
+  private static final int[] FOCUSED_STATE_SET = {
+    android.R.attr.state_focused,
+  };
+  private static final int[] HOVERED_STATE_SET = {
+    android.R.attr.state_hovered,
+  };
+
+  private static final int[] SELECTED_PRESSED_STATE_SET = {
+    android.R.attr.state_selected, android.R.attr.state_pressed,
+  };
+  private static final int[] SELECTED_HOVERED_FOCUSED_STATE_SET = {
+    android.R.attr.state_selected, android.R.attr.state_hovered, android.R.attr.state_focused,
+  };
+  private static final int[] SELECTED_FOCUSED_STATE_SET = {
+    android.R.attr.state_selected, android.R.attr.state_focused,
+  };
+  private static final int[] SELECTED_HOVERED_STATE_SET = {
+    android.R.attr.state_selected, android.R.attr.state_hovered,
+  };
+  private static final int[] SELECTED_STATE_SET = {
+    android.R.attr.state_selected,
+  };
+
+  private RippleUtils() {}
+
+  /**
+   * Converts the given color state list to one that can be passed to a RippleDrawable.
+   *
+   * <p>The passed in stateful ripple color can contain colors for these states:
+   *
+   * <ul>
+   *   <li>android:state_pressed="true"
+   *   <li>android:state_focused="true" and android:state_hovered="true"
+   *   <li>android:state_focused="true"
+   *   <li>android:state_hovered="true"
+   *   <li>Default unselected state - transparent color. TODO: remove
+   * </ul>
+   *
+   * <p>For selectable components, the ripple color may contain additional colors for these states:
+   *
+   * <ul>
+   *   <li>android:state_pressed="true" and android:state_selected="true"
+   *   <li>android:state_focused="true" and android:state_hovered="true" and
+   *       android:state_selected="true"
+   *   <li>android:state_focused="true" and android:state_selected="true"
+   *   <li>android:state_hovered="true" and android:state_selected="true"
+   *   <li>Default selected state - transparent color.
+   * </ul>
+   */
+  @NonNull
+  public static ColorStateList convertToRippleDrawableColor(@Nullable ColorStateList rippleColor) {
+    if (USE_FRAMEWORK_RIPPLE) {
+      int size = 2;
+
+      final int[][] states = new int[size][];
+      final int[] colors = new int[size];
+      int i = 0;
+
+      // Ideally we would define a different composite color for each state, but that causes the
+      // ripple animation to abort prematurely.
+      // So we only allow two base states: selected, and non-selected. For each base state, we only
+      // base the ripple composite on its pressed state.
+
+      // Selected base state.
+      states[i] = SELECTED_STATE_SET;
+      colors[i] = getColorForState(rippleColor, SELECTED_PRESSED_STATE_SET);
+      i++;
+
+      // Non-selected base state.
+      states[i] = StateSet.NOTHING;
+      colors[i] = getColorForState(rippleColor, PRESSED_STATE_SET);
+      i++;
+
+      return new ColorStateList(states, colors);
+    } else {
+      int size = 10;
+
+      final int[][] states = new int[size][];
+      final int[] colors = new int[size];
+      int i = 0;
+
+      states[i] = SELECTED_PRESSED_STATE_SET;
+      colors[i] = getColorForState(rippleColor, SELECTED_PRESSED_STATE_SET);
+      i++;
+
+      states[i] = SELECTED_HOVERED_FOCUSED_STATE_SET;
+      colors[i] = getColorForState(rippleColor, SELECTED_HOVERED_FOCUSED_STATE_SET);
+      i++;
+
+      states[i] = SELECTED_FOCUSED_STATE_SET;
+      colors[i] = getColorForState(rippleColor, SELECTED_FOCUSED_STATE_SET);
+      i++;
+
+      states[i] = SELECTED_HOVERED_STATE_SET;
+      colors[i] = getColorForState(rippleColor, SELECTED_HOVERED_STATE_SET);
+      i++;
+
+      // Checked state.
+      states[i] = SELECTED_STATE_SET;
+      colors[i] = Color.TRANSPARENT;
+      i++;
+
+      states[i] = PRESSED_STATE_SET;
+      colors[i] = getColorForState(rippleColor, PRESSED_STATE_SET);
+      i++;
+
+      states[i] = HOVERED_FOCUSED_STATE_SET;
+      colors[i] = getColorForState(rippleColor, HOVERED_FOCUSED_STATE_SET);
+      i++;
+
+      states[i] = FOCUSED_STATE_SET;
+      colors[i] = getColorForState(rippleColor, FOCUSED_STATE_SET);
+      i++;
+
+      states[i] = HOVERED_STATE_SET;
+      colors[i] = getColorForState(rippleColor, HOVERED_STATE_SET);
+      i++;
+
+      // Default state.
+      states[i] = StateSet.NOTHING;
+      colors[i] = Color.TRANSPARENT;
+      i++;
+
+      return new ColorStateList(states, colors);
+    }
+  }
+
+  @ColorInt
+  private static int getColorForState(@Nullable ColorStateList rippleColor, int[] state) {
+    int color;
+    if (rippleColor != null) {
+      color = rippleColor.getColorForState(state, rippleColor.getDefaultColor());
+    } else {
+      color = Color.TRANSPARENT;
+    }
+    return USE_FRAMEWORK_RIPPLE ? doubleAlpha(color) : color;
+  }
+
+  /**
+   * On API 21+, the framework composites a ripple color onto the display at about 50% opacity.
+   * Since we are providing precise ripple colors, cancel that out by doubling the opacity here.
+   */
+  @ColorInt
+  @TargetApi(VERSION_CODES.LOLLIPOP)
+  private static int doubleAlpha(@ColorInt int color) {
+    int alpha = Math.min(2 * Color.alpha(color), 255);
+    return ColorUtils.setAlphaComponent(color, alpha);
+  }
+}

--- a/support-chip/src/main/res/animator/mtrl_chip_state_list_anim.xml
+++ b/support-chip/src/main/res/animator/mtrl_chip_state_list_anim.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Copyright 2017 The Android Open Source Project
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  -->
+
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+
+  <!-- Pressed state -->
+  <item
+      android:state_enabled="true"
+      android:state_pressed="true">
+    <objectAnimator
+        android:duration="@integer/mtrl_chip_anim_duration"
+        android:propertyName="translationZ"
+        android:valueTo="@dimen/mtrl_chip_pressed_translation_z"
+        android:valueType="floatType"/>
+  </item>
+
+  <!-- Enabled state -->
+  <item android:state_enabled="true">
+    <objectAnimator
+        android:duration="@integer/mtrl_chip_anim_duration"
+        android:propertyName="translationZ"
+        android:valueTo="0"
+        android:valueType="floatType"/>
+  </item>
+
+  <!-- Disabled state -->
+  <item>
+    <objectAnimator
+        android:duration="0"
+        android:propertyName="translationZ"
+        android:valueTo="0"
+        android:valueType="floatType"/>
+  </item>
+
+</selector>

--- a/support-chip/src/main/res/color/mtrl_chip_background_color.xml
+++ b/support-chip/src/main/res/color/mtrl_chip_background_color.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Copyright 2017 The Android Open Source Project
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  -->
+
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+
+  <item android:color="#CACACA" android:state_enabled="true" android:state_selected="true"/>
+  <item android:color="#EBEBEB" android:state_enabled="true"/>
+  <item android:color="#F7F7F7"/>
+
+</selector>

--- a/support-chip/src/main/res/color/mtrl_chip_close_icon_tint.xml
+++ b/support-chip/src/main/res/color/mtrl_chip_close_icon_tint.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Copyright 2017 The Android Open Source Project
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  -->
+
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+
+  <item android:alpha="1.0" android:color="#000000" android:state_pressed="true"/>
+  <item android:alpha="1.0" android:color="#000000" android:state_focused="true" android:state_hovered="true"/>
+  <item android:alpha="0.87" android:color="#000000" android:state_focused="true"/>
+  <item android:alpha="0.72" android:color="#000000" android:state_hovered="true"/>
+  <item android:alpha="0.54" android:color="#000000" android:state_enabled="true"/>
+  <!-- 38% of 54% opacity. -->
+  <item android:alpha="0.21" android:color="#000000"/>
+
+</selector>

--- a/support-chip/src/main/res/color/mtrl_chip_ripple_color.xml
+++ b/support-chip/src/main/res/color/mtrl_chip_ripple_color.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Copyright 2017 The Android Open Source Project
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  -->
+
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+
+  <item android:alpha="0.16" android:color="#000000" android:state_pressed="true"/>
+  <item android:alpha="0.16" android:color="#000000" android:state_focused="true" android:state_hovered="true"/>
+  <item android:alpha="0.12" android:color="#000000" android:state_focused="true"/>
+  <item android:alpha="0.04" android:color="#000000" android:state_hovered="true"/>
+  <item android:alpha="0.00" android:color="#000000"/>
+
+</selector>

--- a/support-chip/src/main/res/color/mtrl_chip_text_color.xml
+++ b/support-chip/src/main/res/color/mtrl_chip_text_color.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Copyright 2017 The Android Open Source Project
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  -->
+
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+
+  <!-- 87% opacity. -->
+  <item android:color="#DE000000" android:state_enabled="true"/>
+  <!-- 38% of 87% opacity. -->
+  <item android:color="#54000000"/>
+
+</selector>

--- a/support-chip/src/main/res/drawable/ic_mtrl_chip_checked_black.xml
+++ b/support-chip/src/main/res/drawable/ic_mtrl_chip_checked_black.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Copyright 2017 The Android Open Source Project
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  -->
+
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:height="24dp"
+    android:viewportHeight="24.0"
+    android:viewportWidth="24.0"
+    android:width="24dp"
+    tools:ignore="NewApi">
+  <path
+      android:fillColor="#000000"
+      android:pathData="M9,16.2L4.8,12l-1.4,1.4L9,19 21,7l-1.4,-1.4L9,16.2z"/>
+</vector>

--- a/support-chip/src/main/res/drawable/ic_mtrl_chip_checked_circle.xml
+++ b/support-chip/src/main/res/drawable/ic_mtrl_chip_checked_circle.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Copyright 2017 The Android Open Source Project
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  -->
+
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:height="24dp"
+    android:viewportHeight="24.0"
+    android:viewportWidth="24.0"
+    android:width="24dp"
+    tools:ignore="NewApi">
+  <path
+      android:fillAlpha="0.5"
+      android:fillColor="#191919"
+      android:pathData="M12,12m-12,0a12,12 0,1 1,24 0a12,12 0,1 1,-24 0"
+      android:strokeColor="#00000000"
+      android:strokeWidth="1"/>
+  <path
+      android:fillColor="#FFFFFF"
+      android:pathData="M9.189,15.939l-3.127,-3.128l-1.061,1.061l4.189,4.189l9,-9l-1.061,-1.061z"
+      android:strokeColor="#00000000"
+      android:strokeWidth="1"/>
+</vector>

--- a/support-chip/src/main/res/drawable/ic_mtrl_chip_close_circle.xml
+++ b/support-chip/src/main/res/drawable/ic_mtrl_chip_close_circle.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Copyright 2017 The Android Open Source Project
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  -->
+
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:height="18dp"
+    android:viewportHeight="18"
+    android:viewportWidth="18"
+    android:width="18dp"
+    tools:ignore="NewApi">
+  <path
+      android:fillColor="#000000"
+      android:pathData="M13,11.87 L11.87,13 L9,10.13 L6.13,13 L5,11.87 L7.87,9 L5,6.13 L6.13,5 L9,7.87 L11.87,5 L13,6.13 L10.13,9 L13,11.87 Z M9,1 C4.58,1,1,4.58,1,9 C1,13.42,4.58,17,9,17 C13.42,17,17,13.42,17,9 C17,4.58,13.42,1,9,1 L9,1 Z"
+      android:strokeWidth="1"/>
+</vector>

--- a/support-chip/src/main/res/values/attrs-button.xml
+++ b/support-chip/src/main/res/values/attrs-button.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright 2017 The Android Open Source Project
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+
+<resources>
+
+  <!-- Style to use for MaterialButtons in this theme. -->
+  <attr name="materialButtonStyle" format="reference"/>
+
+  <declare-styleable name="MaterialButton">
+    <attr name="android:padding"/>
+    <attr name="android:paddingLeft"/>
+    <attr name="android:paddingStart"/>
+    <attr name="android:paddingRight"/>
+    <attr name="android:paddingEnd"/>
+    <attr name="android:paddingTop"/>
+    <attr name="android:paddingBottom"/>
+    <attr name="android:insetLeft"/>
+    <attr name="android:insetRight"/>
+    <attr name="android:insetTop"/>
+    <attr name="android:insetBottom"/>
+    <!-- Background for the MaterialButton -->
+    <attr name="backgroundTint"/>
+    <attr name="backgroundTintMode"/>
+    <!-- Icon drawable to display at the start of this view. -->
+    <attr name="icon" format="reference"/>
+    <!-- Padding between icon and button text. -->
+    <attr name="iconPadding" format="dimension"/>
+    <!-- Tint for icon drawable to display. -->
+    <attr name="iconTint" format="color"/>
+    <!-- Tint mode for icon drawable to display. -->
+    <attr name="iconTintMode"/>
+    <!-- Padding to add/remove from the left side of the button when an icon is present. -->
+    <attr name="additionalPaddingLeftForIcon" format="dimension"/>
+    <!-- Padding to add/remove from the right side of the button when an icon is present. -->
+    <attr name="additionalPaddingRightForIcon" format="dimension"/>
+    <!-- Specifies the color used to draw the path outline of the button. -->
+    <attr name="strokeColor" format="color"/>
+    <!-- Width of the stroke path of the button. Default is 0. -->
+    <attr name="strokeWidth" format="dimension"/>
+    <!--
+        Specifies the radius for the corners of the button. Default is 0, for non-rounded corners.
+    -->
+    <attr name="cornerRadius" format="dimension"/>
+    <!-- Ripple color for the button. This may be a color state list, if the desired ripple color
+         should be stateful. -->
+    <attr name="rippleColor" format="color"/>
+  </declare-styleable>
+
+</resources>

--- a/support-chip/src/main/res/values/attrs-internal.xml
+++ b/support-chip/src/main/res/values/attrs-internal.xml
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (C) 2017 The Android Open Source Project
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+-->
+<resources>
+
+  <declare-styleable name="ThemeEnforcement">
+    <!-- Internal flag used to denote that a style uses new attributes defined by
+         Theme.MaterialComponents, and that the component should check via ThemeEnforcement that the
+         client's app theme inherits from Theme.MaterialComponents.
+
+         Not all usages of new attributes are problematic in the context of a legacy app theme. You
+         should only use this flag if a particular usage is known to cause a visual glitch or crash.
+         For example, tinting a vector drawable with a non-existent theme attribute is known to
+         crash on pre-21 devices. -->
+    <attr name="enforceMaterialTheme" format="boolean"/>
+  </declare-styleable>
+
+  <declare-styleable name="ForegroundLinearLayout">
+    <attr name="android:foreground"/>
+    <attr name="android:foregroundGravity"/>
+    <attr name="foregroundInsidePadding" format="boolean"/>
+  </declare-styleable>
+
+  <declare-styleable name="ScrimInsetsFrameLayout">
+    <attr name="insetForeground" format="color|reference"/>
+  </declare-styleable>
+
+  <declare-styleable name="SnackbarLayout">
+    <attr name="android:maxWidth"/>
+    <attr name="elevation"/>
+    <attr name="maxActionInlineWidth" format="dimension"/>
+  </declare-styleable>
+
+  <declare-styleable name="FlexboxLayout_Layout">
+    <attr name="layout_order" format="integer"/>
+
+    <!-- Negative numbers are invalid. -->
+    <attr name="layout_flexGrow" format="float"/>
+
+    <!-- Negative numbers are invalid. -->
+    <attr name="layout_flexShrink" format="float"/>
+
+    <!--
+        The initial length in a percentage format relative to its parent. This is similar to the
+        flex-basis property in the original CSS specification.
+        (https://www.w3.org/TR/css-flexbox-1/#flex-basis-property)
+        But unlike the flex-basis property, this attribute only accepts a value in fraction
+        (percentage), whereas flex-basis property accepts width values such as 1em, 10px and
+        the 'content' string.
+        But specifying initial fixed width values can be done by specifying width values in
+        layout_width (or layout_height, varies depending on the flexDirection). Also the same
+        effect can be done by specifying "wrap_content" in layout_width (or layout_height) if
+        developers want to achieve the same effect as 'content'.
+        Thus, this attribute only accepts fraction values, which can't be done through
+        layout_width (or layout_height) for simplicity.
+    -->
+    <attr name="layout_flexBasisPercent" format="fraction"/>
+
+    <!--
+        Omitting flex property since it's a shorthand for layout_flexGrow and layout_flexShrink
+        and layout_percentInParent (flex-basis in the original CSS spec).
+    -->
+
+    <attr name="layout_minWidth" format="dimension"/>
+    <attr name="layout_minHeight" format="dimension"/>
+    <attr name="layout_maxWidth" format="dimension"/>
+    <attr name="layout_maxHeight" format="dimension"/>
+
+    <!--
+        This attribute forces a flex line wrapping. i.e. if this is set to true for a
+        flex item, the item will become the first item of a flex line. (A wrapping happens
+        regardless of the flex items being processed in the the previous flex line)
+        This attribute is ignored if the flex_wrap attribute is set to nowrap.
+        The equivalent attribute isn't defined in the original CSS Flexible Box Module
+        specification, but having this attribute is useful for Android developers to flatten
+        the layouts when building a grid like layout or for a situation where developers want
+        to put a new flex line to make a semantic difference from the previous one, etc.
+    -->
+    <attr name="layout_wrapBefore" format="boolean"/>
+  </declare-styleable>
+</resources>

--- a/support-chip/src/main/res/values/attrs-theme.xml
+++ b/support-chip/src/main/res/values/attrs-theme.xml
@@ -1,0 +1,162 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (C) 2015 The Android Open Source Project
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+-->
+<resources>
+
+  <declare-styleable name="MaterialComponentsTheme">
+
+    <!-- The accent color that's applied to many components and controls.
+         This is set to colorSecondary by default, but can also be set to colorPrimary.  -->
+    <attr name="colorAccent"/>
+
+    <!-- The following attributes make up the theme's main color scheme. Components will expect all
+         6 colors to be defined. -->
+    <eat-comment/>
+
+    <!-- The primary branding color for the app. -->
+    <attr name="colorPrimary"/>
+    <!-- The light variant of the primary color. -->
+    <attr name="colorPrimaryLight"/>
+    <!-- The dark variant of the primary color. -->
+    <attr name="colorPrimaryDark"/>
+    <!-- The secondary branding color for the app, usually a bright complement to the primary
+         branding color. -->
+    <attr name="colorSecondary"/>
+    <!-- The light variant of the secondary color. -->
+    <attr name="colorSecondaryLight"/>
+    <!-- The dark variant of the secondary color. -->
+    <attr name="colorSecondaryDark"/>
+
+
+    <!-- The following attributes make up the theme's tonal palette. Components may use these colors
+         for accessibility when the main color scheme does not provide enough contrast. These colors
+         are expected to be opaque, and go from light to dark. The number itself is an arbitrary
+         designation. -->
+    <eat-comment/>
+
+    <!-- The primary 50 tonal variation. Part of the primary tonal palette. -->
+    <attr name="colorPrimary50"/>
+    <!-- The primary 100 tonal variation. Part of the primary tonal palette. -->
+    <attr name="colorPrimary100"/>
+    <!-- The primary 200 tonal variation. Part of the primary tonal palette. -->
+    <attr name="colorPrimary200"/>
+    <!-- The primary 300 tonal variation. Part of the primary tonal palette. -->
+    <attr name="colorPrimary300"/>
+    <!-- The primary 400 tonal variation. Part of the primary tonal palette. -->
+    <attr name="colorPrimary400"/>
+    <!-- The primary 500 tonal variation. Part of the primary tonal palette. -->
+    <attr name="colorPrimary500"/>
+    <!-- The primary 600 tonal variation. Part of the primary tonal palette. This is usually
+         considered to be the main tonal variation in the tonal palette. -->
+    <attr name="colorPrimary600"/>
+    <!-- The primary 700 tonal variation. Part of the primary tonal palette. -->
+    <attr name="colorPrimary700"/>
+    <!-- The primary 800 tonal variation. Part of the primary tonal palette. -->
+    <attr name="colorPrimary800"/>
+    <!-- The primary 900 tonal variation. Part of the primary tonal palette. -->
+    <attr name="colorPrimary900"/>
+
+    <!-- The secondary 50 tonal variation. Part of the secondary tonal palette. -->
+    <attr name="colorSecondary50"/>
+    <!-- The secondary 100 tonal variation. Part of the secondary tonal palette. -->
+    <attr name="colorSecondary100"/>
+    <!-- The secondary 200 tonal variation. Part of the secondary tonal palette. -->
+    <attr name="colorSecondary200"/>
+    <!-- The secondary 300 tonal variation. Part of the secondary tonal palette. -->
+    <attr name="colorSecondary300"/>
+    <!-- The secondary 400 tonal variation. Part of the secondary tonal palette. -->
+    <attr name="colorSecondary400"/>
+    <!-- The secondary 500 tonal variation. Part of the secondary tonal palette. -->
+    <attr name="colorSecondary500"/>
+    <!-- The secondary 600 tonal variation. Part of the secondary tonal palette. This is usually
+         considered to be the main tonal variation in the tonal palette. -->
+    <attr name="colorSecondary600"/>
+    <!-- The secondary 700 tonal variation. Part of the secondary tonal palette. -->
+    <attr name="colorSecondary700"/>
+    <!-- The secondary 800 tonal variation. Part of the secondary tonal palette. -->
+    <attr name="colorSecondary800"/>
+    <!-- The secondary 900 tonal variation. Part of the secondary tonal palette. -->
+    <attr name="colorSecondary900"/>
+
+    <!-- The scrim background that appears below modals and expanded navigation menus.
+         The background can either be a color or a bitmap drawable with tileMode set to repeat. -->
+    <attr name="scrimBackground"/>
+
+    <!-- Default color of background imagery for floating components, ex. dialogs, popups, and cards. -->
+    <attr name="colorBackgroundFloating"/>
+
+    <!-- Theme to use for modal bottom sheet dialogs spawned from this theme. -->
+    <attr name="bottomSheetDialogTheme"/>
+    <!-- Style to use for modal bottom sheets in this theme. -->
+    <attr name="bottomSheetStyle"/>
+    <!-- Style to use for MaterialButtons in this theme. -->
+    <attr name="materialButtonStyle"/>
+    <!-- Style to use MaterialSwitch in this theme. -->
+    <attr name="materialSwitchStyle"/>
+    <!-- Style to use for ChipGroups in this theme. -->
+    <attr name="chipGroupStyle"/>
+    <!-- Style to use for Chips in this theme, usually to be used as a view. -->
+    <attr name="chipStyle"/>
+    <!-- Style to use for standalone Chips in this theme, usually to be used in an EditText. -->
+    <attr name="chipStandaloneStyle"/>
+    <!-- Style to use for MaterialCardView in this theme. -->
+    <attr name="materialCardViewStyle"/>
+    <!-- Style to use for NavigationView in this theme. -->
+    <attr name="navigationViewStyle"/>
+    <!-- Style to use for TabLayouts in this theme. -->
+    <attr name="tabStyle"/>
+    <!-- Style to use for TextInputLayouts in this theme. -->
+    <attr name="textInputStyle"/>
+
+    <!-- Style to use for action button within a Snackbar in this theme. -->
+    <attr name="snackbarButtonStyle"/>
+
+    <!-- Text appearance for the Headline 1 style in this theme. -->
+    <attr name="textAppearanceHeadline1"/>
+    <!-- Text appearance for the Headline 2 style in this theme. -->
+    <attr name="textAppearanceHeadline2"/>
+    <!-- Text appearance for the Headline 3 style in this theme. -->
+    <attr name="textAppearanceHeadline3"/>
+    <!-- Text appearance for the Headline 4 style in this theme. -->
+    <attr name="textAppearanceHeadline4"/>
+    <!-- Text appearance for the Headline 5 style in this theme. -->
+    <attr name="textAppearanceHeadline5"/>
+    <!-- Text appearance for the Headline 6 style in this theme. -->
+    <attr name="textAppearanceHeadline6"/>
+    <!-- Text appearance for the Subtitle 1 style in this theme. -->
+    <attr name="textAppearanceSubtitle1"/>
+    <!-- Text appearance for the Subtitle 2 style in this theme. -->
+    <attr name="textAppearanceSubtitle2"/>
+    <!-- Text appearance for the Body 1 style in this theme. -->
+    <attr name="textAppearanceBody1"/>
+    <!-- Text appearance for the Body 2 style in this theme. -->
+    <attr name="textAppearanceBody2"/>
+    <!-- Text appearance for the Caption style in this theme. -->
+    <attr name="textAppearanceCaption"/>
+    <!-- Text appearance for the Button style in this theme. -->
+    <attr name="textAppearanceButton"/>
+    <!-- Text appearance for the Overline style in this theme. -->
+    <attr name="textAppearanceOverline"/>
+  </declare-styleable>
+
+  <declare-styleable name="DesignTheme">
+    <!-- Theme to use for modal bottom sheet dialogs spawned from this theme. -->
+    <attr name="bottomSheetDialogTheme" format="reference"/>
+    <!-- Style to use for modal bottom sheets in this theme. -->
+    <attr name="bottomSheetStyle" format="reference"/>
+  </declare-styleable>
+
+</resources>

--- a/support-chip/src/main/res/values/attrs.xml
+++ b/support-chip/src/main/res/values/attrs.xml
@@ -1,0 +1,130 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (C) 2017 The Android Open Source Project
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+-->
+<resources>
+
+  <!-- Style to use for ChipGroups in this theme. -->
+  <attr name="chipGroupStyle" format="reference"/>
+  <!-- Style to use for Chips in this theme, usually to be used as a view. -->
+  <attr name="chipStyle" format="reference"/>
+  <!-- Style to use for standalone Chips in this theme, usually to be used in an EditText. -->
+  <attr name="chipStandaloneStyle" format="reference"/>
+
+  <declare-styleable name="ChipDrawable">
+    <!-- Background color to apply to the chip. -->
+    <attr name="chipBackgroundColor" format="color"/>
+    <!-- Min height to apply to the chip. Total height includes stroke width. -->
+    <attr name="chipMinHeight" format="dimension"/>
+    <!-- Corner radius to apply to the chip's shape. -->
+    <attr name="chipCornerRadius" format="dimension"/>
+    <!-- Stroke color to apply to the chip's outline. -->
+    <attr name="chipStrokeColor" format="color"/>
+    <!-- Stroke width to apply to the chip's outline. -->
+    <attr name="chipStrokeWidth" format="dimension"/>
+    <!-- Ripple color to apply to the chip. -->
+    <attr name="rippleColor"/>
+
+    <!-- Text to display on the chip. -->
+    <attr name="chipText" format="string" localization="suggested"/>
+    <!-- Default appearance of text: color, typeface, size, and style. -->
+    <attr name="android:textAppearance"/>
+
+    <!-- Whether to show the chip icon. -->
+    <attr name="chipIconEnabled" format="boolean"/>
+    <!-- Icon drawable to display at the start of the chip. -->
+    <attr name="chipIcon" format="reference"/>
+    <!-- Size of the chip's icon and checked icon. -->
+    <attr name="chipIconSize" format="dimension"/>
+
+    <!-- Whether to show the close icon. -->
+    <attr name="closeIconEnabled" format="boolean"/>
+    <!-- Close icon drawable to display at the end of the chip. -->
+    <attr name="closeIcon" format="reference"/>
+    <!-- Tint to apply to the chip's close icon. -->
+    <attr name="closeIconTint" format="color"/>
+    <!-- Size of the chip's close icon. -->
+    <attr name="closeIconSize" format="dimension"/>
+
+    <!-- Whether the chip can be checked. If false, the chip will act as a button. -->
+    <attr name="android:checkable"/>
+    <!-- Whether to show the checked icon. -->
+    <attr name="checkedIconEnabled" format="boolean"/>
+    <!-- Check icon drawable to overlay the chip's icon. -->
+    <attr name="checkedIcon" format="reference"/>
+
+    <!-- Motion spec for show animation. This should be a MotionSpec resource. -->
+    <attr name="showMotionSpec"/>
+    <!-- Motion spec for hide animation. This should be a MotionSpec resource. -->
+    <attr name="hideMotionSpec"/>
+
+    <!-- The following attributes are adjustable padding on the chip, listed from start to end. -->
+
+    <!-- Chip starts here. -->
+
+    <!-- Padding at the start of the chip, before the icon. -->
+    <attr name="chipStartPadding" format="dimension"/>
+    <!-- Padding at the start of the icon, after the start of the chip. If icon exists. -->
+    <attr name="iconStartPadding" format="dimension"/>
+
+    <!-- Icon is here. -->
+
+    <!-- Padding at the end of the icon, before the text. If icon exists. -->
+    <attr name="iconEndPadding" format="dimension"/>
+    <!-- Padding at the start of the text, after the icon. -->
+    <attr name="textStartPadding" format="dimension"/>
+
+    <!-- Text is here. -->
+
+    <!-- Padding at the end of the text, before the close icon. -->
+    <attr name="textEndPadding" format="dimension"/>
+    <!-- Padding at the start of the close icon, after the text. If close icon exists. -->
+    <attr name="closeIconStartPadding" format="dimension"/>
+
+    <!-- Close icon is here. -->
+
+    <!-- Padding at the end of the close icon, before the end of the chip. If close icon exists. -->
+    <attr name="closeIconEndPadding" format="dimension"/>
+    <!-- Padding at the end of the chip, after the close icon. -->
+    <attr name="chipEndPadding" format="dimension"/>
+
+    <!-- Chip ends here. -->
+  </declare-styleable>
+
+  <declare-styleable name="ChipGroup">
+
+    <!-- Horizontal and vertical spacing between chips in this group. -->
+    <attr name="chipSpacing" format="dimension"/>
+    <!-- Horizontal spacing between chips in this group. -->
+    <attr name="chipSpacingHorizontal" format="dimension"/>
+    <!-- Vertical spacing between chips in this group. -->
+    <attr name="chipSpacingVertical" format="dimension"/>
+
+    <!-- Constrains the chips in this group to a single horizontal line. By default, this is false
+         and the chips in this group will reflow to multiple lines.
+
+         If you set this to true, you'll usually want to wrap this ChipGroup in a
+         HorizontalScrollView. -->
+    <attr name="singleLine" format="boolean"/>
+
+    <!-- Whether only a single chip in this group is allowed to be checked at any time. By default,
+         this is false and multiple chips in this group are allowed to be checked at once. -->
+    <attr name="singleSelection" format="boolean"/>
+    <!-- The id of the child chip that should be checked by default within this chip group. -->
+    <attr name="checkedChip" format="reference"/>
+
+  </declare-styleable>
+  
+</resources>

--- a/support-chip/src/main/res/values/dimens.xml
+++ b/support-chip/src/main/res/values/dimens.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (C) 2017 The Android Open Source Project
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+-->
+<resources>
+
+  <dimen name="mtrl_chip_pressed_translation_z">3dp</dimen>
+  <dimen name="mtrl_chip_text_size">14sp</dimen>
+
+</resources>

--- a/support-chip/src/main/res/values/integers.xml
+++ b/support-chip/src/main/res/values/integers.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (C) 2017 The Android Open Source Project
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+-->
+<resources>
+
+  <integer name="mtrl_chip_anim_duration">100</integer>
+
+</resources>

--- a/support-chip/src/main/res/values/strings.xml
+++ b/support-chip/src/main/res/values/strings.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Copyright 2017 The Android Open Source Project
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  -->
+
+<resources>
+  <string name="mtrl_chip_close_icon_content_description">Close icon</string>
+</resources>

--- a/support-chip/src/main/res/values/styles-chip.xml
+++ b/support-chip/src/main/res/values/styles-chip.xml
@@ -1,0 +1,123 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (C) 2017 The Android Open Source Project
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+-->
+<resources xmlns:tools="http://schemas.android.com/tools">
+
+  <style name="Base.Widget.MaterialComponents.Chip" parent="android:Widget">
+    <item name="android:focusable">true</item>
+    <item name="android:clickable">true</item>
+    <item name="android:checkable">false</item>
+    <item name="android:stateListAnimator" tools:ignore="NewApi">
+      @animator/mtrl_chip_state_list_anim
+    </item>
+
+    <item name="chipIconEnabled">true</item>
+    <item name="checkedIconEnabled">true</item>
+    <item name="closeIconEnabled">true</item>
+
+    <item name="chipIcon">@null</item>
+    <item name="checkedIcon">@drawable/ic_mtrl_chip_checked_circle</item>
+    <item name="closeIcon">@drawable/ic_mtrl_chip_close_circle</item>
+
+    <item name="chipText">@null</item>
+    <item name="android:textAppearance">@style/TextAppearance.MaterialComponents.Chip</item>
+    <item name="closeIconTint">@color/mtrl_chip_close_icon_tint</item>
+
+    <item name="chipBackgroundColor">@color/mtrl_chip_background_color</item>
+    <item name="chipStrokeColor">#00000000</item>
+    <item name="chipStrokeWidth">0dp</item>
+    <item name="rippleColor">@color/mtrl_chip_ripple_color</item>
+
+    <item name="chipMinHeight">32dp</item>
+    <item name="chipCornerRadius">16dp</item>
+    <item name="chipIconSize">24dp</item>
+    <item name="closeIconSize">18dp</item>
+
+    <item name="chipStartPadding">4dp</item>
+    <item name="iconStartPadding">0dp</item>
+    <item name="iconEndPadding">0dp</item>
+    <item name="textStartPadding">8dp</item>
+    <item name="textEndPadding">6dp</item>
+    <item name="closeIconStartPadding">2dp</item>
+    <item name="closeIconEndPadding">2dp</item>
+    <item name="chipEndPadding">6dp</item>
+  </style>
+
+  <!-- Style for Chips that appear in text fields as a span.
+       Use entry chips to represent a complex piece of information in a compact form.
+
+       Entry Chips should adhere to the following attributes:
+       chipIconEnabled - optional
+       closeIconEnabled - optional
+       checkable - optional
+       checkedIconEnabled - optional -->
+  <style name="Widget.MaterialComponents.Chip.Entry" parent="Base.Widget.MaterialComponents.Chip">
+    <item name="android:checkable">true</item>
+  </style>
+
+  <!-- Style for Chips that act as a check box.
+       Use filter chips containing tags or descriptive words to filter a collection.
+
+       Filter Chips should adhere to the following attributes:
+       chipIconEnabled - optional
+       closeIconEnabled - optional
+       checkable - always
+       checkedIconEnabled - optional -->
+  <style name="Widget.MaterialComponents.Chip.Filter" parent="Base.Widget.MaterialComponents.Chip">
+    <item name="android:checkable">true</item>
+
+    <item name="chipIconEnabled">false</item>
+    <item name="closeIconEnabled">false</item>
+
+    <item name="checkedIcon">@drawable/ic_mtrl_chip_checked_black</item>
+  </style>
+
+  <!-- Style for Chips that act as a radio button.
+       Use choice chips to help users make a single selection from a finite set of options.
+
+       Choice Chips should adhere to the following attributes:
+       chipIconEnabled - optional
+       closeIconEnabled - never
+       checkable - always
+       checkedIconEnabled - optional -->
+  <style name="Widget.MaterialComponents.Chip.Choice" parent="Base.Widget.MaterialComponents.Chip">
+    <item name="android:checkable">true</item>
+
+    <item name="chipIconEnabled">false</item>
+    <item name="checkedIconEnabled">false</item>
+    <item name="closeIconEnabled">false</item>
+
+    <item name="checkedIcon">@drawable/ic_mtrl_chip_checked_black</item>
+  </style>
+
+  <!-- Style for Chips that act as a button.
+       Use action chips to trigger an action that is contextual to primary content.
+
+       Action Chips should adhere to the following attributes:
+       chipIconEnabled - optional
+       closeIconEnabled - never
+       checkable - never
+       checkedIconEnabled - never -->
+  <style name="Widget.MaterialComponents.Chip.Action" parent="Base.Widget.MaterialComponents.Chip">
+    <item name="closeIconEnabled">false</item>
+  </style>
+
+  <style name="TextAppearance.MaterialComponents.Chip" parent="TextAppearance.AppCompat">
+    <item name="android:textColor">@color/mtrl_chip_text_color</item>
+    <item name="android:textSize">@dimen/mtrl_chip_text_size</item>
+  </style>
+
+</resources>

--- a/team-props/static-analysis.gradle
+++ b/team-props/static-analysis.gradle
@@ -1,3 +1,9 @@
+// Don't do static analysis for support (adopted) modules
+if (project.name.startsWith('support-')) {
+    // TODO remove this once we get rid of all support (adopted) modules
+    return
+}
+
 apply plugin: 'com.novoda.static-analysis'
 
 staticAnalysis {
@@ -29,7 +35,7 @@ staticAnalysis {
         excludeFilter teamPropsFile('static-analysis/findbugs-excludes.xml')
         includeVariants { variant -> excludeTestAndRelease(variant) }
     }
-    
+
     lintOptions {
         lintConfig teamPropsFile('static-analysis/lint-config.xml')
         warningsAsErrors true


### PR DESCRIPTION
## Problem

We need a better `Chip` implementation than the hack from #485

## Solution

We should be using the Design support library's `Chip` implementation — that is, the one from the [Material Components](https://github.com/material-components/material-components-android/tree/master/lib/java/android/support/design/chip) repo, which is packaged in `com.android.support:design-chip:28+`, but the issue is that we can't bump the target/SDK version to Android P/28 yet, so we need to temporarily import the module into our project.

It's added as a separate module called `support-chip`; modules whose name starts with `support-` are considered to be adopted code (we'll move the RenderThread stuff in a support module too!) and no static analysis is run against them since they're adopted code.

There is no actual code change to the app in this PR, which is against a "feature" branch and not against develop. Basically besides the changes in `static-analysis.gradle` there's nothing to review in this PR.

### Test(s) added

No

### Paired with

Nobody