### PR TITLE
SQ-544 / Keep the query variable synced with the searchfield

### DIFF
--- a/app/src/main/java/net/squanchy/search/SearchActivity.kt
+++ b/app/src/main/java/net/squanchy/search/SearchActivity.kt
@@ -192,7 +192,7 @@ class SearchActivity : AppCompatActivity(), SearchRecyclerView.OnSearchResultCli
     }
 
     override fun onSaveInstanceState(outState: Bundle?) {
-        outState?.putString(QUERY_KEY, searchField.text?.toString())
+        outState?.putString(QUERY_KEY, query)
         super.onSaveInstanceState(outState)
     }
 

--- a/app/src/main/java/net/squanchy/search/SearchActivity.kt
+++ b/app/src/main/java/net/squanchy/search/SearchActivity.kt
@@ -55,7 +55,7 @@ class SearchActivity : AppCompatActivity(), SearchRecyclerView.OnSearchResultCli
         enableLightNavigationBar(this)
         setupToolbar()
 
-        query = savedInstanceState?.getString(QUERY_KEY) ?: ""
+        query = savedInstanceState?.getString(QUERY_KEY) ?: INITIAL_QUERY
 
         with(searchComponent(this)) {
             searchService = service()
@@ -196,11 +196,6 @@ class SearchActivity : AppCompatActivity(), SearchRecyclerView.OnSearchResultCli
         super.onSaveInstanceState(outState)
     }
 
-    override fun onRestoreInstanceState(savedInstanceState: Bundle?) {
-        super.onRestoreInstanceState(savedInstanceState)
-        query = savedInstanceState?.getString(QUERY_KEY) ?: ""
-    }
-
     private fun onVoiceSearchClicked() {
         Intent(RecognizerIntent.ACTION_RECOGNIZE_SPEECH).apply {
             putExtra(RecognizerIntent.EXTRA_MAX_RESULTS, 1)
@@ -255,5 +250,6 @@ class SearchActivity : AppCompatActivity(), SearchRecyclerView.OnSearchResultCli
         private const val QUERY_DEBOUNCE_TIMEOUT = 350L
         private const val MIN_QUERY_LENGTH = 2
         private const val QUERY_KEY = "SearchActivity.query_key"
+        private const val INITIAL_QUERY = ""
     }
 }

--- a/app/src/main/java/net/squanchy/search/SearchActivity.kt
+++ b/app/src/main/java/net/squanchy/search/SearchActivity.kt
@@ -46,7 +46,7 @@ class SearchActivity : AppCompatActivity(), SearchRecyclerView.OnSearchResultCli
     private lateinit var searchTextWatcher: SearchTextWatcher
 
     private var hasQuery: Boolean = false
-    private lateinit var initialQuery: String
+    private lateinit var query: String
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -55,7 +55,7 @@ class SearchActivity : AppCompatActivity(), SearchRecyclerView.OnSearchResultCli
         enableLightNavigationBar(this)
         setupToolbar()
 
-        initialQuery = savedInstanceState?.getString(QUERY_KEY) ?: ""
+        query = savedInstanceState?.getString(QUERY_KEY) ?: ""
 
         with(searchComponent(this)) {
             searchService = service()
@@ -78,7 +78,8 @@ class SearchActivity : AppCompatActivity(), SearchRecyclerView.OnSearchResultCli
 
         val searchSubscription = querySubject.throttleLast(QUERY_DEBOUNCE_TIMEOUT, TimeUnit.MILLISECONDS)
             .doOnNext(::updateSearchActionIcon)
-            .startWith(initialQuery)
+            .startWith(query)
+            .doOnNext { query = it }
             .flatMap(searchService::find)
             .distinctUntilChanged()
             .subscribeOn(Schedulers.io())
@@ -193,6 +194,11 @@ class SearchActivity : AppCompatActivity(), SearchRecyclerView.OnSearchResultCli
     override fun onSaveInstanceState(outState: Bundle?) {
         outState?.putString(QUERY_KEY, searchField.text?.toString())
         super.onSaveInstanceState(outState)
+    }
+
+    override fun onRestoreInstanceState(savedInstanceState: Bundle?) {
+        super.onRestoreInstanceState(savedInstanceState)
+        query = savedInstanceState?.getString(QUERY_KEY) ?: ""
     }
 
     private fun onVoiceSearchClicked() {


### PR DESCRIPTION
## Problem

See #544 

## Solution

Introduce a side effect to keep the query variable in the search activity always in sync with the search text field, so that when we stop the activity but don't save the instance state we will not lose it

### Test(s) added

No

### Paired with

Nobody