### PR TITLE
Fix text cut in Speaker Details when scrollable

### DIFF
--- a/app/src/main/java/net/squanchy/speaker/widget/SpeakerDetailsLayout.kt
+++ b/app/src/main/java/net/squanchy/speaker/widget/SpeakerDetailsLayout.kt
@@ -1,21 +1,13 @@
 package net.squanchy.speaker.widget
 
 import android.content.Context
+import android.support.constraint.ConstraintLayout
 import android.util.AttributeSet
-import android.widget.LinearLayout
 import kotlinx.android.synthetic.main.activity_speaker_details.view.*
 import net.squanchy.speaker.domain.view.Speaker
 import net.squanchy.support.text.parseHtml
 
-class SpeakerDetailsLayout(context: Context, attrs: AttributeSet) : LinearLayout(context, attrs) {
-
-    init {
-        super.setOrientation(LinearLayout.VERTICAL)
-    }
-
-    override fun setOrientation(orientation: Int): Nothing {
-        throw UnsupportedOperationException("Changing orientation is not supported for SpeakerDetailsLayout")
-    }
+class SpeakerDetailsLayout(context: Context, attrs: AttributeSet) : ConstraintLayout(context, attrs) {
 
     fun updateWith(speaker: Speaker) {
         speakerDetailsHeader.updateWith(speaker)

--- a/app/src/main/java/net/squanchy/speaker/widget/SpeakerHeaderView.kt
+++ b/app/src/main/java/net/squanchy/speaker/widget/SpeakerHeaderView.kt
@@ -1,9 +1,9 @@
 package net.squanchy.speaker.widget
 
 import android.content.Context
+import android.support.constraint.ConstraintLayout
 import android.util.AttributeSet
 import android.view.View
-import android.widget.LinearLayout
 import arrow.core.Option
 import kotlinx.android.synthetic.main.activity_speaker_details.view.*
 import net.squanchy.R
@@ -16,9 +16,8 @@ import net.squanchy.support.unwrapToActivityContext
 class SpeakerHeaderView @JvmOverloads constructor(
     context: Context,
     attrs: AttributeSet,
-    defStyleAttr: Int = 0,
-    defStyleRes: Int = 0
-) : LinearLayout(context, attrs, defStyleAttr, defStyleRes) {
+    defStyleAttr: Int = 0
+) : ConstraintLayout(context, attrs, defStyleAttr) {
 
     private var imageLoader: ImageLoader? = null
 
@@ -27,12 +26,6 @@ class SpeakerHeaderView @JvmOverloads constructor(
             val activity = context.unwrapToActivityContext()
             imageLoader = imageLoaderComponent(activity).imageLoader()
         }
-
-        super.setOrientation(LinearLayout.HORIZONTAL)
-    }
-
-    override fun setOrientation(orientation: Int): Nothing {
-        throw UnsupportedOperationException("Changing orientation is not supported for SpeakerHeaderView")
     }
 
     fun updateWith(speaker: Speaker) {

--- a/app/src/main/res/layout/activity_speaker_details.xml
+++ b/app/src/main/res/layout/activity_speaker_details.xml
@@ -4,12 +4,16 @@
   xmlns:tools="http://schemas.android.com/tools"
   android:id="@+id/speakerDetailsLayout"
   android:layout_width="match_parent"
-  android:layout_height="wrap_content">
+  android:layout_height="match_parent">
 
   <android.support.design.widget.AppBarLayout
+    android:id="@+id/appbar"
     android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"
-    android:layout_width="match_parent"
-    android:layout_height="wrap_content">
+    android:layout_width="@dimen/match_constraint"
+    android:layout_height="wrap_content"
+    app:layout_constraintStart_toStartOf="parent"
+    app:layout_constraintEnd_toEndOf="parent"
+    app:layout_constraintTop_toTopOf="parent">
 
     <android.support.v7.widget.Toolbar
       android:id="@+id/toolbar"
@@ -29,31 +33,30 @@
         style="@style/SpeakerDetails.Header.Speaker.Photo"
         android:layout_width="@dimen/speaker_details_speaker_photo"
         android:layout_height="@dimen/speaker_details_speaker_photo"
-        android:layout_gravity="start|center_vertical"
-        android:layout_marginEnd="@dimen/speaker_details_speaker_photo_margin_end"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
         tools:src="?colorAccent" />
 
-      <LinearLayout
-        android:layout_width="match_parent"
+      <TextView
+        android:id="@+id/speakerName"
+        style="@style/SpeakerDetails.Header.Speaker.Name"
+        android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_gravity="fill_horizontal|center_vertical"
-        android:orientation="vertical">
+        android:layout_marginStart="@dimen/speaker_details_speaker_photo_margin_end"
+        app:layout_constraintTop_toTopOf="@+id/speakerPhoto"
+        app:layout_constraintStart_toEndOf="@+id/speakerPhoto"
+        app:layout_constraintBottom_toTopOf="@+id/speakerCompany"
+        app:layout_constraintVertical_chainStyle="packed"
+        tools:text="Qi Qu" />
 
-        <TextView
-          android:id="@+id/speakerName"
-          style="@style/SpeakerDetails.Header.Speaker.Name"
-          android:layout_width="wrap_content"
-          android:layout_height="wrap_content"
-          tools:text="Qi Qu" />
-
-        <TextView
-          android:id="@+id/speakerCompany"
-          style="@style/SpeakerDetails.Header.Speaker.Company"
-          android:layout_width="wrap_content"
-          android:layout_height="wrap_content"
-          tools:text="Novoda" />
-
-      </LinearLayout>
+      <TextView
+        android:id="@+id/speakerCompany"
+        style="@style/SpeakerDetails.Header.Speaker.Company"
+        android:layout_width="wrap_content"
+        android:layout_height="0dp"
+        app:layout_constraintTop_toBottomOf="@+id/speakerName"
+        app:layout_constraintStart_toStartOf="@+id/speakerName"
+        tools:text="Novoda" />
 
     </net.squanchy.speaker.widget.SpeakerHeaderView>
 
@@ -61,17 +64,19 @@
 
   <android.support.v4.widget.NestedScrollView
     style="@style/SpeakerDetails.Bio"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_width="@dimen/match_constraint"
+    android:layout_height="@dimen/match_constraint"
+    app:layout_constraintStart_toStartOf="parent"
+    app:layout_constraintEnd_toEndOf="parent"
+    app:layout_constraintTop_toBottomOf="@+id/appbar"
+    app:layout_constraintBottom_toBottomOf="parent">
 
     <TextView
       android:id="@+id/speakerBio"
       style="@style/SpeakerDetails.Bio.Text"
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
-      android:layout_marginStart="@dimen/speaker_details_bio_padding"
-      android:layout_marginTop="@dimen/speaker_details_bio_padding"
-      android:layout_marginEnd="@dimen/speaker_details_bio_padding"
+      android:padding="@dimen/speaker_details_bio_padding_horizontal"
       tools:text="Now this is a story all about how\nMy life got flipped-turned upside down\nAnd I'd like to take a minute\nJust sit right there\nI'll tell you how I became the prince of a town called Bel-Air" />
 
   </android.support.v4.widget.NestedScrollView>

--- a/app/src/main/res/layout/activity_speaker_details.xml
+++ b/app/src/main/res/layout/activity_speaker_details.xml
@@ -53,7 +53,7 @@
         android:id="@+id/speakerCompany"
         style="@style/SpeakerDetails.Header.Speaker.Company"
         android:layout_width="wrap_content"
-        android:layout_height="0dp"
+        android:layout_height="@dimen/match_constraint"
         app:layout_constraintTop_toBottomOf="@+id/speakerName"
         app:layout_constraintStart_toStartOf="@+id/speakerName"
         tools:text="Novoda" />

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -92,7 +92,8 @@
   <dimen name="speaker_details_speaker_margin_start">32dp</dimen>
   <dimen name="speaker_details_speaker_margin_bottom">8dp</dimen>
   <dimen name="speaker_details_bio">14sp</dimen>
-  <dimen name="speaker_details_bio_padding">32dp</dimen>
+  <dimen name="speaker_details_bio_padding_horizontal">32dp</dimen>
+  <dimen name="speaker_details_bio_padding_vertical">48dp</dimen>
   <dimen name="speaker_details_bio_line_spacing_extra">4sp</dimen>
 
   <dimen name="venue_info_content_padding_horizontal">16dp</dimen>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -341,15 +341,15 @@
   </style>
 
   <style name="SpeakerDetails.Bio" parent="None">
-    <item name="android:requiresFadingEdge">vertical</item>
-    <item name="android:fadingEdgeLength">64dp</item>
     <item name="android:colorBackgroundCacheHint">@color/white</item>
+    <item name="android:fadingEdgeLength">@dimen/speaker_details_bio_padding_vertical</item>
+    <item name="android:requiresFadingEdge">vertical</item>
   </style>
 
   <style name="SpeakerDetails.Bio.Text" parent="None">
     <item name="android:lineSpacingExtra">@dimen/speaker_details_bio_line_spacing_extra</item>
     <item name="android:lineSpacingMultiplier">1</item>
-    <item name="android:paddingBottom">@dimen/speaker_details_bio_padding</item>
+    <item name="android:paddingBottom">@dimen/speaker_details_bio_padding_vertical</item>
     <item name="android:textAppearance">@style/TextAppearance.Squanchy.SpeakerDetails.Bio</item>
   </style>
 


### PR DESCRIPTION
## Problem

When scrollable the text at the bottom of a speaker bio is cut

## Solution

Convert everything to `ConstraintLayout` which magically fixes it

### Test(s) added

No

### Paired with

Nobody