### PR TITLE
Update Android Gradle Plugin 3.1.0-rc03 -> 3.1.0

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -57,7 +57,7 @@ ext {
     ]
 
     buildScript = [
-        android                   : 'com.android.tools.build:gradle:3.1.0-rc03',
+        android                   : 'com.android.tools.build:gradle:3.1.0',
         firebase                  : 'com.google.firebase:firebase-plugins:1.1.5',
         googleServices            : 'com.google.gms:google-services:3.2.0',
         gradleStaticAnalysisPlugin: 'com.novoda:gradle-static-analysis-plugin:0.5.2',


### PR DESCRIPTION
## Problem

AS 3.1.0 stable is out but we can't use it until we update the AGP to the stable 3.1.0 version

## Solution

Update the AGP to the stable 3.1.0 version

### Test(s) added

No

### Paired with

Nobody