### PR TITLE
Fixing elevation clipping for Sign-in button in Favourites screen

### DIFF
--- a/app/src/main/res/layout/view_page_favorites.xml
+++ b/app/src/main/res/layout/view_page_favorites.xml
@@ -24,6 +24,8 @@
   <FrameLayout
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:clipChildren="false"
+    android:clipToPadding="false"
     app:layout_behavior="@string/appbar_scrolling_view_behavior">
 
     <net.squanchy.favorites.view.FavoritesSignedInEmptyLayout
@@ -47,6 +49,8 @@
       android:layout_gravity="center"
       android:layout_marginStart="@dimen/favorites_empty_margin_horizontal"
       android:layout_marginEnd="@dimen/favorites_empty_margin_horizontal"
+      android:clipChildren="false"
+      android:clipToPadding="false"
       android:gravity="center"
       android:orientation="vertical"
       android:visibility="gone">


### PR DESCRIPTION
## Problem

The `Sign in` button's shadow in the Favourites page is partially clipped.

## Solution

Just making sure parent containers are not clipping their children,

### Test(s) added

N/A

### Screenshots

 Before | After
 ------ | -----
![screen-1523618144](https://user-images.githubusercontent.com/3001957/38731995-cfac5b74-3f1c-11e8-8ffe-d0e70499b44f.png) | ![screen-1523597840](https://user-images.githubusercontent.com/3001957/38731949-9d804c82-3f1c-11e8-88a4-b4757d071576.png)



### Paired with

Nobody
