### PR TITLE
Add @IgnoreExtraProperties to FirestoreEvent and FirestoreDay

### DIFF
--- a/app/src/main/java/net/squanchy/service/firebase/model/schedule/FirestoreSchedule.kt
+++ b/app/src/main/java/net/squanchy/service/firebase/model/schedule/FirestoreSchedule.kt
@@ -1,5 +1,6 @@
 package net.squanchy.service.firebase.model.schedule
 
+import com.google.firebase.firestore.IgnoreExtraProperties
 import java.util.Date
 
 class FirestoreSchedulePage {
@@ -7,11 +8,13 @@ class FirestoreSchedulePage {
     var events: List<FirestoreEvent> = emptyList()
 }
 
+@IgnoreExtraProperties
 class FirestoreDay {
     lateinit var id: String
     lateinit var date: Date
 }
 
+@IgnoreExtraProperties
 class FirestoreEvent {
     lateinit var id: String
     lateinit var title: String


### PR DESCRIPTION
## Problem

`FirestoreEvent` and `FirestoreDay` are missing some fields compared to Firestore's knowledge and it complains. Those are extra fields we don't really care about in the app and the warnings we get in the log because of it are annoying.

## Solution

Add the `@IgnoreExtraProperties` annotation to them.

### Test(s) added

No

### Paired with

Nobody