### PR TITLE
Add Arrow to FOSS licences

### DIFF
--- a/app/src/main/java/net/squanchy/about/licenses/Libraries.kt
+++ b/app/src/main/java/net/squanchy/about/licenses/Libraries.kt
@@ -6,6 +6,7 @@ internal object Libraries {
             Library("Squanchy", "the Squanchy Contributors", License.APACHE_2),
             Library("Android", "Google Inc. and the Open Handset Alliance", License.APACHE_2),
             Library("Android Support Library", "Google Inc. and the Open Handset Alliance", License.APACHE_2),
+            Library("Λrrow", "The Arrow Authors", License.APACHE_2),
             Library("Dagger", "the Dagger Authors", License.APACHE_2),
             Library("Checkstyle", "the Checkstyle Authors", License.GNU_LGPL_2_1),
             Library("Detekt", "the Detekt contributors", License.APACHE_2),


### PR DESCRIPTION
## Problem

We forgot to add @arrow-kt to the licences screen

## Solution

Add it!

### Test(s) added

Nothing to test

### Screenshots

 Before | After
 ------ | -----
 ![image](https://user-images.githubusercontent.com/153802/38643582-7e547718-3dd5-11e8-9645-a194fdbcc52f.png) | ![image](https://user-images.githubusercontent.com/153802/38643644-bcc21154-3dd5-11e8-8c68-513885c75adf.png)

### Paired with

Nobody