### PR TITLE
Ensure circular reveal maintains end colour when on SW rendering (P+)

### DIFF
--- a/app/src/main/java/net/squanchy/support/graphics/CircularRevealDrawable.kt
+++ b/app/src/main/java/net/squanchy/support/graphics/CircularRevealDrawable.kt
@@ -8,6 +8,7 @@ import android.graphics.drawable.ColorDrawable
 import android.support.annotation.ColorInt
 import android.support.annotation.IntRange
 import android.support.v4.view.animation.FastOutLinearInInterpolator
+import androidx.animation.doOnEnd
 import me.eugeniomarletti.renderthread.CanvasProperty
 import me.eugeniomarletti.renderthread.RenderThread
 import kotlin.math.max
@@ -80,6 +81,10 @@ class CircularRevealDrawable : ColorDrawable() {
         radiusAnimator = RenderThread.createFloatAnimator(this, canvas, radiusProperty, targetRadius)
         radiusAnimator.interpolator = interpolator
         radiusAnimator.duration = revealDuration.toLong()
+        radiusAnimator.doOnEnd {
+            color = targetColor
+        }
+
         targetColor = pendingTargetColor
     }
 


### PR DESCRIPTION
## Problem

On Android P+, where the `RenderThread` HW-based methods aren't available, `RenderThread` falls back on to regular SW-based which doesn't seem to work correctly.

## Solution

Ensure we actually set the current colour correctly at the end of the animation. That's all.

### Test(s) added

No

### Screenshots

 Before | After
 ------ | -----
 ![reveal-before](https://user-images.githubusercontent.com/153802/38628731-fe70d9c2-3da9-11e8-9bb5-a7a7df7c7bdd.gif) | ![reveal-after](https://user-images.githubusercontent.com/153802/38628729-fe46626e-3da9-11e8-95c6-c99c05e97471.gif)

### Paired with

Nobody