### PR TITLE
Fix home menu

### DIFF
--- a/app/src/main/java/net/squanchy/favorites/FavoritesPageView.kt
+++ b/app/src/main/java/net/squanchy/favorites/FavoritesPageView.kt
@@ -80,10 +80,6 @@ class FavoritesPageView @JvmOverloads constructor(
                 showSettings()
                 true
             }
-            R.id.action_filter -> {
-                navigator.toScheduleFiltering(context)
-                true
-            }
             else -> false
         }
     }

--- a/app/src/main/java/net/squanchy/navigation/Navigator.kt
+++ b/app/src/main/java/net/squanchy/navigation/Navigator.kt
@@ -1,7 +1,6 @@
 package net.squanchy.navigation
 
 import android.app.Activity
-import android.content.Context
 import android.content.Intent
 import android.content.Intent.FLAG_ACTIVITY_CLEAR_TASK
 import android.content.Intent.FLAG_ACTIVITY_CLEAR_TOP
@@ -62,8 +61,8 @@ class Navigator(
         attemptDeeplinkOrFallback(deeplinkStatusUrl, fallbackStatusUrl)
     }
 
-    fun toScheduleFiltering(ctx: Context) {
-        start(Intent(ctx, ScheduleTracksFilterActivity::class.java))
+    fun toScheduleFiltering() {
+        start(Intent(activity, ScheduleTracksFilterActivity::class.java))
     }
 
     private fun attemptDeeplinkOrFallback(deeplinkUrl: String, fallbackUrl: String) {

--- a/app/src/main/java/net/squanchy/navigation/Navigator.kt
+++ b/app/src/main/java/net/squanchy/navigation/Navigator.kt
@@ -20,6 +20,7 @@ import net.squanchy.settings.SettingsActivity
 import net.squanchy.signin.SignInActivity
 import net.squanchy.signin.SignInOrigin
 import net.squanchy.speaker.SpeakerDetailsActivity
+import net.squanchy.support.widget.OriginCoordinates
 import net.squanchy.tweets.domain.TweetLinkInfo
 import net.squanchy.venue.domain.view.Venue
 import timber.log.Timber
@@ -61,8 +62,8 @@ class Navigator(
         attemptDeeplinkOrFallback(deeplinkStatusUrl, fallbackStatusUrl)
     }
 
-    fun toScheduleFiltering() {
-        start(Intent(activity, ScheduleTracksFilterActivity::class.java))
+    fun toScheduleFiltering(originCoordinates: OriginCoordinates?) {
+        start(ScheduleTracksFilterActivity.createIntent(activity, originCoordinates))
     }
 
     private fun attemptDeeplinkOrFallback(deeplinkUrl: String, fallbackUrl: String) {

--- a/app/src/main/java/net/squanchy/schedule/SchedulePageView.kt
+++ b/app/src/main/java/net/squanchy/schedule/SchedulePageView.kt
@@ -64,6 +64,8 @@ class SchedulePageView @JvmOverloads constructor(
     private fun setupToolbar() {
         toolbar.setTitle(R.string.activity_schedule)
         toolbar.inflateMenu(R.menu.homepage)
+        toolbar.menu.findItem(R.id.action_filter).isVisible = true
+
         toolbar.setOnMenuItemClickListener { item ->
             when (item.itemId) {
                 R.id.action_search -> {

--- a/app/src/main/java/net/squanchy/schedule/SchedulePageView.kt
+++ b/app/src/main/java/net/squanchy/schedule/SchedulePageView.kt
@@ -25,6 +25,7 @@ import net.squanchy.support.text.applyTypeface
 import net.squanchy.support.text.getFontFor
 import net.squanchy.support.text.hasTypefaceSpan
 import net.squanchy.support.unwrapToActivityContext
+import net.squanchy.support.widget.calculateMenuItemCenterCoordinates
 import timber.log.Timber
 
 class SchedulePageView @JvmOverloads constructor(
@@ -77,7 +78,7 @@ class SchedulePageView @JvmOverloads constructor(
                     true
                 }
                 R.id.action_filter -> {
-                    navigate.toScheduleFiltering()
+                    navigate.toScheduleFiltering(toolbar.calculateMenuItemCenterCoordinates(R.id.action_filter))
                     true
                 }
                 else -> false

--- a/app/src/main/java/net/squanchy/schedule/SchedulePageView.kt
+++ b/app/src/main/java/net/squanchy/schedule/SchedulePageView.kt
@@ -77,7 +77,7 @@ class SchedulePageView @JvmOverloads constructor(
                     true
                 }
                 R.id.action_filter -> {
-                    navigate.toScheduleFiltering(context)
+                    navigate.toScheduleFiltering()
                     true
                 }
                 else -> false

--- a/app/src/main/java/net/squanchy/schedule/tracksfilter/ScheduleTracksFilter.kt
+++ b/app/src/main/java/net/squanchy/schedule/tracksfilter/ScheduleTracksFilter.kt
@@ -113,6 +113,29 @@ class ScheduleTracksFilterActivity : AppCompatActivity() {
             }
     }
 
+    private fun prepareAppearAnimation() {
+        appearInterpolator = AnimationUtils.loadInterpolator(this, android.R.interpolator.linear_out_slow_in)
+        filtersRoot.visibility = View.VISIBLE
+
+        val titleDeltaY = resources.getDimension(R.dimen.track_filters_title_appear_delta_y)
+        dialogTitle.apply {
+            translationY = -titleDeltaY
+            alpha = 0F
+        }
+
+        val subtitleDeltaY = resources.getDimension(R.dimen.track_filters_subtitle_appear_delta_y)
+        dialogSubtitle.apply {
+            translationY = -subtitleDeltaY
+            alpha = 0F
+        }
+
+        val tracksDeltaY = resources.getDimension(R.dimen.track_filters_tracks_appear_delta_y)
+        trackFiltersList.apply {
+            translationY = -tracksDeltaY
+            alpha = 0F
+        }
+    }
+
     @Suppress("MagicNumber") // Just animation code… needs a few magic numbers
     private fun animateAppearing() {
         val centerX = closeButton.x + closeButton.width / 2
@@ -145,29 +168,6 @@ class ScheduleTracksFilterActivity : AppCompatActivity() {
         .setDuration(duration)
         .setStartDelay(delay)
         .start()
-
-    private fun prepareAppearAnimation() {
-        appearInterpolator = AnimationUtils.loadInterpolator(this, android.R.interpolator.linear_out_slow_in)
-        filtersRoot.visibility = View.VISIBLE
-
-        val titleDeltaY = resources.getDimension(R.dimen.track_filters_title_appear_delta_y)
-        dialogTitle.apply {
-            translationY = -titleDeltaY
-            alpha = 0F
-        }
-
-        val subtitleDeltaY = resources.getDimension(R.dimen.track_filters_subtitle_appear_delta_y)
-        dialogSubtitle.apply {
-            translationY = -subtitleDeltaY
-            alpha = 0F
-        }
-
-        val tracksDeltaY = resources.getDimension(R.dimen.track_filters_tracks_appear_delta_y)
-        trackFiltersList.apply {
-            translationY = -tracksDeltaY
-            alpha = 0F
-        }
-    }
 
     private fun combineIntoCheckableTracks(): BiFunction<List<Track>, Set<Track>, List<CheckableTrack>> {
         return BiFunction { tracks, selectedTracks ->

--- a/app/src/main/java/net/squanchy/support/widget/ToolbarHacks.kt
+++ b/app/src/main/java/net/squanchy/support/widget/ToolbarHacks.kt
@@ -1,0 +1,47 @@
+package net.squanchy.support.widget
+
+import android.os.Parcel
+import android.os.Parcelable
+import android.support.annotation.IdRes
+import android.support.annotation.Px
+import android.support.v7.widget.ActionMenuView
+import android.support.v7.widget.Toolbar
+import android.view.View
+import android.view.ViewGroup
+import androidx.view.children
+
+fun Toolbar.calculateMenuItemCenterCoordinates(@IdRes menuItemId: Int): OriginCoordinates? {
+    val actionMenuView = children.find { it is ActionMenuView } as? ViewGroup
+        ?: return null
+
+    val menuItemView = actionMenuView.findViewById<View?>(menuItemId) ?: return null
+
+    return OriginCoordinates(
+        x = menuItemView.x + actionMenuView.x + menuItemView.width / 2,
+        y = menuItemView.y + actionMenuView.y + menuItemView.height / 2
+    )
+}
+
+data class OriginCoordinates(@Px val x: Float, @Px val y: Float) : Parcelable {
+
+    constructor(parcel: Parcel) : this(parcel.readFloat(), parcel.readFloat())
+
+    override fun writeToParcel(parcel: Parcel, flags: Int) {
+        parcel.writeFloat(x)
+        parcel.writeFloat(y)
+    }
+
+    override fun describeContents(): Int {
+        return 0
+    }
+
+    companion object CREATOR : Parcelable.Creator<OriginCoordinates> {
+        override fun createFromParcel(parcel: Parcel): OriginCoordinates {
+            return OriginCoordinates(parcel)
+        }
+
+        override fun newArray(size: Int): Array<OriginCoordinates?> {
+            return arrayOfNulls(size)
+        }
+    }
+}

--- a/app/src/main/res/layout/activity_track_filters.xml
+++ b/app/src/main/res/layout/activity_track_filters.xml
@@ -28,7 +28,7 @@
       android:layout_marginEnd="@dimen/track_filters_title_margin_horizontal"
       app:layout_constraintTop_toTopOf="parent"
       app:layout_constraintStart_toStartOf="parent"
-      app:layout_constraintEnd_toStartOf="@+id/closeButton" />
+      app:layout_constraintEnd_toEndOf="parent" />
 
     <TextView
       android:id="@+id/dialogSubtitle"
@@ -39,15 +39,6 @@
       app:layout_constraintStart_toStartOf="@+id/dialogTitle"
       app:layout_constraintTop_toBottomOf="@+id/dialogTitle"
       app:layout_constraintEnd_toEndOf="@+id/dialogTitle" />
-
-    <ImageButton
-      android:id="@+id/closeButton"
-      style="@style/TrackFilters.Filters.CloseButton"
-      android:layout_width="@dimen/track_filters_close_button_size"
-      android:layout_height="@dimen/track_filters_close_button_size"
-      android:layout_marginTop="@dimen/track_filters_close_button_margin"
-      app:layout_constraintEnd_toEndOf="parent"
-      app:layout_constraintTop_toTopOf="parent" />
 
     <android.support.v7.widget.RecyclerView
       android:id="@+id/trackFiltersList"

--- a/app/src/main/res/menu/homepage.xml
+++ b/app/src/main/res/menu/homepage.xml
@@ -3,9 +3,10 @@
   xmlns:app="http://schemas.android.com/apk/res-auto">
 
   <item
-    android:id="@+id/action_settings"
-    android:title="@string/settings_label"
-    android:icon="@drawable/ic_settings"
+    android:id="@+id/action_filter"
+    android:title="@string/filter_schedule"
+    android:icon="@drawable/ic_filter_list"
+    android:visible="false"
     app:showAsAction="ifRoom" />
 
   <item
@@ -15,9 +16,9 @@
     app:showAsAction="ifRoom" />
 
   <item
-    android:id="@+id/action_filter"
-    android:title="@string/filter_schedule"
-    android:icon="@drawable/ic_filter_list"
-    app:showAsAction="ifRoom" />
+    android:id="@+id/action_settings"
+    android:title="@string/settings_label"
+    android:icon="@drawable/ic_settings"
+    app:showAsAction="never" />
 
 </menu>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -14,7 +14,6 @@
 
   <color name="navigation_bar_light">#EEEEEE</color>
   <color name="dialog_dim">#4D000000</color>
-  <color name="track_filters_close_button_tint">#4D000000</color>
 
   <color name="empty_view_text_color">#4d606060</color>
 

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -205,8 +205,6 @@
   <dimen name="track_filters_tracks_appear_delta_y">22dp</dimen>
   <dimen name="track_filters_item_padding_vertical">8dp</dimen>
   <dimen name="track_filters_item_padding_horizontal">16dp</dimen>
-  <dimen name="track_filters_close_button_size">48dp</dimen>
-  <dimen name="track_filters_close_button_margin">4dp</dimen>
   <dimen name="track_filters_item_corner_radius">200dp</dimen>
   <dimen name="track_filters_item_stroke_width">2dp</dimen>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -34,7 +34,7 @@
   <string name="bottom_bar_schedule_label">Schedule</string>
   <string name="bottom_bar_favorites_label">Favorites</string>
   <string name="bottom_bar_tweets_label">Tweets</string>
-  <string name="bottom_bar_venue_label">Venue Info</string>
+  <string name="bottom_bar_venue_label">Venue</string>
   <string name="menu_search">Search</string>
   <string name="menu_voice_search">Voice search</string>
   <string name="menu_clear_query">Clear query</string>
@@ -75,7 +75,7 @@
   <string name="settings_debug_category">Debug</string>
   <string name="settings_open_debug_title">Tinker</string>
 
-  <string name="venue_info_label">Information</string>
+  <string name="venue_info_label">Venue</string>
   <string name="venue_about_label">About the venue</string>
   <string name="venue_map_content_description">Map to the venue</string>
 

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -38,6 +38,7 @@
   <style name="Squanchy.Toolbar" parent="Widget.AppCompat.Toolbar">
     <item name="titleTextAppearance">@style/TextAppearance.Squanchy.Toolbar</item>
     <item name="subtitleTextAppearance">@style/TextAppearance.Squanchy.Toolbar</item>
+    <item name="popupTheme">@style/ThemeOverlay.AppCompat.Light</item>
   </style>
 
   <style name="TextAppearance.Squanchy.Toolbar" parent="TextAppearance.Widget.AppCompat.Toolbar.Title">

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -703,13 +703,6 @@
     <item name="fontFamily">@font/default_typeface_medium</item>
   </style>
 
-  <style name="TrackFilters.Filters.CloseButton" parent="None">
-    <item name="android:background">?android:attr/selectableItemBackgroundBorderless</item>
-    <item name="android:scaleType">centerInside</item>
-    <item name="android:src">@drawable/ic_close</item>
-    <item name="android:tint">@color/track_filters_close_button_tint</item>
-  </style>
-
   <style name="TrackFilters.Filters.Tracks" parent="None">
     <item name="android:clipToPadding">false</item>
     <item name="android:minHeight">64dp</item>


### PR DESCRIPTION
## Problem

We're showing the filter menu item on all homescreen pages but we should only show it for Schedule.

## Solution

Only show the item in Schedule, and reorganise menu items so that their order makes more sense. Move Settings into the overflow. Rename Venue Info to Venue.

The animation of the track filters originates to and goes out to the menu item triggering it. The filters don't have a close button anymore as it makes relatively little sense at this point to still have it, imo.

### Test(s) added

No

### Screenshots

 Before | After
 ------ | -----
 ![schedule-rooms](https://user-images.githubusercontent.com/153802/38614181-1d7703bc-3d84-11e8-99d6-5ae9ba27444a.png) | ![image](https://user-images.githubusercontent.com/153802/38614189-2487adfa-3d84-11e8-94e4-b1cd8826cb13.png)

![in-out-tracks](https://user-images.githubusercontent.com/153802/38616716-e8e9a862-3d8c-11e8-97b1-ca350ac7fa37.gif)

### Paired with

Nobody