### PR TITLE
Use timezone when formatting non-session event times

### DIFF
--- a/app/src/main/java/net/squanchy/schedule/view/OtherEventItemView.kt
+++ b/app/src/main/java/net/squanchy/schedule/view/OtherEventItemView.kt
@@ -35,10 +35,11 @@ class OtherEventItemView @JvmOverloads constructor(
     }
 
     private fun startTimeAsFormattedString(event: Event): String {
+        val timeZone = event.timeZone
         val formatter = DateTimeFormat.shortTime()
-            .withZone(event.timeZone)
+            .withZone(timeZone)
 
-        return formatter.print(event.startTime.toDateTime())
+        return formatter.print(event.startTime.toDateTime(timeZone))
     }
 
     @DrawableRes


### PR DESCRIPTION
## Problem

We forgot to pass in the timezone when doing `LocalDateTime#toDateTime()` to display start time for the non-talk items, with the result of those times being shown at the local device time instead

## Solution

Pass it in 😅 

### Test(s) added

No but things look ok now

### Paired with

Nobody
