### PR TITLE
Tweak copy: "wifi" -> "Wi-Fi"

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -68,9 +68,9 @@
   <string name="settings_notifications_about_to_start_summary_on">Show notifications for favorite events starting soon</string>
   <string name="settings_notifications_about_to_start_summary_off">Do not show notifications for favorite events starting soon</string>
   <string name="settings_message_signed_out">You have been signed out.</string>
-  <string name="settings_message_wifi_success">Wifi network successfully configured</string>
+  <string name="settings_message_wifi_success">Wi-Fi network successfully configured</string>
   <string name="about_title">About</string>
-  <string name="auto_wifi_title">Configure wifi</string>
+  <string name="auto_wifi_title">Configure Wi-Fi</string>
   <string name="settings_account_not_signed_in">Not signed in</string>
   <string name="settings_header_not_signed_in">You’re not signed in</string>
   <string name="version_x">Version: %1$s</string>


### PR DESCRIPTION
## Problem

`Wi-Fi` should not be spelled `wifi`, but we have a couple of those in our copy

## Solution

Fix it

### Test(s) added

No

### Paired with

Nobody