### PR TITLE
delete the show current talk feature to allow the saving and restoring of the current tab / position

### DIFF
--- a/app/src/main/java/net/squanchy/schedule/SchedulePageView.kt
+++ b/app/src/main/java/net/squanchy/schedule/SchedulePageView.kt
@@ -53,10 +53,6 @@ class SchedulePageView @JvmOverloads constructor(
         tabstrip.setupWithViewPager(viewpager)
         hackToApplyTypefaces(tabstrip)
 
-        viewpager.adapter = viewPagerAdapter
-
-        tabstrip.addOnTabSelectedListener(TrackingOnTabSelectedListener(analytics, viewPagerAdapter))
-
         setupToolbar()
     }
 
@@ -87,7 +83,7 @@ class SchedulePageView @JvmOverloads constructor(
             service.schedule()
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(
-                    { updateWith(it, { event -> onEventClicked(event) }) },
+                    { updateWith(it, ::onEventClicked) },
                     { Timber.e(it) }
                 )
         )
@@ -135,42 +131,11 @@ class SchedulePageView @JvmOverloads constructor(
         tabstrip.visibility = VISIBLE
         emptyView.visibility = GONE
 
-        val initialEventForPage = schedule.pages.map { schedule.findNextEventForPage(it, currentTime) }.toTypedArray()
-        viewPagerAdapter.updateWith(schedule.pages, initialEventForPage, onEventClicked)
+        viewPagerAdapter.updateWith(schedule.pages, onEventClicked)
+        if (viewpager.adapter == null) {
+            viewpager.adapter = viewPagerAdapter
+        }
 
-        val todayPageIndex = schedule.findTodayIndexOrDefault(currentTime)
-        viewpager.setCurrentItem(todayPageIndex, false)
-
-        tabstrip.addOnTabSelectedListener(ScrollingOnTabSelectedListener(schedule, viewPagerAdapter, currentTime))
         progressbar.visibility = View.GONE
-    }
-
-    private interface OnTabSelectedListener : TabLayout.OnTabSelectedListener {
-
-        override fun onTabReselected(tab: TabLayout.Tab) {}
-        override fun onTabUnselected(tab: TabLayout.Tab) {}
-        override fun onTabSelected(tab: TabLayout.Tab) {}
-    }
-
-    private class ScrollingOnTabSelectedListener(
-        private val schedule: Schedule,
-        private val viewPagerAdapter: ScheduleViewPagerAdapter,
-        private val currentTime: CurrentTime
-    ) : OnTabSelectedListener {
-
-        override fun onTabReselected(tab: TabLayout.Tab) {
-            val page = schedule.pages[tab.position]
-            schedule.findNextEventForPage(page, currentTime)?.let { viewPagerAdapter.refresh(tab.position, it) }
-        }
-    }
-
-    private class TrackingOnTabSelectedListener(
-        private val analytics: Analytics,
-        private val viewPagerAdapter: ScheduleViewPagerAdapter
-    ) : OnTabSelectedListener {
-
-        override fun onTabSelected(tab: TabLayout.Tab) {
-            analytics.trackItemSelected(ContentType.SCHEDULE_DAY, viewPagerAdapter.getPageDayId(tab.position))
-        }
     }
 }

--- a/app/src/main/java/net/squanchy/schedule/domain/view/Schedule.kt
+++ b/app/src/main/java/net/squanchy/schedule/domain/view/Schedule.kt
@@ -1,46 +1,9 @@
 package net.squanchy.schedule.domain.view
 
-import net.squanchy.support.system.CurrentTime
 import org.joda.time.DateTimeZone
-
-private const val NOT_FOUND_INDEX = -1
-private const val FIRST_PAGE_INDEX = 0
-
-private const val CURRENT_SLOT_THRESHOLD = .6f
 
 data class Schedule(val pages: List<SchedulePage>, val timeZone: DateTimeZone) {
 
     val isEmpty: Boolean
         get() = pages.all { it.events.isEmpty() }
-
-    fun findTodayIndexOrDefault(currentTime: CurrentTime): Int {
-        val now = currentTime.currentDateTime().withZone(timeZone)
-        return pages
-            .indexOfFirst { page ->
-                page.date.isEqual(now.toLocalDate())
-            }
-            .let {
-                when (it) {
-                    NOT_FOUND_INDEX -> FIRST_PAGE_INDEX
-                    else -> it
-                }
-            }
-    }
-
-    fun findNextEventForPage(page: SchedulePage, currentTime: CurrentTime) =
-        page.events
-            .firstOrNull { event ->
-                val startDateTime = event.startTime.toDateTime().withZone(event.timeZone)
-                val currentDateTime = currentTime.currentDateTime().toDateTime().withZone(event.timeZone)
-                val endDateTime = event.endTime.toDateTime().withZone(event.timeZone)
-
-                if (currentDateTime.isAfter(endDateTime)) {
-                    false
-                } else {
-                    val duration = endDateTime.millis - startDateTime.millis
-                    val offset = currentDateTime.millis - startDateTime.millis
-
-                    offset.toFloat() / duration < CURRENT_SLOT_THRESHOLD
-                }
-            }
 }

