### PR TITLE
Improve filters UI/MVP chips

### DIFF
--- a/app/src/main/java/net/squanchy/schedule/tracksfilter/ScheduleTracksFilter.kt
+++ b/app/src/main/java/net/squanchy/schedule/tracksfilter/ScheduleTracksFilter.kt
@@ -3,6 +3,7 @@ package net.squanchy.schedule.tracksfilter
 import android.content.Context
 import android.graphics.Color
 import android.os.Bundle
+import android.support.v4.content.ContextCompat
 import android.support.v7.app.AppCompatActivity
 import android.support.v7.recyclerview.extensions.ListAdapter
 import android.support.v7.util.DiffUtil
@@ -131,7 +132,7 @@ private class TrackViewHolder(val item: FilterChipView) : RecyclerView.ViewHolde
 
             color = when {
                 track.accentColor.isPresent -> Color.parseColor(track.accentColor.get())
-                else -> Color.MAGENTA // TODO handle default color for tracks (maybe gray-ish?)
+                else -> ContextCompat.getColor(context, R.color.chip_default_background_tint)
             }
 
             onCheckedChangeListener = { _, checked -> listener.invoke(track, checked) }

--- a/app/src/main/java/net/squanchy/schedule/tracksfilter/ScheduleTracksFilter.kt
+++ b/app/src/main/java/net/squanchy/schedule/tracksfilter/ScheduleTracksFilter.kt
@@ -1,17 +1,14 @@
 package net.squanchy.schedule.tracksfilter
 
 import android.content.Context
-import android.content.res.ColorStateList
 import android.graphics.Color
 import android.os.Bundle
-import android.support.v4.content.ContextCompat
 import android.support.v7.app.AppCompatActivity
 import android.support.v7.recyclerview.extensions.ListAdapter
 import android.support.v7.util.DiffUtil
 import android.support.v7.widget.RecyclerView
 import android.view.LayoutInflater
 import android.view.ViewGroup
-import android.widget.CheckBox
 import com.google.android.flexbox.FlexDirection
 import com.google.android.flexbox.FlexboxItemDecoration
 import com.google.android.flexbox.FlexboxLayoutManager
@@ -23,8 +20,8 @@ import io.reactivex.schedulers.Schedulers
 import kotlinx.android.synthetic.main.activity_track_filters.*
 import net.squanchy.R
 import net.squanchy.schedule.domain.view.Track
+import net.squanchy.schedule.tracksfilter.widget.FilterChipView
 import net.squanchy.service.repository.TracksRepository
-import net.squanchy.support.graphics.contrastingTextColor
 
 class ScheduleTracksFilterActivity : AppCompatActivity() {
 
@@ -101,7 +98,7 @@ private class TracksFilterAdapter(
     private val layoutInflater = LayoutInflater.from(context)
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): TrackViewHolder {
-        val view = layoutInflater.inflate(R.layout.track_filters_item, parent, false) as CheckBox
+        val view = layoutInflater.inflate(R.layout.track_filters_item, parent, false) as FilterChipView
         return TrackViewHolder(view)
     }
 
@@ -124,38 +121,21 @@ private class TracksFilterAdapter(
     }
 }
 
