### PR TITLE
SQ-550 crash with null data

### DIFF
--- a/app/src/main/java/net/squanchy/schedule/SchedulePageView.kt
+++ b/app/src/main/java/net/squanchy/schedule/SchedulePageView.kt
@@ -10,6 +10,7 @@ import io.reactivex.Observable
 import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.disposables.CompositeDisposable
 import io.reactivex.functions.BiFunction
+import io.reactivex.schedulers.Schedulers
 import kotlinx.android.synthetic.main.view_page_schedule.view.*
 import net.squanchy.R
 import net.squanchy.analytics.Analytics
@@ -89,6 +90,7 @@ class SchedulePageView @JvmOverloads constructor(
     override fun startLoading() {
         subscriptions.add(
             Observable.combineLatest(service.schedule(), featureFlags.showEventRoomInSchedule.toObservable(), combineInPair())
+                .subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(
                     { updateWith(it.first, it.second, ::onEventClicked) },

--- a/app/src/main/java/net/squanchy/service/firebase/FirestoreDbService.kt
+++ b/app/src/main/java/net/squanchy/service/firebase/FirestoreDbService.kt
@@ -2,9 +2,12 @@ package net.squanchy.service.firebase
 
 import com.google.android.gms.tasks.Task
 import com.google.firebase.firestore.DocumentReference
+import com.google.firebase.firestore.DocumentSnapshot
 import com.google.firebase.firestore.FirebaseFirestore
+import com.google.firebase.firestore.QuerySnapshot
 import io.reactivex.Completable
 import io.reactivex.Observable
+import io.reactivex.ObservableEmitter
 import net.squanchy.service.firebase.model.conferenceinfo.FirestoreConferenceInfo
 import net.squanchy.service.firebase.model.conferenceinfo.FirestoreVenue
 import net.squanchy.service.firebase.model.schedule.FirestoreEvent
@@ -15,8 +18,6 @@ import net.squanchy.service.firebase.model.schedule.FirestoreTrack
 import net.squanchy.service.firebase.model.twitter.FirestoreTweet
 import org.joda.time.DateTimeZone
 
-// TODO
-// val onCurrentThread = Executors.newSingleThreadExecutor { Thread.currentThread() }
 class FirestoreDbService(private val db: FirebaseFirestore) {
 
     fun scheduleView(): Observable<List<FirestoreSchedulePage>> {
@@ -24,14 +25,7 @@ class FirestoreDbService(private val db: FirebaseFirestore) {
             val registration = view(VIEW_SCHEDULE)
                 .collection(COLLECTION_SCHEDULE_PAGES)
                 .orderBy(DAY_DATE_SORTING)
-                .addSnapshotListener { snapshot, exception ->
-                    if (exception != null) {
-                        subscriber.onError(exception)
-                        return@addSnapshotListener
-                    }
-
-                    subscriber.onNext(snapshot.documents.map { it.toObject(FirestoreSchedulePage::class.java) })
-                }
+                .addSnapshotListener { snapshot, exception -> subscriber.injectSnapshotResult(snapshot, exception) }
 
             subscriber.setCancellable { registration.remove() }
         }
@@ -42,13 +36,7 @@ class FirestoreDbService(private val db: FirebaseFirestore) {
             val registration = db.collection(SOCIAL_STREAM)
                 .document(VIEW_TWITTER)
                 .collection(COLLECTION_TWEETS)
-                .addSnapshotListener { snapshot, exception ->
-                    if (exception != null && subscriber.isDisposed.not()) {
-                        subscriber.onError(exception)
-                        return@addSnapshotListener
-                    }
-                    subscriber.onNext(snapshot.documents.map { it.toObject(FirestoreTweet::class.java) })
-                }
+                .addSnapshotListener { snapshot, exception -> subscriber.injectSnapshotResult(snapshot, exception) }
 
             subscriber.setCancellable { registration.remove() }
         }
@@ -62,13 +50,7 @@ class FirestoreDbService(private val db: FirebaseFirestore) {
         return Observable.create { subscriber ->
             val registration = db.collection(CONFERENCE_INFO)
                 .document(VENUE)
-                .addSnapshotListener { snapshot, exception ->
-                    if (exception != null && subscriber.isDisposed.not()) {
-                        subscriber.onError(exception)
-                        return@addSnapshotListener
-                    }
-                    subscriber.onNext(snapshot.toObject(FirestoreVenue::class.java))
-                }
+                .addSnapshotListener { snapshot, exception -> subscriber.injectSnapshotResult(snapshot, exception) }
 
             subscriber.setCancellable { registration.remove() }
         }
@@ -78,13 +60,7 @@ class FirestoreDbService(private val db: FirebaseFirestore) {
         return Observable.create { subscriber ->
             val registration = db.collection(CONFERENCE_INFO)
                 .document(CONFERENCE)
-                .addSnapshotListener { snapshot, exception ->
-                    if (exception != null && subscriber.isDisposed.not()) {
-                        subscriber.onError(exception)
-                        return@addSnapshotListener
-                    }
-                    subscriber.onNext(snapshot.toObject(FirestoreConferenceInfo::class.java))
-                }
+                .addSnapshotListener { snapshot, exception -> subscriber.injectSnapshotResult(snapshot, exception) }
 
             subscriber.setCancellable { registration.remove() }
         }
@@ -94,13 +70,7 @@ class FirestoreDbService(private val db: FirebaseFirestore) {
         return Observable.create { subscriber ->
             val registration = view(VIEW_SPEAKERS)
                 .collection(COLLECTION_SPEAKER_PAGES)
-                .addSnapshotListener { snapshot, exception ->
-                    if (exception != null && subscriber.isDisposed.not()) {
-                        subscriber.onError(exception)
-                        return@addSnapshotListener
-                    }
-                    subscriber.onNext(snapshot.documents.map { it.toObject(FirestoreSpeaker::class.java) })
-                }
+                .addSnapshotListener { snapshot, exception -> subscriber.injectSnapshotResult(snapshot, exception) }
 
             subscriber.setCancellable { registration.remove() }
         }
@@ -111,13 +81,7 @@ class FirestoreDbService(private val db: FirebaseFirestore) {
             val registration = view(VIEW_SPEAKERS)
                 .collection(COLLECTION_SPEAKER_PAGES)
                 .document(speakerId)
-                .addSnapshotListener { snapshot, exception ->
-                    if (exception != null && subscriber.isDisposed.not()) {
-                        subscriber.onError(exception)
-                        return@addSnapshotListener
-                    }
-                    subscriber.onNext(snapshot.toObject(FirestoreSpeaker::class.java))
-                }
+                .addSnapshotListener { snapshot, exception -> subscriber.injectSnapshotResult(snapshot, exception) }
 
             subscriber.setCancellable { registration.remove() }
         }
@@ -127,13 +91,7 @@ class FirestoreDbService(private val db: FirebaseFirestore) {
         return Observable.create { subscriber ->
             val registration = view(VIEW_EVENT_DETAILS)
                 .collection(COLLECTION_EVENTS)
-                .addSnapshotListener { snapshot, exception ->
-                    if (exception != null && subscriber.isDisposed.not()) {
-                        subscriber.onError(exception)
-                        return@addSnapshotListener
-                    }
-                    subscriber.onNext(snapshot.documents.map { it.toObject(FirestoreEvent::class.java) })
-                }
+                .addSnapshotListener { snapshot, exception -> subscriber.injectSnapshotResult(snapshot, exception) }
 
             subscriber.setCancellable { registration.remove() }
         }
@@ -144,13 +102,7 @@ class FirestoreDbService(private val db: FirebaseFirestore) {
             val registration = view(VIEW_EVENT_DETAILS)
                 .collection(COLLECTION_EVENTS)
                 .document(eventId)
-                .addSnapshotListener { snapshot, exception ->
-                    if (exception != null && subscriber.isDisposed.not()) {
-                        subscriber.onError(exception)
-                        return@addSnapshotListener
-                    }
-                    subscriber.onNext(snapshot.toObject(FirestoreEvent::class.java))
-                }
+                .addSnapshotListener { snapshot, exception -> subscriber.injectSnapshotResult(snapshot, exception) }
 
             subscriber.setCancellable { registration.remove() }
         }
@@ -160,15 +112,7 @@ class FirestoreDbService(private val db: FirebaseFirestore) {
         return Observable.create { subscriber ->
             val registration = view(VIEW_TRACKS)
                 .collection(COLLECTION_TRACKS)
-                .addSnapshotListener { snapshot, exception ->
-                    if (exception != null && subscriber.isDisposed.not()) {
-                        subscriber.onError(exception)
-                        return@addSnapshotListener
-                    }
-                    subscriber.onNext(snapshot.documents.map { trackSnapshot ->
-                        trackSnapshot.toObject(FirestoreTrack::class.java)
-                    })
-                }
+                .addSnapshotListener { snapshot, exception -> subscriber.injectSnapshotResult(snapshot, exception) }
 
             subscriber.setCancellable { registration.remove() }
         }
@@ -181,15 +125,7 @@ class FirestoreDbService(private val db: FirebaseFirestore) {
             val registration = db.collection(USER_DATA)
                 .document(userId)
                 .collection(COLLECTION_FAVORITES)
-                .addSnapshotListener { snapshot, exception ->
-                    if (exception != null && subscriber.isDisposed.not()) {
-                        subscriber.onError(exception)
-                        return@addSnapshotListener
-                    }
-                    subscriber.onNext(snapshot.documents.map { favoriteSnapshot ->
-                        favoriteSnapshot.toObject(FirestoreFavorite::class.java)
-                    })
-                }
+                .addSnapshotListener { snapshot, exception -> subscriber.injectSnapshotResult(snapshot, exception) }
 
             subscriber.setCancellable(registration::remove)
         }
@@ -251,3 +187,42 @@ class FirestoreDbService(private val db: FirebaseFirestore) {
         private const val DAY_DATE_SORTING = "day.date"
     }
 }
+
+@Suppress("TooGenericExceptionCaught") // Firestore doesn't have a strong Exception typing
+private inline fun <reified T> ObservableEmitter<List<T>>.injectSnapshotResult(snapshot: QuerySnapshot?, exception: Exception?) {
+    when {
+        exception != null && isDisposed.not() -> {
+            onError(exception)
+            return
+        }
+        else -> {
+            try {
+                onNext(snapshot?.toObjects(T::class.java)?.toList() ?: emptyList())
+            } catch (e: RuntimeException) {
+                onError(e)
+            }
+        }
+    }
+}
+
+@Suppress("TooGenericExceptionCaught") // Firestore doesn't have a strong Exception typing
+private inline fun <reified T> ObservableEmitter<T>.injectSnapshotResult(snapshot: DocumentSnapshot?, exception: Exception?) {
+    when {
+        exception != null && isDisposed.not() -> {
+            onError(exception)
+            return
+        }
+        snapshot?.exists() == true -> {
+            try {
+                onNext(snapshot.toObject(T::class.java))
+            } catch (e: RuntimeException) {
+                onError(e)
+            }
+        }
+        else -> onError(NonExistingDocumentException(snapshot))
+    }
+}
+
+private class NonExistingDocumentException(snapshot: DocumentSnapshot?) : RuntimeException(
+    "The specified path does not exist on the DB: ${snapshot?.reference?.path ?: "[null snapshot]"}"
+)


### PR DESCRIPTION
## Problem

Crashlytics tells us the app sometimes emits `null` into the pipeline because `Firestore` doesn't throw when deserializing in some cases but instead returns a fancy `null`.

## Solution

Make sure we emit errors when the data we're trying to get is returned as `null` by Firestore. Closes #550 

### Test(s) added

No, ensured tests still pass.

### Paired with

Nobody