### PR TITLE
Use list adapters where possible (part 1)

### DIFF
--- a/app/src/main/java/net/squanchy/schedule/tracksfilter/TracksFilterAdapter.kt
+++ b/app/src/main/java/net/squanchy/schedule/tracksfilter/TracksFilterAdapter.kt
@@ -15,7 +15,7 @@ import net.squanchy.schedule.tracksfilter.widget.FilterChipView
 internal class TracksFilterAdapter(
     context: Context,
     private val trackStateChangeListener: OnTrackSelectedChangeListener
-) : ListAdapter<CheckableTrack, TrackViewHolder>(DiffCallback()) {
+) : ListAdapter<CheckableTrack, TrackViewHolder>(DiffCallback) {
 
     init {
         setHasStableIds(true)
@@ -35,15 +35,15 @@ internal class TracksFilterAdapter(
     override fun getItemId(position: Int): Long {
         return getItem(position).track().numericId
     }
+}
 
-    class DiffCallback : DiffUtil.ItemCallback<CheckableTrack>() {
-        override fun areItemsTheSame(oldItem: CheckableTrack?, newItem: CheckableTrack?): Boolean {
-            return oldItem?.track()?.id == newItem?.track()?.id
-        }
+private object DiffCallback : DiffUtil.ItemCallback<CheckableTrack>() {
+    override fun areItemsTheSame(oldItem: CheckableTrack?, newItem: CheckableTrack?): Boolean {
+        return oldItem?.track()?.id == newItem?.track()?.id
+    }
 
-        override fun areContentsTheSame(oldItem: CheckableTrack?, newItem: CheckableTrack?): Boolean {
-            return oldItem == newItem
-        }
+    override fun areContentsTheSame(oldItem: CheckableTrack?, newItem: CheckableTrack?): Boolean {
+        return oldItem == newItem
     }
 }
 

--- a/app/src/main/java/net/squanchy/schedule/view/EventsAdapter.kt
+++ b/app/src/main/java/net/squanchy/schedule/view/EventsAdapter.kt
@@ -10,7 +10,7 @@ import net.squanchy.schedule.domain.view.Event
 
 internal class EventsAdapter(
     context: Context
-) : ListAdapter<Event, EventViewHolder>(DiffCallback()) {
+) : ListAdapter<Event, EventViewHolder>(DiffCallback) {
 
     init {
         setHasStableIds(true)
@@ -42,15 +42,15 @@ internal class EventsAdapter(
     override fun onBindViewHolder(holder: EventViewHolder, position: Int) {
         holder.updateWith(getItem(position), eventClickListener)
     }
+}
 
-    internal class DiffCallback : DiffUtil.ItemCallback<Event>() {
-        override fun areItemsTheSame(oldItem: Event?, newItem: Event?): Boolean {
-            return oldItem?.numericId == newItem?.numericId
-        }
+private object DiffCallback : DiffUtil.ItemCallback<Event>() {
+    override fun areItemsTheSame(oldItem: Event?, newItem: Event?): Boolean {
+        return oldItem?.numericId == newItem?.numericId
+    }
 
-        override fun areContentsTheSame(oldItem: Event?, newItem: Event?): Boolean {
-            return oldItem == newItem
-        }
+    override fun areContentsTheSame(oldItem: Event?, newItem: Event?): Boolean {
+        return oldItem == newItem
     }
 }
 

--- a/app/src/main/java/net/squanchy/schedule/view/EventsAdapter.kt
+++ b/app/src/main/java/net/squanchy/schedule/view/EventsAdapter.kt
@@ -1,38 +1,29 @@
 package net.squanchy.schedule.view
 
 import android.content.Context
-import android.support.v7.widget.RecyclerView
+import android.support.v7.recyclerview.extensions.ListAdapter
+import android.support.v7.util.DiffUtil
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import net.squanchy.R
 import net.squanchy.schedule.domain.view.Event
 
-internal class EventsAdapter(context: Context) : RecyclerView.Adapter<EventViewHolder>() {
-
-    enum class ItemViewType {
-        TYPE_TALK,
-        TYPE_OTHER
-    }
-
-    private val layoutInflater: LayoutInflater
-    private lateinit var listener: (Event) -> Unit
-    private var _events = emptyList<Event>()
-    val events get() = _events
+internal class EventsAdapter(
+    context: Context
+) : ListAdapter<Event, EventViewHolder>(DiffCallback()) {
 
     init {
         setHasStableIds(true)
-        layoutInflater = LayoutInflater.from(context)
     }
 
-    override fun getItemId(position: Int) = _events[position].numericId
+    private val layoutInflater: LayoutInflater = LayoutInflater.from(context)
 
-    fun updateWith(events: List<Event>, listener: (Event) -> Unit) {
-        this._events = events
-        this.listener = listener
-    }
+    lateinit var eventClickListener: OnEventClickListener
+
+    override fun getItemId(position: Int) = getItem(position).numericId
 
     override fun getItemViewType(position: Int): Int {
-        val itemType = _events[position].type
+        val itemType = getItem(position).type
         return when (itemType) {
             Event.Type.KEYNOTE, Event.Type.TALK, Event.Type.WORKSHOP -> ItemViewType.TYPE_TALK.ordinal
             Event.Type.COFFEE_BREAK, Event.Type.LUNCH, Event.Type.OTHER, Event.Type.REGISTRATION, Event.Type.SOCIAL -> ItemViewType.TYPE_OTHER.ordinal
@@ -49,8 +40,23 @@ internal class EventsAdapter(context: Context) : RecyclerView.Adapter<EventViewH
     }
 
     override fun onBindViewHolder(holder: EventViewHolder, position: Int) {
-        holder.updateWith(_events[position], listener)
+        holder.updateWith(getItem(position), eventClickListener)
     }
 
-    override fun getItemCount() = _events.size
+    internal class DiffCallback : DiffUtil.ItemCallback<Event>() {
+        override fun areItemsTheSame(oldItem: Event?, newItem: Event?): Boolean {
+            return oldItem?.numericId == newItem?.numericId
+        }
+
+        override fun areContentsTheSame(oldItem: Event?, newItem: Event?): Boolean {
+            return oldItem == newItem
+        }
+    }
 }
+
+private enum class ItemViewType {
+    TYPE_TALK,
+    TYPE_OTHER
+}
+
+typealias OnEventClickListener = (Event) -> Unit

--- a/app/src/main/java/net/squanchy/schedule/view/ScheduleDayPageView.kt
+++ b/app/src/main/java/net/squanchy/schedule/view/ScheduleDayPageView.kt
@@ -31,7 +31,8 @@ class ScheduleDayPageView @JvmOverloads constructor(
     }
 
     fun updateWith(newData: List<Event>, listener: (Event) -> Unit) {
-        setAdapterIfNone(adapter.apply { eventClickListener = listener })
+        adapter.eventClickListener = listener
+        setAdapterIfNone(adapter)
         adapter.submitList(newData)
     }
 

--- a/app/src/main/java/net/squanchy/schedule/view/ScheduleDayPageView.kt
+++ b/app/src/main/java/net/squanchy/schedule/view/ScheduleDayPageView.kt
@@ -1,7 +1,6 @@
 package net.squanchy.schedule.view
 
 import android.content.Context
-import android.support.v7.util.DiffUtil
 import android.support.v7.widget.LinearLayoutManager
 import android.support.v7.widget.LinearSmoothScroller
 import android.support.v7.widget.RecyclerView
@@ -9,6 +8,7 @@ import android.util.AttributeSet
 import net.squanchy.R
 import net.squanchy.schedule.domain.view.Event
 import net.squanchy.support.view.CardSpacingItemDecorator
+import net.squanchy.support.view.setAdapterIfNone
 
 class ScheduleDayPageView @JvmOverloads constructor(
     context: Context,
@@ -24,7 +24,6 @@ class ScheduleDayPageView @JvmOverloads constructor(
         val layoutManager = SnappingLinearLayoutManager(context)
         setLayoutManager(layoutManager)
         adapter = EventsAdapter(context)
-        setAdapter(adapter)
 
         val horizontalSpacing = resources.getDimensionPixelSize(R.dimen.card_horizontal_margin)
         val verticalSpacing = resources.getDimensionPixelSize(R.dimen.card_vertical_margin)
@@ -32,10 +31,8 @@ class ScheduleDayPageView @JvmOverloads constructor(
     }
 
     fun updateWith(newData: List<Event>, listener: (Event) -> Unit) {
-        val callback = EventsDiffCallback(adapter.events, newData)
-        val diffResult = DiffUtil.calculateDiff(callback, true) // TODO move off the UI thread
-        adapter.updateWith(newData, listener)
-        diffResult.dispatchUpdatesTo(adapter)
+        setAdapterIfNone(adapter.apply { eventClickListener = listener })
+        adapter.submitList(newData)
     }
 
     private var userHasScrolled: Boolean = false
@@ -52,20 +49,6 @@ class ScheduleDayPageView @JvmOverloads constructor(
             animate -> smoothScrollToPosition(eventPosition)
             else -> scrollToPosition(eventPosition)
         }
-    }
-
-    private class EventsDiffCallback(
-        private val oldEvents: List<Event>,
-        private val newEvents: List<Event>
-    ) : DiffUtil.Callback() {
-
-        override fun getOldListSize() = oldEvents.size
-
-        override fun getNewListSize() = newEvents.size
-
-        override fun areItemsTheSame(oldItemPosition: Int, newItemPosition: Int) = oldEvents[oldItemPosition].id == newEvents[newItemPosition].id
-
-        override fun areContentsTheSame(oldItemPosition: Int, newItemPosition: Int) = oldEvents[oldItemPosition] == newEvents[newItemPosition]
     }
 
     private class SnappingLinearLayoutManager(context: Context) : LinearLayoutManager(context) {

--- a/app/src/main/java/net/squanchy/schedule/view/ScheduleViewPagerAdapter.kt
+++ b/app/src/main/java/net/squanchy/schedule/view/ScheduleViewPagerAdapter.kt
@@ -10,13 +10,15 @@ import net.squanchy.schedule.domain.view.Event
 import net.squanchy.schedule.domain.view.SchedulePage
 import java.util.Locale
 
-class ScheduleViewPagerAdapter(private val context: Context) : ViewPagerAdapter<ScheduleDayPageView>() {
+class ScheduleViewPagerAdapter(context: Context) : ViewPagerAdapter<ScheduleDayPageView>() {
 
     private lateinit var listener: (Event) -> Unit
 
     private var pages = emptyList<SchedulePage>()
     private var initialEventForPage = emptyArray<Event?>()
     private var triggerScrollForPage = emptyArray<((Event) -> Unit)?>()
+
+    private val inflater = LayoutInflater.from(context)
 
     fun updateWith(pages: List<SchedulePage>, initialEventForPage: Array<Event?>, listener: (Event) -> Unit) {
         this.pages = pages
@@ -29,8 +31,7 @@ class ScheduleViewPagerAdapter(private val context: Context) : ViewPagerAdapter<
     override fun getCount() = pages.size
 
     override fun createView(container: ViewGroup, position: Int): ScheduleDayPageView {
-        return LayoutInflater.from(context)
-            .inflate(R.layout.view_page_schedule_day, container, false) as ScheduleDayPageView
+        return inflater.inflate(R.layout.view_page_schedule_day, container, false) as ScheduleDayPageView
     }
 
     override fun bindView(view: ScheduleDayPageView, position: Int) {
@@ -52,11 +53,7 @@ class ScheduleViewPagerAdapter(private val context: Context) : ViewPagerAdapter<
         triggerScrollForPage[page]?.invoke(event)
     }
 
-    override fun isViewFromObject(view: View, `object`: Any) = view === `object`
-
-    interface OnEventClickedListener {
-        fun onEventClicked(event: Event)
-    }
+    override fun isViewFromObject(view: View, anObject: Any) = view === anObject
 
     companion object {
         private const val TITLE_FORMAT_TEMPLATE = "EEE d"

--- a/app/src/main/java/net/squanchy/search/view/SearchRecyclerView.java
+++ b/app/src/main/java/net/squanchy/search/view/SearchRecyclerView.java
@@ -10,7 +10,7 @@ import android.util.AttributeSet;
 import android.view.View;
 
 import net.squanchy.R;
-import net.squanchy.schedule.view.ScheduleViewPagerAdapter;
+import net.squanchy.schedule.domain.view.Event;
 import net.squanchy.search.SearchResults;
 import net.squanchy.speaker.domain.view.Speaker;
 import net.squanchy.support.widget.CardLayout;
@@ -61,7 +61,9 @@ public class SearchRecyclerView extends RecyclerView {
         layoutManager.setSpanSizeLookup(spanSizeLookup);
     }
 
-    public interface OnSearchResultClickListener extends ScheduleViewPagerAdapter.OnEventClickedListener {
+    public interface OnSearchResultClickListener {
+
+        void onEventClicked(Event event);
 
         void onSpeakerClicked(Speaker speaker);
     }

--- a/app/src/main/java/net/squanchy/tweets/TweetsPageView.kt
+++ b/app/src/main/java/net/squanchy/tweets/TweetsPageView.kt
@@ -3,7 +3,7 @@ package net.squanchy.tweets
 import android.content.Context
 import android.support.design.widget.CoordinatorLayout
 import android.util.AttributeSet
-import android.view.View
+import androidx.view.isVisible
 import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.disposables.Disposable
 import kotlinx.android.synthetic.main.view_page_tweets.view.*
@@ -11,6 +11,7 @@ import net.squanchy.R
 import net.squanchy.home.Loadable
 import net.squanchy.navigation.Navigator
 import net.squanchy.support.unwrapToActivityContext
+import net.squanchy.support.view.setAdapterIfNone
 import net.squanchy.tweets.domain.TweetLinkInfo
 import net.squanchy.tweets.domain.view.TwitterScreenViewModel
 import net.squanchy.tweets.service.TwitterService
@@ -28,8 +29,7 @@ class TweetsPageView @JvmOverloads constructor(
     private val navigator: Navigator = component.navigator()
 
     private val tweetClickListener: ((TweetLinkInfo) -> Unit) = { navigator.toTweet(it) }
-
-    private val tweetsAdapter = TweetsAdapter(context)
+    private val tweetsAdapter = TweetsAdapter(context, tweetClickListener)
 
     private lateinit var subscription: Disposable
 
@@ -37,16 +37,20 @@ class TweetsPageView @JvmOverloads constructor(
         super.onFinishInflate()
 
         setupToolbar()
-
-        tweetFeed.adapter = tweetsAdapter
     }
 
     private fun setupToolbar() {
         toolbar.inflateMenu(R.menu.homepage)
         toolbar.setOnMenuItemClickListener { item ->
             when (item.itemId) {
-                R.id.action_search -> { navigator.toSearch(); true }
-                R.id.action_settings -> { navigator.toSettings(); true }
+                R.id.action_search -> {
+                    navigator.toSearch()
+                    true
+                }
+                R.id.action_settings -> {
+                    navigator.toSettings()
+                    true
+                }
                 else -> false
             }
         }
@@ -55,31 +59,33 @@ class TweetsPageView @JvmOverloads constructor(
     override fun startLoading() {
         subscription = twitterService.refresh()
             .observeOn(AndroidSchedulers.mainThread())
-            .subscribe(::onSuccess, ::onError)
+            .subscribe(::onTweetsFetched, ::onError)
     }
 
     override fun stopLoading() {
         subscription.dispose()
     }
 
-    private fun onSuccess(data: TwitterScreenViewModel) {
+    private fun onTweetsFetched(data: TwitterScreenViewModel) {
+        tweetFeed.setAdapterIfNone(tweetsAdapter)
+
         toolbar.title = data.hashtag
-        tweetsAdapter.updateWith(data.tweets, tweetClickListener)
-        onRefreshCompleted()
+        tweetsAdapter.submitList(data.tweets)
+        updateUi()
     }
 
     private fun onError(e: Throwable) {
         Timber.e(e, "Error refreshing the Twitter timeline")
-        onRefreshCompleted()
+        updateUi()
     }
 
-    private fun onRefreshCompleted() {
+    private fun updateUi() {
         if (tweetsAdapter.isEmpty) {
-            tweetEmptyView.visibility = View.VISIBLE
-            tweetFeed.visibility = View.GONE
+            tweetEmptyView.isVisible = true
+            tweetFeed.isVisible = false
         } else {
-            tweetEmptyView.visibility = View.GONE
-            tweetFeed.visibility = View.VISIBLE
+            tweetEmptyView.isVisible = false
+            tweetFeed.isVisible = true
         }
     }
 }

--- a/app/src/main/java/net/squanchy/tweets/view/TweetsAdapter.kt
+++ b/app/src/main/java/net/squanchy/tweets/view/TweetsAdapter.kt
@@ -12,7 +12,7 @@ import net.squanchy.tweets.domain.view.TweetViewModel
 class TweetsAdapter(
     context: Context,
     private val linkClickedListener: OnTweetLinkClicked
-) : ListAdapter<TweetViewModel, TweetViewHolder>(DiffCallback()) {
+) : ListAdapter<TweetViewModel, TweetViewHolder>(DiffCallback) {
 
     init {
         setHasStableIds(true)
@@ -35,15 +35,15 @@ class TweetsAdapter(
     override fun getItemId(position: Int): Long {
         return getItem(position).id
     }
+}
 
-    class DiffCallback : DiffUtil.ItemCallback<TweetViewModel>() {
-        override fun areItemsTheSame(oldItem: TweetViewModel?, newItem: TweetViewModel?): Boolean {
-            return oldItem?.id == newItem?.id
-        }
+private object DiffCallback : DiffUtil.ItemCallback<TweetViewModel>() {
+    override fun areItemsTheSame(oldItem: TweetViewModel?, newItem: TweetViewModel?): Boolean {
+        return oldItem?.id == newItem?.id
+    }
 
-        override fun areContentsTheSame(oldItem: TweetViewModel?, newItem: TweetViewModel?): Boolean {
-            return oldItem == newItem
-        }
+    override fun areContentsTheSame(oldItem: TweetViewModel?, newItem: TweetViewModel?): Boolean {
+        return oldItem == newItem
     }
 }
 

--- a/app/src/main/java/net/squanchy/tweets/view/TweetsAdapter.kt
+++ b/app/src/main/java/net/squanchy/tweets/view/TweetsAdapter.kt
@@ -1,36 +1,50 @@
 package net.squanchy.tweets.view
 
 import android.content.Context
-import android.support.v7.widget.RecyclerView
+import android.support.v7.recyclerview.extensions.ListAdapter
+import android.support.v7.util.DiffUtil
 import android.view.LayoutInflater
 import android.view.ViewGroup
-
 import net.squanchy.R
 import net.squanchy.tweets.domain.TweetLinkInfo
 import net.squanchy.tweets.domain.view.TweetViewModel
 
-class TweetsAdapter(private val context: Context) : RecyclerView.Adapter<TweetViewHolder>() {
+class TweetsAdapter(
+    context: Context,
+    private val linkClickedListener: OnTweetLinkClicked
+) : ListAdapter<TweetViewModel, TweetViewHolder>(DiffCallback()) {
 
-    private var tweets: List<TweetViewModel> = emptyList()
-    private lateinit var listener: (TweetLinkInfo) -> Unit
+    init {
+        setHasStableIds(true)
+    }
 
-    val isEmpty: Boolean
-        get() = tweets.isEmpty()
+    private val inflater = LayoutInflater.from(context)
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): TweetViewHolder {
-        val view = LayoutInflater.from(context).inflate(R.layout.item_tweet, parent, false)
+        val view = inflater.inflate(R.layout.item_tweet, parent, false)
         return TweetViewHolder(view)
     }
 
     override fun onBindViewHolder(holder: TweetViewHolder, position: Int) {
-        holder.updateWith(tweets[position], listener)
+        holder.updateWith(getItem(position), linkClickedListener)
     }
 
-    override fun getItemCount() = tweets.size
+    val isEmpty: Boolean
+        get() = itemCount == 0
 
-    fun updateWith(tweets: List<TweetViewModel>, listener: (TweetLinkInfo) -> Unit) {
-        this.tweets = tweets
-        this.listener = listener
-        notifyDataSetChanged()
+    override fun getItemId(position: Int): Long {
+        return getItem(position).id
+    }
+
+    class DiffCallback : DiffUtil.ItemCallback<TweetViewModel>() {
+        override fun areItemsTheSame(oldItem: TweetViewModel?, newItem: TweetViewModel?): Boolean {
+            return oldItem?.id == newItem?.id
+        }
+
+        override fun areContentsTheSame(oldItem: TweetViewModel?, newItem: TweetViewModel?): Boolean {
+            return oldItem == newItem
+        }
     }
 }
+
+typealias OnTweetLinkClicked = (TweetLinkInfo) -> Unit


### PR DESCRIPTION
## Problem

We should be using `ListAdapter`s wherever possible

## Solution

Switch to `ListAdapters` in the schedule and tweets. Favourites will be done in a separate PR as it will require considerably more work.

This PR closes #289.

### Test(s) added

No

### Paired with

Nobody