-private class TrackViewHolder(val item: CheckBox) : RecyclerView.ViewHolder(item) {
-
-    val darkTextColor = ContextCompat.getColor(item.context, R.color.primary_text)
-    val lightTextColor = ContextCompat.getColor(item.context, R.color.text_inverse)
-
-    companion object {
-        private const val ALPHA_CHECKED = 1.0F
-        private const val ALPHA_NOT_CHECKED = 0.7F
-    }
+private class TrackViewHolder(val item: FilterChipView) : RecyclerView.ViewHolder(item) {
 
     fun bind(checkableTrack: CheckableTrack, listener: OnTrackSelectedChangeListener) {
         val (track, selected) = checkableTrack
 
         item.apply {
             text = track.name
-            tag = track
+
+            color = when {
+                track.accentColor.isPresent -> Color.parseColor(track.accentColor.get())
+                else -> Color.MAGENTA // TODO handle default color for tracks (maybe gray-ish?)
+            }
+
+            onCheckedChangeListener = { _, checked -> listener.invoke(track, checked) }
             isChecked = selected
-
-            val trackColor = Color.parseColor(track.accentColor.get())
-            if (track.accentColor.isPresent) {
-                backgroundTintList = ColorStateList.valueOf(trackColor)
-            }
-
-            if (isChecked) {
-                setTextColor(trackColor.contrastingTextColor(darkTextColor, lightTextColor))
-                alpha = ALPHA_CHECKED
-            } else {
-                setTextColor(trackColor)
-                alpha = ALPHA_NOT_CHECKED
-            }
-
-            setOnClickListener { listener.invoke(track, isChecked) }
         }
     }
 }

--- a/app/src/main/java/net/squanchy/schedule/tracksfilter/widget/FilterChipView.kt
+++ b/app/src/main/java/net/squanchy/schedule/tracksfilter/widget/FilterChipView.kt
@@ -1,0 +1,222 @@
+package net.squanchy.schedule.tracksfilter.widget
+
+import android.content.Context
+import android.content.res.ColorStateList
+import android.graphics.Color
+import android.graphics.PorterDuff
+import android.graphics.drawable.Drawable
+import android.graphics.drawable.GradientDrawable
+import android.support.annotation.ColorInt
+import android.support.annotation.Px
+import android.support.v4.content.res.ResourcesCompat
+import android.util.AttributeSet
+import android.view.accessibility.AccessibilityEvent
+import android.view.accessibility.AccessibilityNodeInfo
+import android.widget.Checkable
+import android.widget.TextView
+import net.squanchy.R
+import net.squanchy.support.graphics.pickBestTextColorByContrast
+
+class FilterChipView @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet,
+    defStyle: Int = 0
+) : TextView(context, attrs, defStyle), Checkable {
+
+    private var isInitialized = false
+
+    private var isChecked: Boolean = false
+    private var isBroadcastingCheckedChange: Boolean = false
+
+    private var baseColor: Int
+    private var textDarkColor: Int
+    private var textLightColor: Int
+    @Px
+    private var strokeWidth: Int
+    private var backgroundDrawable: GradientDrawable
+    private var backgroundAlpha: CheckableValue<Float>
+
+    private lateinit var backgroundColor: CheckableValue<Int>
+    private lateinit var strokeColor: CheckableValue<Int>
+    private lateinit var textColor: CheckableValue<Int>
+
+    init {
+        val a = this.context.obtainStyledAttributes(attrs, R.styleable.FilterChipView, defStyle, R.style.Widget_Squanchy_FilterChipView)
+
+        textDarkColor = a.getColor(R.styleable.FilterChipView_checkedDarkTextColor, Color.RED)
+        textLightColor = a.getColor(R.styleable.FilterChipView_checkedLightTextColor, Color.MAGENTA)
+
+        baseColor = a.getColor(R.styleable.FilterChipView_color, Color.MAGENTA)
+        updateColors(baseColor)
+
+        strokeWidth = a.getDimensionPixelSize(R.styleable.FilterChipView_strokeWidth, 0)
+
+        backgroundDrawable = ResourcesCompat.getDrawable(resources, R.drawable.chip_background, context.theme) as GradientDrawable
+        super.setBackground(backgroundDrawable)
+
+        backgroundAlpha = CheckableValue(
+            checkedValue = a.getFloat(R.styleable.FilterChipView_checkedAlpha, DEFAULT_CHECKED_ALPHA),
+            uncheckedValue = a.getFloat(R.styleable.FilterChipView_uncheckedAlpha, DEFAULT_UNCHECKED_ALPHA)
+        )
+
+        a.recycle()
+
+        isClickable = true
+        isFocusable = true
+
+        super.setOnClickListener { toggle() }
+
+        isInitialized = true
+    }
+
+    var color: Int
+        @ColorInt
+        get() = baseColor
+        set(@ColorInt color) = updateColors(color)
+
+    private fun updateColors(@ColorInt baseColor: Int) {
+        this.baseColor = baseColor
+        backgroundColor = CheckableValue(checkedValue = baseColor, uncheckedValue = Color.TRANSPARENT)
+        strokeColor = CheckableValue(checkedValue = baseColor, uncheckedValue = baseColor)
+
+        val checkedTextColor = baseColor.pickBestTextColorByContrast(textLightColor, textDarkColor)
+        val uncheckedTextColor = Color.WHITE.pickBestTextColorByContrast(baseColor, textDarkColor)
+        textColor = CheckableValue(checkedValue = checkedTextColor, uncheckedValue = uncheckedTextColor)
+
+        invalidate()
+    }
+
+    override fun isChecked(): Boolean = isChecked
+
+    override fun toggle() {
+        setChecked(!isChecked)
+    }
+
+    override fun setChecked(checked: Boolean) {
+        if (checked == isChecked) return
+        isChecked = checked
+
+        updateBackgroundDrawable()
+        updateTextColor()
+        invalidate()
+
+        // Avoid infinite recursions if checked is set from a listener
+        if (isBroadcastingCheckedChange) {
+            return
+        }
+
+        isBroadcastingCheckedChange = true
+        onCheckedChangeListener?.invoke(this, checked)
+        isBroadcastingCheckedChange = false
+    }
+
+    private fun updateBackgroundDrawable() {
+        with(backgroundDrawable) {
+            setStroke(strokeWidth, strokeColor[isChecked])
+            color = ColorStateList.valueOf(backgroundColor[isChecked])
+            alpha = (backgroundAlpha[isChecked] * Companion.MAX_ALPHA_VALUE).toInt()
+        }
+
+        invalidateOutline()
+    }
+
+    private fun updateTextColor() {
+        super.setTextColor(textColor[isChecked])
+    }
+
+    var onCheckedChangeListener: ((FilterChipView, Boolean) -> Unit)? = null
+
+    override fun getAccessibilityClassName(): CharSequence {
+        return FilterChipView::class.java.name
+    }
+
+    override fun onInitializeAccessibilityNodeInfo(info: AccessibilityNodeInfo) {
+        super.onInitializeAccessibilityNodeInfo(info)
+        info.isCheckable = true
+        info.isChecked = isChecked
+    }
+
+    override fun onInitializeAccessibilityEvent(event: AccessibilityEvent) {
+        super.onInitializeAccessibilityEvent(event)
+        event.isChecked = isChecked
+    }
+
+    override fun setOnClickListener(l: OnClickListener?) {
+        throw UnsupportedOperationException("Can't set a custom click listener on FilterChipView, use onCheckedChangeListener instead")
+    }
+
+    override fun setBackgroundTintList(tint: ColorStateList?) {
+        when {
+            isInitialized -> UnsupportedOperationException("Can't interact with a FilterChipView's background directly")
+            else -> super.setBackgroundTintList(tint)
+        }
+    }
+
+    override fun setBackground(background: Drawable?) {
+        when {
+            isInitialized -> UnsupportedOperationException("Can't interact with a FilterChipView's background directly")
+            else -> super.setBackground(background)
+        }
+    }
+
+    override fun setBackgroundTintMode(tintMode: PorterDuff.Mode?) {
+        when {
+            isInitialized -> UnsupportedOperationException("Can't interact with a FilterChipView's background directly")
+            else -> super.setBackgroundTintMode(tintMode)
+        }
+    }
+
+    @Suppress("DEPRECATION") // We're just preventing others from messing with this, not really using it
+    override fun setBackgroundDrawable(background: Drawable?) {
+        when {
+            isInitialized -> UnsupportedOperationException("Can't interact with a FilterChipView's background directly")
+            else -> super.setBackgroundDrawable(background)
+        }
+    }
+
+    override fun setBackgroundResource(resid: Int) {
+        when {
+            isInitialized -> UnsupportedOperationException("Can't interact with a FilterChipView's background directly")
+            else -> super.setBackgroundResource(resid)
+        }
+    }
+
+    override fun setBackgroundColor(color: Int) {
+        when {
+            isInitialized -> UnsupportedOperationException("Can't interact with a FilterChipView's background directly")
+            else -> super.setBackgroundColor(color)
+        }
+    }
+
+    override fun getBackgroundTintList(): ColorStateList {
+        throw UnsupportedOperationException("Can't interact with a FilterChipView's background directly")
+    }
+
+    override fun setTextColor(color: Int) {
+        when {
+            isInitialized -> throw UnsupportedOperationException("Can't interact with a FilterChipView's text color directly")
+            else -> super.setTextColor(color)
+        }
+    }
+
+    override fun setTextColor(colors: ColorStateList?) {
+        when {
+            isInitialized -> throw UnsupportedOperationException("Can't interact with a FilterChipView's text color directly")
+            else -> super.setTextColor(colors)
+        }
+    }
+
+    companion object {
+        private const val MAX_ALPHA_VALUE: Int = 255
+        private const val DEFAULT_CHECKED_ALPHA: Float = 1.0F
+        private const val DEFAULT_UNCHECKED_ALPHA: Float = .7F
+    }
+}
+
+private data class CheckableValue<out T>(private val checkedValue: T, private val uncheckedValue: T) {
+
+    operator fun get(checked: Boolean) = when {
+        checked -> checkedValue
+        else -> uncheckedValue
+    }
+}

