### PR TITLE
Track notification status

### DIFF
--- a/app/src/main/java/net/squanchy/SquanchyApplication.kt
+++ b/app/src/main/java/net/squanchy/SquanchyApplication.kt
@@ -30,6 +30,7 @@ class SquanchyApplication : Application() {
             enableExceptionLogging()
             initializeStaticUserProperties()
             trackFirstStartUserNotLoggedIn()
+            trackFirstStartNotificationsEnabled()
         }
 
         if (BuildConfig.DEBUG) {

--- a/app/src/main/java/net/squanchy/analytics/Analytics.kt
+++ b/app/src/main/java/net/squanchy/analytics/Analytics.kt
@@ -70,6 +70,22 @@ class Analytics internal constructor(
         firstStartDetector.setFirstStartNotLoggedInStatusTracked()
     }
 
+    fun trackFirstStartNotificationsEnabled() {
+        if (firstStartDetector.isFirstStartNotificationsEnabledTracked()) {
+            return
+        }
+        trackNotificationsEnabled()
+        firstStartDetector.setFirstStartNotificationsEnabledTracked()
+    }
+
+    fun trackNotificationsEnabled() {
+        firebaseAnalytics.setUserProperty("notifications_status", "enabled")
+    }
+
+    fun trackNotificationsDisabled() {
+        firebaseAnalytics.setUserProperty("notifications_status", "disabled")
+    }
+
     fun trackUserNotLoggedIn() {
         setUserLoginProperty(LoginStatus.NOT_LOGGED_IN)
     }

--- a/app/src/main/java/net/squanchy/analytics/FirstStartDetector.kt
+++ b/app/src/main/java/net/squanchy/analytics/FirstStartDetector.kt
@@ -12,8 +12,17 @@ internal class FirstStartDetector(private val preferences: SharedPreferences) {
             .apply()
     }
 
+    fun isFirstStartNotificationsEnabledTracked() = preferences.getBoolean(KEY_FIRST_START_NOTIFICATIONS_ENABLED_TRACKED, false)
+
+    fun setFirstStartNotificationsEnabledTracked() {
+        preferences.edit()
+            .putBoolean(KEY_FIRST_START_NOTIFICATIONS_ENABLED_TRACKED, true)
+            .apply()
+    }
+
     companion object {
 
         private const val KEY_FIRST_START_NOT_LOGGED_IN_TRACKED = "FirstStart.not_logged_in_tracked"
+        private const val KEY_FIRST_START_NOTIFICATIONS_ENABLED_TRACKED = "FirstStart.notifications_enabled_tracked"
     }
 }

--- a/app/src/main/java/net/squanchy/settings/SettingsFragment.kt
+++ b/app/src/main/java/net/squanchy/settings/SettingsFragment.kt
@@ -63,6 +63,16 @@ class SettingsFragment : PreferenceFragment() {
             navigator.toAboutSquanchy()
             true
         }
+
+        val notificationsPreference = findPreference(getString(R.string.about_to_start_notification_preference_key))
+        notificationsPreference.setOnPreferenceChangeListener { _, enabled ->
+            if (enabled as Boolean) {
+                analytics.trackNotificationsEnabled()
+            } else {
+                analytics.trackNotificationsDisabled()
+            }
+            true
+        }
     }
 
     private fun displayBuildVersion() {


### PR DESCRIPTION
## Problem

We want to track user notification status to firebase analytics

## Solution

Track the status as enabled by default the first time, and update it every time the user changes it in settings

### Test(s) added

no


### Paired with

Nobody
