### PR TITLE
Fix a crash in the SearchActivity and improve its state management

### DIFF
--- a/app/src/main/java/net/squanchy/search/SearchActivity.kt
+++ b/app/src/main/java/net/squanchy/search/SearchActivity.kt
@@ -46,7 +46,7 @@ class SearchActivity : AppCompatActivity(), SearchRecyclerView.OnSearchResultCli
     private lateinit var searchTextWatcher: SearchTextWatcher
 
     private var hasQuery: Boolean = false
-    private lateinit var query: String
+    private lateinit var initialQuery: String
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -54,7 +54,7 @@ class SearchActivity : AppCompatActivity(), SearchRecyclerView.OnSearchResultCli
         enableLightNavigationBar(this)
         setupToolbar()
 
-        query = savedInstanceState?.getString(QUERY_KEY) ?: ""
+        initialQuery = savedInstanceState?.getString(QUERY_KEY) ?: ""
 
         with(searchComponent(this)) {
             searchService = service()
@@ -77,7 +77,7 @@ class SearchActivity : AppCompatActivity(), SearchRecyclerView.OnSearchResultCli
 
         val searchSubscription = querySubject.throttleLast(QUERY_DEBOUNCE_TIMEOUT, TimeUnit.MILLISECONDS)
             .doOnNext(::updateSearchActionIcon)
-            .startWith(query)
+            .startWith(initialQuery)
             .flatMap(searchService::find)
             .distinctUntilChanged()
             .subscribeOn(Schedulers.io())
@@ -189,8 +189,8 @@ class SearchActivity : AppCompatActivity(), SearchRecyclerView.OnSearchResultCli
         }
     }
 
-    override fun onSaveInstanceState(outState: Bundle?) {
-        outState?.putString(QUERY_KEY, searchField.text?.toString())
+    override fun onSaveInstanceState(outState: Bundle) {
+        outState.putString(QUERY_KEY, searchField.text?.toString())
         super.onSaveInstanceState(outState)
     }
 

--- a/app/src/main/java/net/squanchy/search/SearchActivity.kt
+++ b/app/src/main/java/net/squanchy/search/SearchActivity.kt
@@ -189,8 +189,8 @@ class SearchActivity : AppCompatActivity(), SearchRecyclerView.OnSearchResultCli
         }
     }
 
-    override fun onSaveInstanceState(outState: Bundle) {
-        outState.putString(QUERY_KEY, searchField.text?.toString())
+    override fun onSaveInstanceState(outState: Bundle?) {
+        outState?.putString(QUERY_KEY, searchField.text?.toString())
         super.onSaveInstanceState(outState)
     }
 

--- a/app/src/main/java/net/squanchy/search/SearchActivity.kt
+++ b/app/src/main/java/net/squanchy/search/SearchActivity.kt
@@ -46,12 +46,15 @@ class SearchActivity : AppCompatActivity(), SearchRecyclerView.OnSearchResultCli
     private lateinit var searchTextWatcher: SearchTextWatcher
 
     private var hasQuery: Boolean = false
+    private lateinit var query: String
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_search)
         enableLightNavigationBar(this)
         setupToolbar()
+
+        query = savedInstanceState?.getString(QUERY_KEY) ?: ""
 
         with(searchComponent(this)) {
             searchService = service()
@@ -72,10 +75,9 @@ class SearchActivity : AppCompatActivity(), SearchRecyclerView.OnSearchResultCli
         searchTextWatcher = SearchTextWatcher(querySubject)
         searchField.addTextChangedListener(searchTextWatcher)
 
-        val searchSubscription = querySubject.distinctUntilChanged()
-            .debounce(QUERY_DEBOUNCE_TIMEOUT, TimeUnit.MILLISECONDS)
+        val searchSubscription = querySubject.throttleLast(QUERY_DEBOUNCE_TIMEOUT, TimeUnit.MILLISECONDS)
             .doOnNext(::updateSearchActionIcon)
-            .startWith(getInitialQuery())
+            .startWith(query)
             .flatMap(searchService::find)
             .distinctUntilChanged()
             .subscribeOn(Schedulers.io())
@@ -92,11 +94,6 @@ class SearchActivity : AppCompatActivity(), SearchRecyclerView.OnSearchResultCli
         }
 
         searchField.requestFocus()
-    }
-
-    private fun getInitialQuery(): String {
-        val text = searchField.text
-        return text?.toString() ?: EMPTY_QUERY
     }
 
     private fun updateSearchActionIcon(query: String) {
@@ -123,9 +120,8 @@ class SearchActivity : AppCompatActivity(), SearchRecyclerView.OnSearchResultCli
         } else {
             emptyView.isInvisible = true
             searchRecyclerView.isVisible = true
-
-            searchRecyclerView.updateWith(searchResult, this)
         }