--- a/app/src/main/java/net/squanchy/schedule/view/ScheduleDayPageView.kt
+++ b/app/src/main/java/net/squanchy/schedule/view/ScheduleDayPageView.kt
@@ -2,7 +2,6 @@ package net.squanchy.schedule.view
 
 import android.content.Context
 import android.support.v7.widget.LinearLayoutManager
-import android.support.v7.widget.LinearSmoothScroller
 import android.support.v7.widget.RecyclerView
 import android.util.AttributeSet
 import net.squanchy.R
@@ -21,7 +20,7 @@ class ScheduleDayPageView @JvmOverloads constructor(
     override fun onFinishInflate() {
         super.onFinishInflate()
 
-        val layoutManager = SnappingLinearLayoutManager(context)
+        val layoutManager = LinearLayoutManager(context)
         setLayoutManager(layoutManager)
         adapter = EventsAdapter(context)
 
@@ -34,32 +33,5 @@ class ScheduleDayPageView @JvmOverloads constructor(
         adapter.eventClickListener = listener
         setAdapterIfNone(adapter)
         adapter.submitList(newData)
-    }
-
-    private var userHasScrolled: Boolean = false
-
-    override fun onScrolled(dx: Int, dy: Int) {
-        userHasScrolled = true
-        super.onScrolled(dx, dy)
-    }
-
-    fun autoscrollToEvent(eventPosition: Int, animate: Boolean) {
-        if (userHasScrolled) return // TODO only do it if it's an actual autoscroll (i.e., not because user has tapped the tab)
-
-        when {
-            animate -> smoothScrollToPosition(eventPosition)
-            else -> scrollToPosition(eventPosition)
-        }
-    }
-
-    private class SnappingLinearLayoutManager(context: Context) : LinearLayoutManager(context) {
-
-        override fun smoothScrollToPosition(recyclerView: RecyclerView, state: RecyclerView.State?, position: Int) {
-            val smoothScroller = object : LinearSmoothScroller(recyclerView.context) {
-                override fun getVerticalSnapPreference() = SNAP_TO_START
-            }
-            smoothScroller.targetPosition = position
-            startSmoothScroll(smoothScroller)
-        }
     }
 }

--- a/app/src/main/java/net/squanchy/schedule/view/ScheduleViewPagerAdapter.kt
+++ b/app/src/main/java/net/squanchy/schedule/view/ScheduleViewPagerAdapter.kt
@@ -15,16 +15,12 @@ class ScheduleViewPagerAdapter(context: Context) : ViewPagerAdapter<ScheduleDayP
     private lateinit var listener: (Event) -> Unit
 
     private var pages = emptyList<SchedulePage>()
-    private var initialEventForPage = emptyArray<Event?>()
-    private var triggerScrollForPage = emptyArray<((Event) -> Unit)?>()
 
     private val inflater = LayoutInflater.from(context)
 
-    fun updateWith(pages: List<SchedulePage>, initialEventForPage: Array<Event?>, listener: (Event) -> Unit) {
+    fun updateWith(pages: List<SchedulePage>, listener: (Event) -> Unit) {
         this.pages = pages
-        this.initialEventForPage = initialEventForPage
         this.listener = listener
-        this.triggerScrollForPage = arrayOfNulls(pages.size)
         notifyDataSetChanged()
     }
 
@@ -36,21 +32,12 @@ class ScheduleViewPagerAdapter(context: Context) : ViewPagerAdapter<ScheduleDayP
 
     override fun bindView(view: ScheduleDayPageView, position: Int) {
         val events = pages[position].events
-        val initialEvent = initialEventForPage[position]
-        triggerScrollForPage[position] = { view.autoscrollToEvent(events.indexOf(it), true) }
         view.updateWith(events, listener)
-        initialEvent?.let { view.autoscrollToEvent(events.indexOf(it), false) }
     }
 
     override fun getPageTitle(position: Int): CharSequence? {
         val date = pages[position].date
         return date.toString(TITLE_FORMAT_TEMPLATE).toUpperCase(Locale.getDefault())
-    }
-
-    fun getPageDayId(position: Int) = pages[position].dayId
-
-    fun refresh(page: Int, event: Event) {
-        triggerScrollForPage[page]?.invoke(event)
     }
 
     override fun isViewFromObject(view: View, anObject: Any) = view === anObject

--- a/app/src/main/java/net/squanchy/search/SearchService.kt
+++ b/app/src/main/java/net/squanchy/search/SearchService.kt
@@ -73,9 +73,4 @@ class SearchService(
             add(AlgoliaLogo)
         }
     }
-
-    fun speakers(): Observable<List<Speaker>> {
-        return speakerRepository.speakers()
-            .map { it.sortedBy(Speaker::name) }
-    }
 }


### PR DESCRIPTION
## Problem

The feature for showing the current talk in the schedule was breaking the saving and restoring of the tab and the position in the RecyclerView when rotating the device. 

## Solution

For now we are removing it, with the idea of reimplementing it sometimes soon

### Test(s) added

None

### Paired with

Nobody