### PR TITLE
Fix notifications speakers

### DIFF
--- a/app/src/debug/java/net/squanchy/support/debug/DebugActivity.kt
+++ b/app/src/debug/java/net/squanchy/support/debug/DebugActivity.kt
@@ -110,7 +110,7 @@ class DebugActivity : AppCompatActivity() {
         "UI",
         Option(generateColor()),
         Option(generateColor()),
-        Option("gs://droidcon-italy-2017.appspot.com/tracks/0.webp")
+        Option.empty()
     )
 
     private fun generateColor(): String {

--- a/app/src/main/java/net/squanchy/notification/NotificationCreator.kt
+++ b/app/src/main/java/net/squanchy/notification/NotificationCreator.kt
@@ -160,7 +160,7 @@ class NotificationCreator(private val context: Context) {
     }
 
     private fun getSpeakerNamesFrom(speakers: List<Speaker>): String {
-        val speakerNames = speakers.joinToString(prefix = ", ", transform = { it.name })
+        val speakerNames = speakers.joinToString(separator = ", ", transform = { it.name })
 
         return context.getString(R.string.event_notification_starting_by, speakerNames)
     }


### PR DESCRIPTION
## Problem

We're using the comma as prefix instead of separator in the list of speakers in notifications.

## Solution

Use it as separator, and also use an empty track icon in debug notifications rather than an icon from an old edition of the app.

### Test(s) added

No

### Paired with

Nobody