### PR TITLE
Removing a useless CardLayout from the Venue page

### DIFF
--- a/app/src/main/res/layout/view_page_venue.xml
+++ b/app/src/main/res/layout/view_page_venue.xml
@@ -24,15 +24,10 @@
     android:layout_height="match_parent"
     android:clipToPadding="false"
     android:paddingBottom="@dimen/venue_info_content_padding_bottom"
+    android:background="@color/white"
     app:layout_behavior="@string/appbar_scrolling_view_behavior" >
 
-    <net.squanchy.support.widget.CardLayout
-      android:layout_width="match_parent"
-      android:layout_height="wrap_content">
-
-      <include layout="@layout/merge_venue_info_layout" />
-
-    </net.squanchy.support.widget.CardLayout>
+    <include layout="@layout/merge_venue_info_layout" />
 
   </android.support.v4.widget.NestedScrollView>
 


### PR DESCRIPTION
## Problem

Looks like there is a not-needed `CardLayout` inside the _Venue_ page (it also casts a shadow at the bottom of the page.

## Solution

Just removed it (this will flatten the layout and remove the shadow). Unfortunately, I can't test with real data so please give it a try :)

### Test(s) added

N/A

### Screenshots

 Before | After
 ------ | -----
![screen-1523618260](https://user-images.githubusercontent.com/3001957/38733197-4e2282d6-3f21-11e8-886d-bd37bf30efdd.png) | ![screen-1523619457](https://user-images.githubusercontent.com/3001957/38733189-466424be-3f21-11e8-9d77-6d2152b9bb6a.png)

### Paired with

"Nobody"
