### PR TITLE
Fix voice search crash on Samsung

### DIFF
--- a/app/src/main/java/net/squanchy/search/SearchActivity.kt
+++ b/app/src/main/java/net/squanchy/search/SearchActivity.kt
@@ -211,10 +211,10 @@ class SearchActivity : AppCompatActivity(), SearchRecyclerView.OnSearchResultCli
         searchField.setText("")
     }
 
-    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent) {
+    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
         if (requestCode == SPEECH_REQUEST_CODE && resultCode == Activity.RESULT_OK) {
-            val results = data.getStringArrayListExtra(RecognizerIntent.EXTRA_RESULTS)
-            searchField.setText(results[0])
+            val results = data?.getStringArrayListExtra(RecognizerIntent.EXTRA_RESULTS)
+            if (results != null) searchField.setText(results[0])
             return
         }
         super.onActivityResult(requestCode, resultCode, data)

--- a/app/src/main/java/net/squanchy/signin/SignInActivity.kt
+++ b/app/src/main/java/net/squanchy/signin/SignInActivity.kt
@@ -92,7 +92,7 @@ class SignInActivity : AppCompatActivity() {
         window.setGravity(Gravity.FILL_HORIZONTAL or Gravity.BOTTOM)
     }
 
-    public override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent) {
+    public override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
         super.onActivityResult(requestCode, resultCode, data)
 
         if (requestCode == RC_SIGN_IN) {


### PR DESCRIPTION
## Problem

For [some reason](https://speakerdeck.com/jgilfelt/android-camera-apis?slide=45) the voice search on the Galaxy J7 (2016) running Marshmallow can return a `null` data intent even when reporting a success. We incorrectly have `data: Intent` instead of `data: Intent?` and that makes the app crash.

## Solution

Make the data an `Intent?`. Same preventive fix in `SignInActivity`. No other issues in the project I could find.

### Test(s) added

No

### Paired with

Nobody