--- a/app/src/main/java/net/squanchy/schedule/tracksfilter/widget/FilterChipView.kt
+++ b/app/src/main/java/net/squanchy/schedule/tracksfilter/widget/FilterChipView.kt
@@ -8,6 +8,7 @@ import android.graphics.drawable.Drawable
 import android.graphics.drawable.GradientDrawable
 import android.support.annotation.ColorInt
 import android.support.annotation.Px
+import android.support.v4.content.ContextCompat
 import android.support.v4.content.res.ResourcesCompat
 import android.util.AttributeSet
 import android.view.accessibility.AccessibilityEvent
@@ -48,7 +49,7 @@ class FilterChipView @JvmOverloads constructor(
         textDarkColor = a.getColor(R.styleable.FilterChipView_checkedDarkTextColor, Color.RED)
         textLightColor = a.getColor(R.styleable.FilterChipView_checkedLightTextColor, Color.MAGENTA)
 
-        baseColor = a.getColor(R.styleable.FilterChipView_color, Color.MAGENTA)
+        baseColor = a.getColor(R.styleable.FilterChipView_color, ContextCompat.getColor(context, R.color.chip_default_background_tint))
         updateColors(baseColor)
 
         strokeWidth = a.getDimensionPixelSize(R.styleable.FilterChipView_strokeWidth, 0)

--- a/app/src/main/java/net/squanchy/schedule/tracksfilter/widget/FilterChipView.kt
+++ b/app/src/main/java/net/squanchy/schedule/tracksfilter/widget/FilterChipView.kt
@@ -33,6 +33,8 @@ class FilterChipView @JvmOverloads constructor(
     private var textLightColor: Int
     @Px
     private var strokeWidth: Int
+
+    // It sounds weird, but a <shape> with a stroke color inflates as a GradientDrawable
     private var backgroundDrawable: GradientDrawable
     private var backgroundAlpha: CheckableValue<Float>
 
@@ -146,63 +148,64 @@ class FilterChipView @JvmOverloads constructor(
     }
 
     override fun setBackgroundTintList(tint: ColorStateList?) {
-        when {
-            isInitialized -> UnsupportedOperationException("Can't interact with a FilterChipView's background directly")
-            else -> super.setBackgroundTintList(tint)
+        allowOnlyWhileInitializing("Can't interact with a FilterChipView's background directly") {
+            super.setBackgroundTintList(tint)
         }
     }
 
     override fun setBackground(background: Drawable?) {
-        when {
-            isInitialized -> UnsupportedOperationException("Can't interact with a FilterChipView's background directly")
-            else -> super.setBackground(background)
+        allowOnlyWhileInitializing("Can't interact with a FilterChipView's background directly") {
+            super.setBackground(background)
         }
     }
 
     override fun setBackgroundTintMode(tintMode: PorterDuff.Mode?) {
-        when {
-            isInitialized -> UnsupportedOperationException("Can't interact with a FilterChipView's background directly")
-            else -> super.setBackgroundTintMode(tintMode)
+        allowOnlyWhileInitializing("Can't interact with a FilterChipView's background directly") {
+            super.setBackgroundTintMode(tintMode)
         }
     }
 
-    @Suppress("DEPRECATION") // We're just preventing others from messing with this, not really using it
+    @Suppress("DEPRECATION", "OverridingDeprecatedMember") // We're just preventing others from messing with this, not really using it
     override fun setBackgroundDrawable(background: Drawable?) {
-        when {
-            isInitialized -> UnsupportedOperationException("Can't interact with a FilterChipView's background directly")
-            else -> super.setBackgroundDrawable(background)
+        allowOnlyWhileInitializing("Can't interact with a FilterChipView's background directly") {
+            super.setBackgroundDrawable(background)
         }
     }
 
     override fun setBackgroundResource(resid: Int) {
-        when {
-            isInitialized -> UnsupportedOperationException("Can't interact with a FilterChipView's background directly")
-            else -> super.setBackgroundResource(resid)
+        allowOnlyWhileInitializing("Can't interact with a FilterChipView's background directly") {
+            super.setBackgroundResource(resid)
         }
     }
 
     override fun setBackgroundColor(color: Int) {
-        when {
-            isInitialized -> UnsupportedOperationException("Can't interact with a FilterChipView's background directly")
-            else -> super.setBackgroundColor(color)
+        allowOnlyWhileInitializing("Can't interact with a FilterChipView's background directly") {
+            super.setBackgroundColor(color)
         }
     }
 
     override fun getBackgroundTintList(): ColorStateList {
-        throw UnsupportedOperationException("Can't interact with a FilterChipView's background directly")
+        return allowOnlyWhileInitializing("Can't obtain the background color of a FilterChipView, use the color property") {
+            return@allowOnlyWhileInitializing super.getBackgroundTintList()
+        }
     }
 
     override fun setTextColor(color: Int) {
-        when {
-            isInitialized -> throw UnsupportedOperationException("Can't interact with a FilterChipView's text color directly")
-            else -> super.setTextColor(color)
+        allowOnlyWhileInitializing("Can't interact with a FilterChipView's text color directly") {
+            super.setTextColor(color)
         }
     }
 
     override fun setTextColor(colors: ColorStateList?) {
+        allowOnlyWhileInitializing("Can't interact with a FilterChipView's text color directly") {
+            super.setTextColor(colors)
+        }
+    }
+
+    private inline fun <T> allowOnlyWhileInitializing(errorMessage: String, whileInitializing: () -> T): T {
         when {
-            isInitialized -> throw UnsupportedOperationException("Can't interact with a FilterChipView's text color directly")
-            else -> super.setTextColor(colors)
+            isInitialized -> throw UnsupportedOperationException(errorMessage)
+            else -> return whileInitializing.invoke()
         }
     }
 

--- a/app/src/main/java/net/squanchy/schedule/tracksfilter/widget/FilterChipView.kt
+++ b/app/src/main/java/net/squanchy/schedule/tracksfilter/widget/FilterChipView.kt
@@ -49,6 +49,7 @@ class FilterChipView @JvmOverloads constructor(
     init {
         val a = this.context.obtainStyledAttributes(attrs, R.styleable.FilterChipView, defStyle, R.style.Widget_Squanchy_FilterChipView)
 
+        // TODO use more appropriate defaults once finished dev'ing
         checkedTextColorDark = a.getColor(R.styleable.FilterChipView_checkedTextColorDark, Color.YELLOW)
         checkedTextColorLight = a.getColor(R.styleable.FilterChipView_checkedTextColorLight, Color.MAGENTA)
         uncheckedFallbackTextColor = a.getColor(R.styleable.FilterChipView_uncheckedFallbackTextColor, Color.GREEN)

--- a/app/src/main/java/net/squanchy/schedule/tracksfilter/widget/FilterChipView.kt
+++ b/app/src/main/java/net/squanchy/schedule/tracksfilter/widget/FilterChipView.kt
@@ -127,7 +127,7 @@ class FilterChipView @JvmOverloads constructor(
     }
 
     private fun updateBackgroundDrawable() {
-        with(backgroundDrawable) {
+        backgroundDrawable.apply {
             setStroke(strokeWidth, strokeColor[isChecked])
             color = ColorStateList.valueOf(backgroundColor[isChecked])
             alpha = (backgroundAlpha[isChecked] * Companion.MAX_ALPHA_VALUE).toInt()

--- a/app/src/main/java/net/squanchy/schedule/view/ScheduleDayPageView.kt
+++ b/app/src/main/java/net/squanchy/schedule/view/ScheduleDayPageView.kt
@@ -38,9 +38,21 @@ class ScheduleDayPageView @JvmOverloads constructor(
         diffResult.dispatchUpdatesTo(adapter)
     }
 
-    fun scrollToEvent(eventPosition: Int, animate: Boolean) =
-        if (animate) smoothScrollToPosition(eventPosition)
-        else scrollToPosition(eventPosition)
+    private var userHasScrolled: Boolean = false
+
+    override fun onScrolled(dx: Int, dy: Int) {
+        userHasScrolled = true
+        super.onScrolled(dx, dy)
+    }
+
+    fun autoscrollToEvent(eventPosition: Int, animate: Boolean) {
+        if (userHasScrolled) return       // TODO only do it if it's an actual autoscroll (i.e., not because user has tapped the tab)
+
+        when {
+            animate -> smoothScrollToPosition(eventPosition)
+            else -> scrollToPosition(eventPosition)
+        }
+    }
 
     private class EventsDiffCallback(
         private val oldEvents: List<Event>,

--- a/app/src/main/java/net/squanchy/schedule/view/ScheduleDayPageView.kt
+++ b/app/src/main/java/net/squanchy/schedule/view/ScheduleDayPageView.kt
@@ -46,7 +46,7 @@ class ScheduleDayPageView @JvmOverloads constructor(
     }
 
     fun autoscrollToEvent(eventPosition: Int, animate: Boolean) {
-        if (userHasScrolled) return       // TODO only do it if it's an actual autoscroll (i.e., not because user has tapped the tab)
+        if (userHasScrolled) return // TODO only do it if it's an actual autoscroll (i.e., not because user has tapped the tab)
 
         when {
             animate -> smoothScrollToPosition(eventPosition)

--- a/app/src/main/java/net/squanchy/schedule/view/ScheduleViewPagerAdapter.kt
+++ b/app/src/main/java/net/squanchy/schedule/view/ScheduleViewPagerAdapter.kt
@@ -36,9 +36,9 @@ class ScheduleViewPagerAdapter(private val context: Context) : ViewPagerAdapter<
     override fun bindView(view: ScheduleDayPageView, position: Int) {
         val events = pages[position].events
         val initialEvent = initialEventForPage[position]
-        triggerScrollForPage[position] = { view.scrollToEvent(events.indexOf(it), true) }
+        triggerScrollForPage[position] = { view.autoscrollToEvent(events.indexOf(it), true) }
         view.updateWith(events, listener)
-        initialEvent?.let { view.scrollToEvent(events.indexOf(it), false) }
+        initialEvent?.let { view.autoscrollToEvent(events.indexOf(it), false) }
     }
 
     override fun getPageTitle(position: Int): CharSequence? {

--- a/app/src/main/java/net/squanchy/support/graphics/Color.kt
+++ b/app/src/main/java/net/squanchy/support/graphics/Color.kt
@@ -1,29 +1,15 @@
 package net.squanchy.support.graphics
 
-import android.graphics.Color
 import android.support.annotation.ColorInt
-
-private const val MAX_COLOR_COMPONENT = 255.0
-private const val GAMMA_FACTOR = 2.2
-private const val MAX_LIGHTNESS_FOR_LIGHT_TEXT = .18
-private const val FACTOR_RED = 0.2126
-private const val FACTOR_GREEN = 0.7151
-private const val FACTOR_BLUE = 0.0721
+import android.support.v4.graphics.ColorUtils
 
 @ColorInt
-internal fun Int.contrastingTextColor(@ColorInt darkTextColor: Int, @ColorInt lightTextColor: Int): Int {
-    val r = Color.red(this)
-    val g = Color.green(this)
-    val b = Color.blue(this)
-    val lightness = FACTOR_RED * gamaCorrectColorComponent(r) +
-        FACTOR_GREEN * gamaCorrectColorComponent(g) +
-        FACTOR_BLUE * gamaCorrectColorComponent(b)
+internal fun Int.pickBestTextColorByContrast(@ColorInt firstTextColor: Int, @ColorInt secondTextColor: Int): Int {
+    val firstTextContrast = ColorUtils.calculateContrast(firstTextColor, this)
+    val secondTextContrast = ColorUtils.calculateContrast(secondTextColor, this)
 
-    return if (lightness > MAX_LIGHTNESS_FOR_LIGHT_TEXT) {
-        darkTextColor
-    } else {
-        lightTextColor
+    return when {
+        firstTextContrast > secondTextContrast -> firstTextColor
+        else -> secondTextColor
     }
 }
-
-private fun gamaCorrectColorComponent(r: Int) = Math.pow(r / MAX_COLOR_COMPONENT, GAMMA_FACTOR)

--- a/app/src/main/java/net/squanchy/support/graphics/Color.kt
+++ b/app/src/main/java/net/squanchy/support/graphics/Color.kt
@@ -1,7 +1,12 @@
 package net.squanchy.support.graphics
 
 import android.support.annotation.ColorInt
+import android.support.annotation.FloatRange
 import android.support.v4.graphics.ColorUtils
+import android.support.v4.graphics.ColorUtils.HSLToColor
+import android.support.v4.graphics.ColorUtils.calculateContrast
+import android.support.v4.graphics.ColorUtils.colorToHSL
+import android.support.v4.graphics.ColorUtils.compositeColors
 
 @ColorInt
 internal fun Int.pickBestTextColorByContrast(@ColorInt firstTextColor: Int, @ColorInt secondTextColor: Int): Int {
@@ -13,3 +18,47 @@ internal fun Int.pickBestTextColorByContrast(@ColorInt firstTextColor: Int, @Col
         else -> secondTextColor
     }
 }
+
+@ColorInt
+internal fun Int.darkenToEnsureTextContrasts(@ColorInt background: Int, @ColorInt fallbackTextColor: Int): Int {
+    var currentColor = this
+    var compositeColor = compositeColors(currentColor, background)
+    var contrastRatio = calculateContrast(compositeColor, background)
+
+    val hslColor: HSLColor = FloatArray(HSL_COMPONENTS)
+    colorToHSL(compositeColor, hslColor)
+    var numIterations = 0
+
+    while (numIterations <= CONTRAST_SEARCH_MAX_ITERATIONS && hslColor.lightness >= MIN_LIGHTNESS) {
+        if (contrastRatio >= MIN_CONTRAST_RATIO) {
+            return currentColor
+        }
+
+        val newLightness = Math.max(hslColor.lightness - LIGHTNESS_STEP_SIZE, MIN_LIGHTNESS)
+        hslColor.lightness = newLightness
+        currentColor = HSLToColor(hslColor)
+        compositeColor = compositeColors(currentColor, background)
+        contrastRatio = calculateContrast(compositeColor, background)
+
+        numIterations++
+    }
+    return fallbackTextColor
+}
+
+private const val HSL_COMPONENTS = 3
+
+private const val CONTRAST_SEARCH_MAX_ITERATIONS = 10F
+private const val LIGHTNESS_STEP_SIZE = .05F
+private const val MIN_CONTRAST_RATIO = 3.5F
+private const val MIN_LIGHTNESS = 0.0F
+private const val MAX_LIGHTNESS = 1.0F
+
+private typealias HSLColor = FloatArray
+private const val HSL_COMPONENT_LIGHTNESS = 2
+
+private var HSLColor.lightness
+    @FloatRange(from = MIN_LIGHTNESS.toDouble(), to = MAX_LIGHTNESS.toDouble())
+    get() = this[HSL_COMPONENT_LIGHTNESS]
+    set(@FloatRange(from = MIN_LIGHTNESS.toDouble(), to = MAX_LIGHTNESS.toDouble()) value) {
+        this[HSL_COMPONENT_LIGHTNESS] = value
+    }

--- a/app/src/main/res/drawable/chip_background.xml
+++ b/app/src/main/res/drawable/chip_background.xml
@@ -1,17 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
-<selector xmlns:android="http://schemas.android.com/apk/res/android">
-  <item android:state_checked="true">
-    <shape android:shape="rectangle">
-      <corners android:radius="@dimen/track_filters_item_corner_radius" />
-      <solid android:color="@color/white" />
-      <stroke android:color="@color/white" android:width="@dimen/track_filters_item_stroke_width" />
-    </shape>
-  </item>
-  <item android:state_checked="false">
-    <shape android:shape="rectangle">
-      <corners android:radius="@dimen/track_filters_item_corner_radius" />
-      <solid android:color="@color/transparent" />
-      <stroke android:color="@color/white" android:width="@dimen/track_filters_item_stroke_width" />
-    </shape>
-  </item>
-</selector>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+  android:shape="rectangle">
+  <!-- We set an enormous corner radius so the edges are always 100% rounded -->
+  <corners android:radius="10000dp" />
+  <solid android:color="@color/white" />
+  <stroke
+    android:color="@color/white"
+    android:width="@dimen/track_filters_item_stroke_width" />
+</shape>

--- a/app/src/main/res/layout/track_filters_item.xml
+++ b/app/src/main/res/layout/track_filters_item.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<CheckBox
+<net.squanchy.schedule.tracksfilter.widget.FilterChipView
   xmlns:android="http://schemas.android.com/apk/res/android"
   xmlns:tools="http://schemas.android.com/tools"
   style="@style/TrackFilters.Filters.Tracks.Item"

--- a/app/src/main/res/values/attrs_filter_chip_view.xml
+++ b/app/src/main/res/values/attrs_filter_chip_view.xml
@@ -5,8 +5,9 @@
     <attr name="strokeWidth" format="dimension" />
     <attr name="uncheckedStrokeWidth" format="dimension" />
 
-    <attr name="checkedLightTextColor" format="color" />
-    <attr name="checkedDarkTextColor" format="color" />
+    <attr name="checkedTextColorLight" format="color" />
+    <attr name="checkedTextColorDark" format="color" />
+    <attr name="uncheckedFallbackTextColor" format="color" />
 
     <attr name="checkedAlpha" format="float" />
     <attr name="uncheckedAlpha" format="float" />
@@ -15,8 +16,9 @@
   <style name="Widget.Squanchy.FilterChipView" parent="None">
     <item name="color">@color/chip_default_background_tint</item>
     <item name="strokeWidth">2dp</item>
-    <item name="checkedLightTextColor">@color/white</item>
-    <item name="checkedDarkTextColor">?android:textColorPrimary</item>
+    <item name="checkedTextColorLight">@color/white</item>
+    <item name="checkedTextColorDark">?android:textColorPrimary</item>
+    <item name="uncheckedFallbackTextColor">?android:textColorPrimary</item>
     <item name="checkedAlpha">1.0</item>
     <item name="uncheckedAlpha">0.7</item>
   </style>

--- a/app/src/main/res/values/attrs_filter_chip_view.xml
+++ b/app/src/main/res/values/attrs_filter_chip_view.xml
@@ -13,7 +13,7 @@
   </declare-styleable>
 
   <style name="Widget.Squanchy.FilterChipView" parent="None">
-    <item name="color">?colorAccent</item>
+    <item name="color">@color/chip_default_background_tint</item>
     <item name="strokeWidth">2dp</item>
     <item name="checkedLightTextColor">@color/white</item>
     <item name="checkedDarkTextColor">?android:textColorPrimary</item>
@@ -21,4 +21,5 @@
     <item name="uncheckedAlpha">0.7</item>
   </style>
 
+  <color name="chip_default_background_tint">#e0e0e0</color>
 </resources>

--- a/app/src/main/res/values/attrs_filter_chip_view.xml
+++ b/app/src/main/res/values/attrs_filter_chip_view.xml
@@ -1,0 +1,24 @@
+<resources>
+
+  <declare-styleable name="FilterChipView">
+    <attr name="color" format="color" />
+    <attr name="strokeWidth" format="dimension" />
+    <attr name="uncheckedStrokeWidth" format="dimension" />
+
+    <attr name="checkedLightTextColor" format="color" />
+    <attr name="checkedDarkTextColor" format="color" />
+
+    <attr name="checkedAlpha" format="float" />
+    <attr name="uncheckedAlpha" format="float" />
+  </declare-styleable>
+
+  <style name="Widget.Squanchy.FilterChipView" parent="None">
+    <item name="color">?colorAccent</item>
+    <item name="strokeWidth">2dp</item>
+    <item name="checkedLightTextColor">@color/white</item>
+    <item name="checkedDarkTextColor">?android:textColorPrimary</item>
+    <item name="checkedAlpha">1.0</item>
+    <item name="uncheckedAlpha">0.7</item>
+  </style>
+
+</resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -657,7 +657,7 @@
   </style>
 
   <style name="TrackFilters.Filters.Subtitle" parent="None">
-    <item name="android:text">@string/filter_tracks_title</item>
+    <item name="android:text">@string/filter_tracks_subtitle</item>
     <item name="android:textAppearance">@style/TextAppearance.Squanchy.TrackFilters.Filters.Subtitle</item>
   </style>
 
@@ -680,19 +680,17 @@
   </style>
 
   <style name="TrackFilters.Filters.Tracks.Item" parent="None">
-    <item name="android:background">@drawable/chip_background</item>
-    <item name="android:button">@null</item>
     <item name="android:gravity">center</item>
     <item name="android:paddingLeft">@dimen/track_filters_item_padding_horizontal</item>
     <item name="android:paddingTop">@dimen/track_filters_item_padding_vertical</item>
     <item name="android:paddingRight">@dimen/track_filters_item_padding_horizontal</item>
     <item name="android:paddingBottom">@dimen/track_filters_item_padding_vertical</item>
     <item name="android:textAppearance">@style/TextAppearance.Squanchy.TrackFilters.Filters.Tracks.Item</item>
+    <item name="fontFamily">@font/default_typeface_bold</item>
   </style>
 
   <style name="TextAppearance.Squanchy.TrackFilters.Filters.Tracks.Item" parent="None">
     <item name="android:textSize">12sp</item>
-    <item name="fontFamily">@font/default_typeface_bold</item>
   </style>
 
 </resources>


### PR DESCRIPTION
## Problem

Our existing chip views don't work well (they're just a mock), and the Material Components' `Chip` are too inflexible for what we want to do.

## Solution

Create our very own `FilterChipView`!
 * Based on `TextView`, because `CheckBox`es have issues with applying fonts
 * Implements `Checkable`
 * Should behave well with a11y too (copied from `CompoundButton` and `Checkbox`)
 * Follows the design specs, and also has a few nice things
 * Ensures proper contrast between the background (assumed white for now) and text

Next steps:
 * Animating between states (not MVP, but hopefully coming soon)
 * Animating filters dialog in/ou

This PR also has a bugfix for an extremely annoying issue introduced with the schedule autoscrolling — see #288 — where the events are autoscrolled regardless of user interaction, which means the list would just jump around. The whole code that manages autoscrolling is quite perfectible, but that's tracked in #495.

### Test(s) added

No.

### Screenshots

 All selected | Some selected
 ------ | -----
 ![image](https://user-images.githubusercontent.com/153802/38046707-443c2be8-32b8-11e8-827f-48ea28e06474.png) | ![image](https://user-images.githubusercontent.com/153802/38046728-5225a482-32b8-11e8-82a5-b2b8b6c523ec.png)

![filters](https://user-images.githubusercontent.com/153802/38046668-22a29b8e-32b8-11e8-948d-0d8db4ba6ee8.gif)

### Paired with

Nobody