+        searchRecyclerView.updateWith(searchResult, this)
     }
 
     private fun onSearchError() {
@@ -193,6 +189,11 @@ class SearchActivity : AppCompatActivity(), SearchRecyclerView.OnSearchResultCli
         }
     }
 
+    override fun onSaveInstanceState(outState: Bundle?) {
+        outState?.putString(QUERY_KEY, searchField.text?.toString())
+        super.onSaveInstanceState(outState)
+    }
+
     private fun onVoiceSearchClicked() {
         Intent(RecognizerIntent.ACTION_RECOGNIZE_SPEECH).apply {
             putExtra(RecognizerIntent.EXTRA_MAX_RESULTS, 1)
@@ -246,6 +247,6 @@ class SearchActivity : AppCompatActivity(), SearchRecyclerView.OnSearchResultCli
         private const val SPEECH_REQUEST_CODE = 100
         private const val QUERY_DEBOUNCE_TIMEOUT = 250L
         private const val MIN_QUERY_LENGTH = 2
-        private const val EMPTY_QUERY = ""
+        private const val QUERY_KEY = "SearchActivity.query_key"
     }
 }

--- a/app/src/main/java/net/squanchy/search/SearchService.kt
+++ b/app/src/main/java/net/squanchy/search/SearchService.kt
@@ -51,7 +51,7 @@ class SearchService(
     }
 
     private fun createResultForQueryNotLongEnough(speakers: List<Speaker>): List<SearchListElement> {
-        return listOf(SpeakerHeader) + speakers.map(::SpeakerElement)
+        return listOf(SpeakerHeader) + speakers.map(::SpeakerElement).sortedBy { it.speaker.name }
     }
 
     private fun createResultForSuccessfulSearch(events: List<Event>, speakers: List<Speaker>): List<SearchListElement> {

--- a/app/src/main/java/net/squanchy/search/view/GridSpanSizeLookup.kt
+++ b/app/src/main/java/net/squanchy/search/view/GridSpanSizeLookup.kt
@@ -3,14 +3,22 @@ package net.squanchy.search.view
 import android.support.v7.widget.GridLayoutManager
 import net.squanchy.search.SearchListElement
 
-internal class GridSpanSizeLookup(private val items: List<SearchListElement>, private val columnCount: Int) : GridLayoutManager.SpanSizeLookup() {
+internal class GridSpanSizeLookup(
+    private val itemRetriever: (Int) -> SearchListElement,
+    private val isAdapterEmpty: () -> Boolean,
+    private val columnCount: Int
+) : GridLayoutManager.SpanSizeLookup() {
 
     init {
         super.setSpanIndexCacheEnabled(true)
     }
 
     override fun getSpanSize(position: Int): Int {
-        return if (items.isEmpty()) SINGLE_COLUMN_SPAN_SIZE else getSpanSizeFor(items[position])
+        if (isAdapterEmpty()) {
+            return SINGLE_COLUMN_SPAN_SIZE
+        } else {
+            return getSpanSizeFor(itemRetriever(position))
+        }
     }
 
     private fun getSpanSizeFor(element: SearchListElement): Int =

--- a/app/src/main/java/net/squanchy/search/view/SearchAdapter.kt
+++ b/app/src/main/java/net/squanchy/search/view/SearchAdapter.kt
@@ -79,7 +79,7 @@ internal class SearchAdapter(activity: AppCompatActivity) : ListAdapter<SearchLi
     }
 
     override fun onBindViewHolder(holder: SearchItemViewHolder, position: Int) {
-        val item = searchResult.elements[position]
+        val item = getItem(position)
         when (item) {
             is SearchListElement.EventHeader -> (holder as HeaderViewHolder).updateWith(HeaderType.EVENTS)
             is SearchListElement.SpeakerHeader -> (holder as HeaderViewHolder).updateWith(HeaderType.SPEAKERS)
@@ -90,8 +90,10 @@ internal class SearchAdapter(activity: AppCompatActivity) : ListAdapter<SearchLi
     }
 
     fun createSpanSizeLookup(columnsCount: Int): GridLayoutManager.SpanSizeLookup {
-        return GridSpanSizeLookup(searchResult.elements, columnsCount)
+        return GridSpanSizeLookup(::getItem, ::isEmpty, columnsCount)
     }
+
+    private fun isEmpty() = itemCount == 0
 
     fun updateWith(searchResult: SearchResult.Success, listener: SearchRecyclerView.OnSearchResultClickListener) {
         this.listener = listener


### PR DESCRIPTION
## Problem

A bug in the `GridSpanLookup` after the migration to `ListAdapter` caused a crash in the `SearchActivity`

## Solution

Use `ListAdapter.getItem` as only source of truth for retrieving an item from the adapter, plus some few more improvements pointed out in the code.

This closes #531

### Test(s) added

Unfortunately too Android to test

### Paired with

Nobody
