### PR TITLE
Use list adapters for favourites

### DIFF
--- a/app/src/main/java/net/squanchy/favorites/FavoritesComponent.kt
+++ b/app/src/main/java/net/squanchy/favorites/FavoritesComponent.kt
@@ -9,14 +9,12 @@ import net.squanchy.injection.ApplicationComponent
 import net.squanchy.injection.applicationComponent
 import net.squanchy.navigation.NavigationModule
 import net.squanchy.navigation.Navigator
-import net.squanchy.schedule.ScheduleModule
-import net.squanchy.schedule.ScheduleService
 
 @ActivityLifecycle
-@Component(modules = [ScheduleModule::class, NavigationModule::class], dependencies = [ApplicationComponent::class])
+@Component(modules = [FavoritesModule::class, NavigationModule::class], dependencies = [ApplicationComponent::class])
 internal interface FavoritesComponent {
 
-    fun scheduleService(): ScheduleService
+    fun favoritesService(): FavoritesService
 
     fun navigator(): Navigator
 
@@ -26,7 +24,7 @@ internal interface FavoritesComponent {
 internal fun favoritesComponent(activity: AppCompatActivity): FavoritesComponent {
     return DaggerFavoritesComponent.builder()
         .applicationComponent(activity.application.applicationComponent)
-        .scheduleModule(ScheduleModule())
+        .favoritesModule(FavoritesModule())
         .navigationModule(NavigationModule())
         .activityContextModule(ActivityContextModule(activity))
         .build()

--- a/app/src/main/java/net/squanchy/favorites/FavoritesModule.kt
+++ b/app/src/main/java/net/squanchy/favorites/FavoritesModule.kt
@@ -1,0 +1,17 @@
+package net.squanchy.favorites
+
+import dagger.Module
+import dagger.Provides
+import net.squanchy.schedule.ScheduleModule
+import net.squanchy.schedule.ScheduleService
+import net.squanchy.service.firebase.FirebaseAuthService
+
+@Module(includes = [ScheduleModule::class])
+class FavoritesModule {
+
+    @Provides
+    internal fun favoritesService(
+        authService: FirebaseAuthService,
+        scheduleService: ScheduleService
+    ): FavoritesService = FirestoreFavoritesService(authService, scheduleService)
+}

--- a/app/src/main/java/net/squanchy/favorites/FavoritesPageView.kt
+++ b/app/src/main/java/net/squanchy/favorites/FavoritesPageView.kt
@@ -65,9 +65,18 @@ class FavoritesPageView @JvmOverloads constructor(
 
     private fun onMenuItemClickListener(menuItem: MenuItem): Boolean {
         return when (menuItem.itemId) {
-            R.id.action_search -> { showSearch(); true }
-            R.id.action_settings -> { showSettings(); true }
-            R.id.action_filter -> { navigator.toScheduleFiltering(context); true }
+            R.id.action_search -> {
+                showSearch()
+                true
+            }
+            R.id.action_settings -> {
+                showSettings()
+                true
+            }
+            R.id.action_filter -> {
+                navigator.toScheduleFiltering(context)
+                true
+            }
             else -> false
         }
     }

--- a/app/src/main/java/net/squanchy/favorites/FavoritesPageView.kt
+++ b/app/src/main/java/net/squanchy/favorites/FavoritesPageView.kt
@@ -4,7 +4,7 @@ import android.content.Context
 import android.support.design.widget.CoordinatorLayout
 import android.util.AttributeSet
 import android.view.MenuItem
-import android.view.View
+import androidx.view.isVisible
 import io.reactivex.Observable
 import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.disposables.CompositeDisposable
@@ -13,12 +13,11 @@ import kotlinx.android.synthetic.main.view_page_favorites.view.*
 import net.squanchy.R
 import net.squanchy.analytics.Analytics
 import net.squanchy.analytics.ContentType
+import net.squanchy.favorites.view.FavoritesItem
 import net.squanchy.home.HomeActivity
 import net.squanchy.home.Loadable
 import net.squanchy.navigation.Navigator
-import net.squanchy.schedule.ScheduleService
 import net.squanchy.schedule.domain.view.Event
-import net.squanchy.schedule.domain.view.Schedule
 import net.squanchy.support.unwrapToActivityContext
 
 class FavoritesPageView @JvmOverloads constructor(
@@ -27,11 +26,19 @@ class FavoritesPageView @JvmOverloads constructor(
     defStyleAttr: Int = 0
 ) : CoordinatorLayout(context, attrs, defStyleAttr), Loadable {
 
-    private val favoritesComponent = favoritesComponent(unwrapToActivityContext(context))
-    private val scheduleService: ScheduleService = favoritesComponent.scheduleService()
-    private val navigator: Navigator = favoritesComponent.navigator()
-    private val analytics: Analytics = favoritesComponent.analytics()
+    private lateinit var favoritesService: FavoritesService
+    private lateinit var navigator: Navigator
+    private lateinit var analytics: Analytics
+
     private val disposable = CompositeDisposable()
+
+    init {
+        with(favoritesComponent(unwrapToActivityContext(context))) {
+            favoritesService = favoritesService()
+            navigator = navigator()
+            analytics = analytics()
+        }
+    }
 
     override fun onFinishInflate() {
         super.onFinishInflate()
@@ -52,9 +59,9 @@ class FavoritesPageView @JvmOverloads constructor(
     override fun startLoading() {
         disposable.add(
             Observable.combineLatest(
-                scheduleService.schedule(onlyFavorites = true),
-                scheduleService.currentUserIsSignedIn(),
-                BiFunction<Schedule, Boolean, LoadScheduleResult>(::LoadScheduleResult)
+                favoritesService.favorites(),
+                favoritesService.currentUserIsSignedIn(),
+                BiFunction<List<FavoritesItem>, Boolean, LoadResult>(::LoadResult)
             )
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(::handleLoadSchedule)
@@ -81,41 +88,38 @@ class FavoritesPageView @JvmOverloads constructor(
         }
     }
 
-    private fun handleLoadSchedule(result: LoadScheduleResult) {
+    private fun handleLoadSchedule(result: LoadResult) {
         when {
-            result.schedule.hasFavorites -> showSchedule(result.schedule)
+            result.favoriteItems.isNotEmpty() -> showFavorites(result.favoriteItems)
             result.signedIn -> promptToFavorite()
             else -> promptToSign()
         }
     }
 
-    private val Schedule.hasFavorites
-        get() = !isEmpty
-
-    private fun showSchedule(schedule: Schedule) {
-        favoritesListView.updateWith(schedule, ::showEventDetails)
-        favoritesListView.visibility = View.VISIBLE
-        emptyViewSignedIn.visibility = View.GONE
-        emptyViewSignedOut.visibility = View.GONE
+    private fun showFavorites(favorites: List<FavoritesItem>) {
+        favoritesListView.updateWith(favorites, ::navigateToEventDetails)
+        favoritesListView.isVisible = true
+        emptyViewSignedIn.isVisible = false
+        emptyViewSignedOut.isVisible = false
     }
 
-    private fun showEventDetails(event: Event) {
+    private fun navigateToEventDetails(event: Event) {
         analytics.trackItemSelected(ContentType.FAVORITES_ITEM, event.id)
         navigator.toEventDetails(event.id)
     }
 
     private fun promptToSign() {
-        emptyViewSignedOut.visibility = View.VISIBLE
-        favoritesListView.visibility = View.GONE
-        progressBar.visibility = View.GONE
-        emptyViewSignedIn.visibility = View.GONE
+        emptyViewSignedOut.isVisible = true
+        favoritesListView.isVisible = false
+        progressBar.isVisible = false
+        emptyViewSignedIn.isVisible = false
     }
 
     private fun promptToFavorite() {
-        emptyViewSignedIn.visibility = View.VISIBLE
-        favoritesListView.visibility = View.GONE
-        progressBar.visibility = View.GONE
-        emptyViewSignedOut.visibility = View.GONE
+        emptyViewSignedIn.isVisible = true
+        favoritesListView.isVisible = false
+        progressBar.isVisible = false
+        emptyViewSignedOut.isVisible = false
     }
 
     private fun showSignIn() {
@@ -130,5 +134,5 @@ class FavoritesPageView @JvmOverloads constructor(
 
     private fun showSettings() = navigator.toSettings()
 
-    private data class LoadScheduleResult(val schedule: Schedule, val signedIn: Boolean)
+    private data class LoadResult(val favoriteItems: List<FavoritesItem>, val signedIn: Boolean)
 }

--- a/app/src/main/java/net/squanchy/favorites/FavoritesService.kt
+++ b/app/src/main/java/net/squanchy/favorites/FavoritesService.kt
@@ -1,14 +1,14 @@
 package net.squanchy.favorites
 
 import io.reactivex.Observable
-import net.squanchy.favorites.view.FavoriteListItem
+import net.squanchy.favorites.view.FavoritesItem
 import net.squanchy.schedule.ScheduleService
 import net.squanchy.schedule.domain.view.Event
 import net.squanchy.service.firebase.FirebaseAuthService
 
 interface FavoritesService {
 
-    fun favorites(): Observable<List<FavoriteListItem>>
+    fun favorites(): Observable<List<FavoritesItem>>
 
     fun currentUserIsSignedIn(): Observable<Boolean>
 }
@@ -18,13 +18,13 @@ internal class FirestoreFavoritesService(
     private val scheduleService: ScheduleService
 ) : FavoritesService {
 
-    override fun favorites(): Observable<List<FavoriteListItem>> {
+    override fun favorites(): Observable<List<FavoritesItem>> {
         return scheduleService.schedule(onlyFavorites = true)
             .map { schedule -> schedule.pages }
             .flatMap { pages ->
                 val flattenedItems = pages.map { page ->
                     val eventsAsFavoriteItems = page.events.map { it.toFavoriteItem() }
-                    listOf(FavoriteListItem.Header(page.date)) + eventsAsFavoriteItems
+                    listOf(FavoritesItem.Header(page.date)) + eventsAsFavoriteItems
                 }.flatten()
                 return@flatMap Observable.just(flattenedItems)
             }
@@ -36,5 +36,5 @@ internal class FirestoreFavoritesService(
     }
 }
 
-private fun Event.toFavoriteItem(): FavoriteListItem.Favorite =
-    FavoriteListItem.Favorite(this)
+private fun Event.toFavoriteItem(): FavoritesItem.Favorite =
+    FavoritesItem.Favorite(this)

--- a/app/src/main/java/net/squanchy/favorites/FavoritesService.kt
+++ b/app/src/main/java/net/squanchy/favorites/FavoritesService.kt
@@ -1,0 +1,40 @@
+package net.squanchy.favorites
+
+import io.reactivex.Observable
+import net.squanchy.favorites.view.FavoriteListItem
+import net.squanchy.schedule.ScheduleService
+import net.squanchy.schedule.domain.view.Event
+import net.squanchy.service.firebase.FirebaseAuthService
+
+interface FavoritesService {
+
+    fun favorites(): Observable<List<FavoriteListItem>>
+
+    fun currentUserIsSignedIn(): Observable<Boolean>
+}
+
+internal class FirestoreFavoritesService(
+    private val authService: FirebaseAuthService,
+    private val scheduleService: ScheduleService
+) : FavoritesService {
+
+    override fun favorites(): Observable<List<FavoriteListItem>> {
+        return scheduleService.schedule(onlyFavorites = true)
+            .map { schedule -> schedule.pages }
+            .flatMap { pages ->
+                val flattenedItems = pages.map { page ->
+                    val eventsAsFavoriteItems = page.events.map { it.toFavoriteItem() }
+                    listOf(FavoriteListItem.Header(page.date)) + eventsAsFavoriteItems
+                }.flatten()
+                return@flatMap Observable.just(flattenedItems)
+            }
+    }
+
+    override fun currentUserIsSignedIn(): Observable<Boolean> {
+        return authService.currentUser()
+            .map { optionalUser -> optionalUser.map { user -> !user.isAnonymous }.or(false) }
+    }
+}
+
+private fun Event.toFavoriteItem(): FavoriteListItem.Favorite =
+    FavoriteListItem.Favorite(this)

--- a/app/src/main/java/net/squanchy/favorites/FavoritesService.kt
+++ b/app/src/main/java/net/squanchy/favorites/FavoritesService.kt
@@ -24,8 +24,14 @@ internal class FirestoreFavoritesService(
             .flatMap { pages ->
                 val flattenedItems = pages.map { page ->
                     val eventsAsFavoriteItems = page.events.map { it.toFavoriteItem() }
-                    listOf(FavoritesItem.Header(page.date)) + eventsAsFavoriteItems
+
+                    if (eventsAsFavoriteItems.isNotEmpty()) {
+                        return@map listOf(FavoritesItem.Header(page.date)) + eventsAsFavoriteItems
+                    } else {
+                        return@map emptyList<FavoritesItem>()
+                    }
                 }.flatten()
+
                 return@flatMap Observable.just(flattenedItems)
             }
     }
@@ -34,7 +40,6 @@ internal class FirestoreFavoritesService(
         return authService.currentUser()
             .map { optionalUser -> optionalUser.map { user -> !user.isAnonymous }.or(false) }
     }
-}
 
-private fun Event.toFavoriteItem(): FavoritesItem.Favorite =
-    FavoritesItem.Favorite(this)
+    private fun Event.toFavoriteItem(): FavoritesItem.Favorite = FavoritesItem.Favorite(this)
+}

--- a/app/src/main/java/net/squanchy/favorites/view/FavoriteListItem.kt
+++ b/app/src/main/java/net/squanchy/favorites/view/FavoriteListItem.kt
@@ -1,0 +1,34 @@
+package net.squanchy.favorites.view
+
+import net.squanchy.schedule.domain.view.Event
+import org.joda.time.LocalDate
+
+sealed class FavoriteListItem {
+
+    abstract val id: Long
+
+    abstract val type: Type
+
+    data class Header(val date: LocalDate) : FavoriteListItem() {
+
+        override val id: Long
+            get() = date.toDateTimeAtCurrentTime().millis // We're relatively sure this won't clash with event IDs
+
+        override val type: Type
+            get() = Type.HEADER
+    }
+
+    data class Favorite(val event: Event) : FavoriteListItem() {
+
+        override val id: Long
+            get() = event.numericId
+
+        override val type: Type
+            get() = Type.FAVOURITE
+    }
+
+    enum class Type {
+        HEADER,
+        FAVOURITE
+    }
+}

--- a/app/src/main/java/net/squanchy/favorites/view/FavoritesAdapter.kt
+++ b/app/src/main/java/net/squanchy/favorites/view/FavoritesAdapter.kt
@@ -1,136 +1,71 @@
 package net.squanchy.favorites.view
 
 import android.content.Context
-import android.support.v7.widget.RecyclerView
+import android.support.v7.recyclerview.extensions.ListAdapter
+import android.support.v7.util.DiffUtil
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import net.squanchy.R
 import net.squanchy.schedule.domain.view.Event
-import net.squanchy.schedule.domain.view.Schedule
-import net.squanchy.schedule.domain.view.SchedulePage
-import net.squanchy.schedule.view.EventItemView
-import net.squanchy.schedule.view.EventViewHolder
-import net.squanchy.search.view.HeaderViewHolder
-import org.joda.time.DateTimeZone
-import org.joda.time.LocalDate
 
-internal class FavoritesAdapter(context: Context) : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
+internal class FavoritesAdapter(
+    context: Context
+) : ListAdapter<FavoritesItem, FavoritesViewHolder<*>>(DiffCallback) {
 
     companion object {
         private const val VIEW_TYPE_TALK: Int = 1
         private const val VIEW_TYPE_HEADER: Int = 2
     }
 
+    lateinit var favoriteClickListener: OnFavoriteClickListener
+
     private val layoutInflater = LayoutInflater.from(context)
-
-    private var schedule = Schedule(emptyList(), DateTimeZone.UTC)
-
-    private var listener: ((Event) -> Unit)? = null
 
     init {
         setHasStableIds(true)
     }
 
-    override fun getItemId(position: Int): Long = produceData(
-        pages = schedule.pages,
-        absolutePosition = position,
-        headerProducer = { schedulePage -> (-schedulePage.dayId.hashCode()).toLong() },
-        rowProducer = { schedulePage, positionInPage -> schedulePage.events[positionInPage].numericId }
-    )
-
-    fun updateWith(schedule: Schedule, listener: (Event) -> Unit) {
-        this.schedule = schedule
-        this.listener = listener
-        notifyDataSetChanged()
+    override fun getItemId(position: Int): Long {
+        return getItem(position).id
     }
 
-    override fun getItemViewType(position: Int) = produceData(
-        pages = schedule.pages,
-        absolutePosition = position,
-        headerProducer = { _ -> VIEW_TYPE_HEADER },
-        rowProducer = { _, _ -> VIEW_TYPE_TALK }
-    )
+    override fun getItemViewType(position: Int): Int {
+        return when (getItem(position).type) {
+            FavoritesItem.Type.HEADER -> VIEW_TYPE_HEADER
+            FavoritesItem.Type.FAVOURITE -> VIEW_TYPE_TALK
+        }
+    }
 
-    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecyclerView.ViewHolder {
-        return when (viewType) {
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): FavoritesViewHolder<*> {
+        val itemView = when (viewType) {
             VIEW_TYPE_TALK -> {
-                val itemView = layoutInflater.inflate(R.layout.item_schedule_event_talk, parent, false) as EventItemView
-                EventViewHolder(itemView)
+                layoutInflater.inflate(R.layout.item_schedule_event_talk, parent, false)
             }
             VIEW_TYPE_HEADER -> {
-                HeaderViewHolder(layoutInflater.inflate(R.layout.item_search_header, parent, false))
+                layoutInflater.inflate(R.layout.item_search_header, parent, false)
             }
             else -> throw IllegalArgumentException("View type not supported: $viewType")
         }
+
+        return favoriteItemViewHolderFor(itemView)
     }
 
-    override fun onBindViewHolder(holder: RecyclerView.ViewHolder, position: Int) {
-        if (holder is EventViewHolder) {
-            val event = produceData(
-                pages = schedule.pages,
-                absolutePosition = position,
-                headerProducer = { throw IndexOutOfBoundsException() },
-                rowProducer = { schedulePage, positionInPage -> schedulePage.events[positionInPage] }
-            )
-            if (listener != null) {
-                holder.updateWith(event, listener!!)
-            }
-        } else if (holder is HeaderViewHolder) {
-            val date = produceData(
-                pages = schedule.pages,
-                absolutePosition = position,
-                headerProducer = { page -> page.date },
-                rowProducer = { _, _ -> throw IndexOutOfBoundsException() }
-            )
-            holder.updateWith(formatHeader(date))
+    override fun onBindViewHolder(holder: FavoritesViewHolder<*>, position: Int) {
+        when (holder) {
+            is EventViewHolder -> holder.updateWith((getItem(position) as FavoritesItem.Favorite).event, favoriteClickListener)
+            is HeaderViewHolder -> holder.updateWith((getItem(position) as FavoritesItem.Header).date)
         }
-    }
-
-    private fun formatHeader(date: LocalDate): CharSequence = date.toString("EEEE d")
-
-    override fun getItemCount(): Int = schedule.pages.fold(0) { count, page ->
-        if (page.events.isNotEmpty()) {
-            count + page.events.size + 1
-        } else {
-            count
-        }
-    }
-
-    @SuppressWarnings("LongParameterList")
-    private fun <T> produceData(
-        pages: List<SchedulePage>,
-        pageIndex: Int = 0,
-        absolutePosition: ItemPosition,
-        headerProducer: (SchedulePage) -> T,
-        rowProducer: (SchedulePage, Int) -> T
-    ): T {
-        if (pageIndex >= pages.size) {
-            throw IndexOutOfBoundsException()
-        }
-
-        val schedulePage = pages[pageIndex]
-        val pageEventsCount = schedulePage.events.size
-        val nextPageIndex = pageIndex + 1
-        var firstPositionInNextPage: ItemPosition = absolutePosition
-
-        if (pageEventsCount != 0) {
-            if (absolutePosition.isHeader()) {
-                return headerProducer(schedulePage)
-            }
-
-            val adjustedPosition = absolutePosition - 1
-            if (adjustedPosition.isRowWithin(pageEventsCount)) {
-                return rowProducer(schedulePage, adjustedPosition)
-            }
-
-            firstPositionInNextPage = adjustedPosition - pageEventsCount
-        }
-        return produceData(pages, nextPageIndex, firstPositionInNextPage, headerProducer, rowProducer)
     }
 }
 
-private typealias ItemPosition = Int
+private object DiffCallback : DiffUtil.ItemCallback<FavoritesItem>() {
+    override fun areItemsTheSame(oldItem: FavoritesItem?, newItem: FavoritesItem?): Boolean {
+        return oldItem?.id == newItem?.id
+    }
 
-private fun ItemPosition.isHeader() = this == 0
+    override fun areContentsTheSame(oldItem: FavoritesItem?, newItem: FavoritesItem?): Boolean {
+        return oldItem == newItem
+    }
+}
 
-private fun ItemPosition.isRowWithin(eventsCount: Int) = this < eventsCount
+typealias OnFavoriteClickListener = (Event) -> Unit

--- a/app/src/main/java/net/squanchy/favorites/view/FavoritesAdapter.kt
+++ b/app/src/main/java/net/squanchy/favorites/view/FavoritesAdapter.kt
@@ -25,9 +25,7 @@ internal class FavoritesAdapter(
         setHasStableIds(true)
     }
 
-    override fun getItemId(position: Int): Long {
-        return getItem(position).id
-    }
+    override fun getItemId(position: Int) = getItem(position).id
 
     override fun getItemViewType(position: Int): Int {
         return when (getItem(position).type) {

--- a/app/src/main/java/net/squanchy/favorites/view/FavoritesItem.kt
+++ b/app/src/main/java/net/squanchy/favorites/view/FavoritesItem.kt
@@ -11,20 +11,16 @@ sealed class FavoritesItem {
 
     data class Header(val date: LocalDate) : FavoritesItem() {
 
-        override val id: Long
-            get() = date.toDateTimeAtCurrentTime().millis // We're relatively sure this won't clash with event IDs
+        override val id = date.toDateTimeAtCurrentTime().millis // We're relatively sure this won't clash with event IDs
 
-        override val type: Type
-            get() = Type.HEADER
+        override val type = Type.HEADER
     }
 
     data class Favorite(val event: Event) : FavoritesItem() {
 
-        override val id: Long
-            get() = event.numericId
+        override val id = event.numericId
 
-        override val type: Type
-            get() = Type.FAVOURITE
+        override val type = Type.FAVOURITE
     }
 
     enum class Type {

--- a/app/src/main/java/net/squanchy/favorites/view/FavoritesItem.kt
+++ b/app/src/main/java/net/squanchy/favorites/view/FavoritesItem.kt
@@ -3,13 +3,13 @@ package net.squanchy.favorites.view
 import net.squanchy.schedule.domain.view.Event
 import org.joda.time.LocalDate
 
-sealed class FavoriteListItem {
+sealed class FavoritesItem {
 
     abstract val id: Long
 
     abstract val type: Type
 
-    data class Header(val date: LocalDate) : FavoriteListItem() {
+    data class Header(val date: LocalDate) : FavoritesItem() {
 
         override val id: Long
             get() = date.toDateTimeAtCurrentTime().millis // We're relatively sure this won't clash with event IDs
@@ -18,7 +18,7 @@ sealed class FavoriteListItem {
             get() = Type.HEADER
     }
 
-    data class Favorite(val event: Event) : FavoriteListItem() {
+    data class Favorite(val event: Event) : FavoritesItem() {
 
         override val id: Long
             get() = event.numericId

--- a/app/src/main/java/net/squanchy/favorites/view/FavoritesListView.kt
+++ b/app/src/main/java/net/squanchy/favorites/view/FavoritesListView.kt
@@ -5,9 +5,8 @@ import android.support.v7.widget.LinearLayoutManager
 import android.support.v7.widget.RecyclerView
 import android.util.AttributeSet
 import net.squanchy.R
-import net.squanchy.schedule.domain.view.Event
-import net.squanchy.schedule.domain.view.Schedule
 import net.squanchy.support.view.CardSpacingItemDecorator
+import net.squanchy.support.view.setAdapterIfNone
 
 internal class FavoritesListView @JvmOverloads constructor(
     context: Context,
@@ -23,14 +22,15 @@ internal class FavoritesListView @JvmOverloads constructor(
         val layoutManager = LinearLayoutManager(context)
         setLayoutManager(layoutManager)
 
-        setAdapter(adapter)
-
         val horizontalSpacing = getResources().getDimensionPixelSize(R.dimen.card_horizontal_margin)
         val verticalSpacing = getResources().getDimensionPixelSize(R.dimen.card_vertical_margin)
         addItemDecoration(CardSpacingItemDecorator(horizontalSpacing, verticalSpacing))
     }
 
-    fun updateWith(newData: Schedule, listener: (Event) -> Unit) {
-        adapter.updateWith(newData, listener)
+    fun updateWith(newData: List<FavoritesItem>, listener: OnFavoriteClickListener) {
+        adapter.favoriteClickListener = listener
+        setAdapterIfNone(adapter)
+
+        adapter.submitList(newData)
     }
 }

--- a/app/src/main/java/net/squanchy/favorites/view/FavoritesViewHolders.kt
+++ b/app/src/main/java/net/squanchy/favorites/view/FavoritesViewHolders.kt
@@ -1,0 +1,31 @@
+package net.squanchy.favorites.view
+
+import android.support.v7.widget.RecyclerView
+import android.view.View
+import android.widget.TextView
+import net.squanchy.schedule.domain.view.Event
+import net.squanchy.schedule.view.EventItemView
+import org.joda.time.LocalDate
+
+fun favoriteItemViewHolderFor(itemView: View) = when (itemView) {
+    is EventItemView -> EventViewHolder(itemView)
+    is TextView -> HeaderViewHolder(itemView)
+    else -> throw UnsupportedOperationException("View of type ${itemView.javaClass.name} is not supported!")
+}
+
+sealed class FavoritesViewHolder<T : View>(itemView: T) : RecyclerView.ViewHolder(itemView)
+
+class EventViewHolder(itemView: EventItemView) : FavoritesViewHolder<EventItemView>(itemView) {
+
+    fun updateWith(event: Event, listener: (Event) -> Unit) {
+        (itemView as EventItemView).updateWith(event)
+        itemView.setOnClickListener { listener(event) }
+    }
+}
+
+class HeaderViewHolder(itemView: TextView) : FavoritesViewHolder<TextView>(itemView) {
+
+    fun updateWith(date: LocalDate) {
+        (itemView as TextView).text = date.toString("EEEE d")
+    }
+}

--- a/app/src/main/java/net/squanchy/schedule/ScheduleService.kt
+++ b/app/src/main/java/net/squanchy/schedule/ScheduleService.kt
@@ -22,8 +22,6 @@ import org.joda.time.LocalDate
 interface ScheduleService {
 
     fun schedule(onlyFavorites: Boolean = false): Observable<Schedule>
-
-    fun currentUserIsSignedIn(): Observable<Boolean>
 }
 
 class FirestoreScheduleService(
@@ -103,9 +101,4 @@ class FirestoreScheduleService(
     private fun FirestoreSchedulePage.toSortedDomainSchedulePage(checksum: Checksum, timeZone: DateTimeZone): SchedulePage =
         SchedulePage(day.id, LocalDate(day.date), events.map { it.toEvent(checksum, timeZone) }
             .sortedBy(Event::startTime))
-
-    override fun currentUserIsSignedIn(): Observable<Boolean> {
-        return authService.currentUser()
-            .map { optionalUser -> optionalUser.map { user -> !user.isAnonymous }.or(false) }
-    }
 }

--- a/app/src/main/java/net/squanchy/schedule/view/EventsAdapter.kt
+++ b/app/src/main/java/net/squanchy/schedule/view/EventsAdapter.kt
@@ -6,6 +6,7 @@ import android.support.v7.util.DiffUtil
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import net.squanchy.R
+import net.squanchy.favorites.view.EventViewHolder
 import net.squanchy.schedule.domain.view.Event
 
 internal class EventsAdapter(

--- a/app/src/main/java/net/squanchy/search/view/SearchAdapter.java
+++ b/app/src/main/java/net/squanchy/search/view/SearchAdapter.java
@@ -15,9 +15,9 @@ import java.lang.annotation.RetentionPolicy;
 import java.util.Collections;
 
 import net.squanchy.R;
+import net.squanchy.favorites.view.EventViewHolder;
 import net.squanchy.imageloader.ImageLoader;
 import net.squanchy.schedule.view.EventItemView;
-import net.squanchy.schedule.view.EventViewHolder;
 import net.squanchy.search.SearchResults;
 
 import static net.squanchy.imageloader.ImageLoaderComponentKt.imageLoaderComponent;

--- a/app/src/test/java/net/squanchy/favorites/FirestoreFavoritesServiceTest.kt
+++ b/app/src/test/java/net/squanchy/favorites/FirestoreFavoritesServiceTest.kt
@@ -1,0 +1,95 @@
+package net.squanchy.favorites
+
+import com.google.firebase.auth.FirebaseUser
+import io.reactivex.Observable
+import net.squanchy.schedule.ScheduleService
+import net.squanchy.schedule.domain.view.aDay
+import net.squanchy.schedule.domain.view.aSchedule
+import net.squanchy.schedule.domain.view.aSchedulePage
+import net.squanchy.schedule.domain.view.anEvent
+import net.squanchy.service.firebase.FirebaseAuthService
+import net.squanchy.support.lang.Optional
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.Mock
+import org.mockito.Mockito.`when`
+import org.mockito.Mockito.mock
+import org.mockito.junit.MockitoJUnit
+import org.mockito.junit.MockitoRule
+
+class FirestoreFavoritesServiceTest {
+
+    @Rule
+    @JvmField
+    val mockitoRule: MockitoRule = MockitoJUnit.rule()
+
+    @Mock
+    private lateinit var authService: FirebaseAuthService
+
+    @Mock
+    private lateinit var scheduleService: ScheduleService
+
+    private lateinit var favoritesService: FirestoreFavoritesService
+
+    @Before
+    fun setUp() {
+        favoritesService = FirestoreFavoritesService(authService, scheduleService)
+    }
+
+    @Test
+    fun `should return an empty list when there are no favorite events`() {
+        `when`(scheduleService.schedule(onlyFavorites = true)).thenReturn(Observable.just(aSchedule(emptyList())))
+
+        favoritesService.favorites()
+            .test()
+            .assertValue(emptyList())
+    }
+
+    @Test
+    fun `should return a header item for each day followed by the days' events`() {
+        val schedule = aSchedule(
+            listOf(
+                aSchedulePage(
+                    date = aDay().date,
+                    events = listOf(anEvent(id = "day 1 event 1"), anEvent(id = "day 1 event 2"))
+                ),
+                aSchedulePage(
+                    date = aDay().date.plusDays(1),
+                    events = listOf(anEvent(id = "day 2 event 1"))
+                )
+            )
+        )
+        `when`(scheduleService.schedule(onlyFavorites = true)).thenReturn(Observable.just(schedule))
+
+        favoritesService.favorites()
+            .test()
+            .assertValue(
+                listOf(
+                    aFavoriteHeaderListItem(aDay().date),
+                    aFavoriteItemListItem(anEvent(id = "day 1 event 1")),
+                    aFavoriteItemListItem(anEvent(id = "day 1 event 2")),
+                    aFavoriteHeaderListItem(aDay().date.plusDays(1)),
+                    aFavoriteItemListItem(anEvent(id = "day 2 event 1"))
+                )
+            )
+    }
+
+    @Test
+    fun `should return false when the user is not signed in`() {
+        `when`(authService.currentUser()).thenReturn(Observable.just(Optional.absent()))
+
+        favoritesService.currentUserIsSignedIn()
+            .test()
+            .assertValue(false)
+    }
+
+    @Test
+    fun `should return true when the user is signed in`() {
+        `when`(authService.currentUser()).thenReturn(Observable.just(Optional.of(mock(FirebaseUser::class.java))))
+
+        favoritesService.currentUserIsSignedIn()
+            .test()
+            .assertValue(true)
+    }
+}

--- a/app/src/test/java/net/squanchy/favorites/FirestoreFavoritesServiceTest.kt
+++ b/app/src/test/java/net/squanchy/favorites/FirestoreFavoritesServiceTest.kt
@@ -39,7 +39,8 @@ class FirestoreFavoritesServiceTest {
 
     @Test
     fun `should return an empty list when there are no favorite events`() {
-        `when`(scheduleService.schedule(onlyFavorites = true)).thenReturn(Observable.just(aSchedule(emptyList())))
+        val schedule = aSchedule(pages = emptyList())
+        `when`(scheduleService.schedule(onlyFavorites = true)).thenReturn(Observable.just(schedule))
 
         favoritesService.favorites()
             .test()
@@ -49,7 +50,7 @@ class FirestoreFavoritesServiceTest {
     @Test
     fun `should return a header item for each day followed by the days' events`() {
         val schedule = aSchedule(
-            listOf(
+            pages = listOf(
                 aSchedulePage(
                     date = aDay().date,
                     events = listOf(anEvent(id = "day 1 event 1"), anEvent(id = "day 1 event 2"))
@@ -73,6 +74,20 @@ class FirestoreFavoritesServiceTest {
                     aFavoriteItemListItem(anEvent(id = "day 2 event 1"))
                 )
             )
+    }
+
+    @Test
+    fun `should not add a header item for a page with no favourites`() {
+        val schedule = aSchedule(
+            pages = listOf(
+                aSchedulePage(events = emptyList())
+            )
+        )
+        `when`(scheduleService.schedule(onlyFavorites = true)).thenReturn(Observable.just(schedule))
+
+        favoritesService.favorites()
+            .test()
+            .assertValue(emptyList())
     }
 
     @Test

--- a/app/src/test/java/net/squanchy/favorites/ListItemFixtures.kt
+++ b/app/src/test/java/net/squanchy/favorites/ListItemFixtures.kt
@@ -1,0 +1,15 @@
+package net.squanchy.favorites
+
+import net.squanchy.favorites.view.FavoriteListItem
+import net.squanchy.schedule.domain.view.Event
+import net.squanchy.schedule.domain.view.aDay
+import net.squanchy.schedule.domain.view.anEvent
+import org.joda.time.LocalDate
+
+fun aFavoriteHeaderListItem(
+    date: LocalDate = aDay().date
+) = FavoriteListItem.Header(date = date)
+
+fun aFavoriteItemListItem(
+    event: Event = anEvent()
+) = FavoriteListItem.Favorite(event = event)

--- a/app/src/test/java/net/squanchy/favorites/ListItemFixtures.kt
+++ b/app/src/test/java/net/squanchy/favorites/ListItemFixtures.kt
@@ -1,6 +1,6 @@
 package net.squanchy.favorites
 
-import net.squanchy.favorites.view.FavoriteListItem
+import net.squanchy.favorites.view.FavoritesItem
 import net.squanchy.schedule.domain.view.Event
 import net.squanchy.schedule.domain.view.aDay
 import net.squanchy.schedule.domain.view.anEvent
@@ -8,8 +8,8 @@ import org.joda.time.LocalDate
 
 fun aFavoriteHeaderListItem(
     date: LocalDate = aDay().date
-) = FavoriteListItem.Header(date = date)
+) = FavoritesItem.Header(date = date)
 
 fun aFavoriteItemListItem(
     event: Event = anEvent()
-) = FavoriteListItem.Favorite(event = event)
+) = FavoritesItem.Favorite(event = event)


### PR DESCRIPTION
## Problem

We're not using a list adapter for favourites, and our logic to display them is extremely complicated and lives entirely in the Favourites adapter, which is kinda crap and means it has no tests.

## Solution

Create a `FavoritesScheduler` which contains the bulk of the (tested ✨) logic, and rewrite the `RecyclerView` adapter to be a `ListAdapter`. There is no visible change in the UI but the whole logic now doesn't sit in the view layer anymore — and as a side effect it's also immensely easier to read.

The new service still uses the `ScheduleService` internally to reduce duplication of the fetching logic of the schedule, then flattens all the favourite events into a list, injecting headers for each day that has favourites.

There's a bunch of KTX-powered boy scouting too, to top it all up.

### Test(s) added

Yes!

### Paired with

Nobody