### PR TITLE
Add default value for the Wifi remote config feature flag

### DIFF
--- a/app/src/main/res/xml/remote_config_defaults.xml
+++ b/app/src/main/res/xml/remote_config_defaults.xml
@@ -6,4 +6,9 @@
     <value>true</value>
   </entry>
 
+  <entry>
+    <key>wifi_config_enabled</key>
+    <value>false</value>
+  </entry>
+
 </defaultsMap>


### PR DESCRIPTION
## Problem

We don't have a default value for the `wifi_config_enabled` key in `RemoteConfig`

## Solution

Add it, ezpz

### Test(s) added

No

### Paired with

Nobody