### PR TITLE
Replacing the FAB hearth icon with an AVD (hearth fill and break)

### DIFF
--- a/app/src/main/java/net/squanchy/eventdetails/widget/EventDetailsCoordinatorLayout.kt
+++ b/app/src/main/java/net/squanchy/eventdetails/widget/EventDetailsCoordinatorLayout.kt
@@ -21,11 +21,10 @@ class EventDetailsCoordinatorLayout @JvmOverloads constructor(
         eventDetailsLayout.updateWith(event)
 
         if (canBeFavorited(event)) {
-            favoriteFab.setImageResource(
-                    if (event.favorited)
-                        R.drawable.ic_favorite_filled
-                    else R.drawable.ic_favorite_empty
-            )
+            // Updates the FAB image state to trigger an AVD animation.
+            val stateSet = intArrayOf(android.R.attr.state_checked * if (event.favorited) 1 else -1)
+            favoriteFab.setImageState(stateSet, true)
+
             favoriteFab.setOnClickListener { listener.onFavoriteClick() }
             favoriteFab.visibility = View.VISIBLE
         } else {

--- a/app/src/main/java/net/squanchy/favorites/view/FavoritesSignedInEmptyLayout.kt
+++ b/app/src/main/java/net/squanchy/favorites/view/FavoritesSignedInEmptyLayout.kt
@@ -2,7 +2,6 @@ package net.squanchy.favorites.view
 
 import android.content.Context
 import android.os.Build
-import android.support.annotation.DrawableRes
 import android.support.annotation.RequiresApi
 import android.support.design.widget.Snackbar
 import android.text.Html
@@ -39,20 +38,20 @@ class FavoritesSignedInEmptyLayout @JvmOverloads constructor(
         this.counter = counter
     }
 
-    override fun setButtonImage(@DrawableRes resId: Int) = favoriteFab.setImageResource(resId)
+    override fun setButtonState(favorited: Boolean) {
+        // Updates the FAB image state to trigger an AVD animation.
+        val stateSet = intArrayOf(android.R.attr.state_checked * if (favorited) 1 else -1)
+        favoriteFab.setImageState(stateSet, true)
+    }
 
     //TODO do we still need this? Also why is it requiring Nougat?
     @RequiresApi(Build.VERSION_CODES.N)
     override fun showAchievement(message: String) = Snackbar.make(this, readAsHtml(message), Snackbar.LENGTH_LONG).show()
 
     private val favoriteButtonClickListener = View.OnClickListener {
-        presentButtonIcon(counter, this, ::favoritesFilledIconId, ::favoritesEmptyIconId)
+        presentButtonIcon(counter, this)
         presentAchievementMessage(counter, this, ::initialAchieventMessage, ::perseveranceAchievementMessage)
     }
-
-    private fun favoritesFilledIconId() = R.drawable.ic_favorite_filled
-
-    private fun favoritesEmptyIconId() = R.drawable.ic_favorite_empty
 
     private fun initialAchieventMessage() = resources.getString(R.string.favorites_achievement_fast_learner)
 

--- a/app/src/main/java/net/squanchy/favorites/view/FavoritesSignedInEmptyLayoutPresenter.kt
+++ b/app/src/main/java/net/squanchy/favorites/view/FavoritesSignedInEmptyLayoutPresenter.kt
@@ -4,12 +4,11 @@ private const val TAPS_TO_TRIGGER_INITIAL_ACHIEVEMENT = 5
 private const val TAPS_TO_TRIGGER_PERSEVERANCE_ACHIEVEMENT = 15
 
 private typealias AchievementMessageProvider = () -> String
-private typealias ResIdProvider = () -> Int
 
-internal fun presentButtonIcon(counter: Int, view: FavoritesSignedInEmptyLayoutView, filledIconId: ResIdProvider, emptyIconId: ResIdProvider) {
-
-    if (counter % 2 == 0) view.setButtonImage(filledIconId()) else view.setButtonImage(emptyIconId())
-}
+internal fun presentButtonIcon(
+    counter: Int,
+    view: FavoritesSignedInEmptyLayoutView
+) = view.setButtonState(counter % 2 == 0)
 
 internal fun presentAchievementMessage(
     counter: Int,

--- a/app/src/main/java/net/squanchy/favorites/view/FavoritesSignedInEmptyLayoutView.kt
+++ b/app/src/main/java/net/squanchy/favorites/view/FavoritesSignedInEmptyLayoutView.kt
@@ -1,12 +1,10 @@
 package net.squanchy.favorites.view
 
-import android.support.annotation.DrawableRes
-
 interface FavoritesSignedInEmptyLayoutView {
 
     fun updateCounter(counter: Int)
 
-    fun setButtonImage(@DrawableRes resId: Int)
+    fun setButtonState(favorited: Boolean)
 
     fun showAchievement(message: String)
 }

--- a/app/src/main/res/animator/animset_ic_favorite_draw_stroke.xml
+++ b/app/src/main/res/animator/animset_ic_favorite_draw_stroke.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<set xmlns:android="http://schemas.android.com/apk/res/android">
+
+  <!-- First reset state as the animation is delayed. -->
+  <objectAnimator
+    android:duration="0"
+    android:propertyName="trimPathEnd"
+    android:valueFrom="0"
+    android:valueTo="0"/>
+
+  <objectAnimator
+    android:duration="0"
+    android:propertyName="strokeAlpha"
+    android:valueFrom="0.4"
+    android:valueTo="0.4"/>
+
+  <!-- Now trim-reveal & fade in the heart path. -->
+  <objectAnimator
+    android:duration="300"
+    android:interpolator="@android:interpolator/fast_out_slow_in"
+    android:propertyName="trimPathEnd"
+    android:startOffset="400"
+    android:valueFrom="0"
+    android:valueTo="1"/>
+
+  <objectAnimator
+    android:duration="300"
+    android:interpolator="@android:interpolator/fast_out_slow_in"
+    android:propertyName="strokeAlpha"
+    android:startOffset="400"
+    android:valueFrom="0.4"
+    android:valueTo="1"/>
+
+</set>

--- a/app/src/main/res/animator/animset_ic_favorite_fade_out.xml
+++ b/app/src/main/res/animator/animset_ic_favorite_fade_out.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<set
+  xmlns:android="http://schemas.android.com/apk/res/android"
+  android:ordering="sequentially">
+
+  <!-- First reset state. -->
+  <objectAnimator
+    android:duration="0"
+    android:propertyName="fillAlpha"
+    android:valueFrom="1"
+    android:valueTo="1"/>
+
+  <objectAnimator
+    android:duration="300"
+    android:interpolator="@android:interpolator/linear_out_slow_in"
+    android:propertyName="fillAlpha"
+    android:startOffset="100"
+    android:valueFrom="1"
+    android:valueTo="0"/>
+
+</set>

--- a/app/src/main/res/drawable/animselector_ic_favorite.xml
+++ b/app/src/main/res/drawable/animselector_ic_favorite.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<animated-selector xmlns:android="http://schemas.android.com/apk/res/android">
+
+  <!-- Animated selector for the Favourite FAB icon -->
+
+  <item
+    android:id="@+id/liked"
+    android:drawable="@drawable/ic_favorite_filled"
+    android:state_checked="true"/>
+
+  <item
+    android:id="@+id/not_liked"
+    android:drawable="@drawable/ic_favorite_empty"/>
+
+  <transition
+    android:drawable="@drawable/avd_ic_favorite_fill"
+    android:fromId="@id/not_liked"
+    android:toId="@id/liked"/>
+
+  <transition
+    android:drawable="@drawable/avd_ic_favorite_break"
+    android:fromId="@id/liked"
+    android:toId="@id/not_liked"/>
+
+</animated-selector>

--- a/app/src/main/res/drawable/avd_ic_favorite_break.xml
+++ b/app/src/main/res/drawable/avd_ic_favorite_break.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="utf-8"?>
+<animated-vector
+  xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:aapt="http://schemas.android.com/aapt"
+  android:drawable="@drawable/ic_favorite_break">
+
+  <!-- Rotate and fade out the left half. -->
+  <target android:name="broken_heart_left_group">
+    <aapt:attr name="android:animation">
+      <objectAnimator
+        android:duration="400"
+        android:interpolator="@android:interpolator/linear_out_slow_in"
+        android:propertyName="rotation"
+        android:valueFrom="0"
+        android:valueTo="-20"/>
+    </aapt:attr>
+  </target>
+
+  <target
+    android:name="broken_heart_left"
+    android:animation="@animator/animset_ic_favorite_fade_out"/>
+
+  <!-- Rotate and fade out the right half. -->
+  <target android:name="broken_heart_right_group">
+    <aapt:attr name="android:animation">
+      <objectAnimator
+        android:duration="400"
+        android:interpolator="@android:interpolator/linear_out_slow_in"
+        android:propertyName="rotation"
+        android:valueFrom="0"
+        android:valueTo="20"/>
+    </aapt:attr>
+  </target>
+
+  <target
+    android:name="broken_heart_right"
+    android:animation="@animator/animset_ic_favorite_fade_out"/>
+
+  <!-- Re-draw the strokes. -->
+  <target
+    android:name="heart_stroke_left_atrium"
+    android:animation="@animator/animset_ic_favorite_draw_stroke"/>
+
+  <target
+    android:name="heart_stroke_right_atrium"
+    android:animation="@animator/animset_ic_favorite_draw_stroke"/>
+
+</animated-vector>

--- a/app/src/main/res/drawable/avd_ic_favorite_fill.xml
+++ b/app/src/main/res/drawable/avd_ic_favorite_fill.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<animated-vector
+  xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:aapt="http://schemas.android.com/aapt"
+  android:drawable="@drawable/ic_favorite_filled">
+
+  <!-- Fill the hearth -->
+  <target android:name="clip">
+    <aapt:attr name="android:animation">
+      <objectAnimator
+        android:duration="@android:integer/config_mediumAnimTime"
+        android:interpolator="@android:interpolator/fast_out_slow_in"
+        android:propertyName="pathData"
+        android:valueFrom="M18 37 L38 37 L38 37 L18 37 Z"
+        android:valueTo="M0 0 L56 0 L56 56 L0 56 Z"
+        android:valueType="pathType"/>
+    </aapt:attr>
+  </target>
+
+</animated-vector>

--- a/app/src/main/res/drawable/ic_favorite_break.xml
+++ b/app/src/main/res/drawable/ic_favorite_break.xml
@@ -1,0 +1,50 @@
+<vector
+  xmlns:android="http://schemas.android.com/apk/res/android"
+  android:width="48dp"
+  android:height="48dp"
+  android:tint="?attr/colorControlNormal"
+  android:viewportHeight="56"
+  android:viewportWidth="56">
+
+  <!-- Stroked heart, 2 paths so can 'draw' them concurrently by animating trim. Initially hidden -->
+  <path
+    android:name="heart_stroke_left_atrium"
+    android:pathData="M28.7194825,38.2960196 L25.6688233,35.5523072 C21.6213379,31.793335 18.0159912,28.8906251 18.0159912,24.845337 C18.0159912,21.5882568 20.6305373,19.9651315 23.6337891,19.9651442 C24.9985352,19.96515 26.7993165,21.180664 28.643982,23.1297608"
+    android:strokeColor="@android:color/white"
+    android:strokeWidth="2"
+    android:trimPathEnd="0"/>
+
+  <path
+    android:name="heart_stroke_right_atrium"
+    android:pathData="M27.2310342,38.2944327 L30.7645263,35.2004395 C34.8336142,31.2354829 37.751709,29.1181308 38.0040283,25.0838624 C38.1681943,22.4590544 35.7730552,20.034668 33.3791503,20.034668 C30.4320068,20.034668 29.671997,21.0472412 27.2310342,23.1328126"
+    android:strokeColor="@android:color/white"
+    android:strokeWidth="2"
+    android:trimPathEnd="0"/>
+
+  <!-- Left broken heart, need group to set pivot for rotation anim. -->
+  <group
+    android:name="broken_heart_left_group"
+    android:pivotX="28"
+    android:pivotY="37.3">
+
+    <path
+      android:name="broken_heart_left"
+      android:fillColor="@android:color/white"
+      android:pathData="M28.0307583,21.0541825 C28.020455,21.0660803 28.0102021,21.0780196 28,21.09 C26.91,19.81 25.24,19 23.5,19 C20.42,19 18,21.42 18,24.5 C18,28.28 21.4,31.36 26.55,36.03 L28,37.35 L28.0022188,37.3479954 L27.7813721,36.988221 L28.4886923,36.0733956 L27.5061678,34.7635697 L28.7816611,33.0267266 L26.9441528,31.0075072 L29.1486431,28.7245062 L27.1169819,27.143298 L29.1486431,25.0178865 L26.4880371,22.9773849 L28.0307583,21.0541825 L28.0307583,21.0541825 Z"/>
+
+  </group>
+
+  <!-- Right broken heart. -->
+  <group
+    android:name="broken_heart_right_group"
+    android:pivotX="28"
+    android:pivotY="37.3">
+
+    <path
+      android:name="broken_heart_right"
+      android:fillColor="@android:color/white"
+      android:pathData="M28.0307583,21.0541825 C28.1689169,20.8946428 28.3161363,20.7425565 28.4714083,20.5985959 L28.9146818,20.226173 C29.9263704,19.4567073 31.193451,19 32.5,19 C35.58,19 38,21.42 38,24.5 C38,28.28 34.6,31.36 29.45,36.04 L28.0022188,37.3479954 L27.7813721,36.988221 L28.4886923,36.0733956 L27.5061678,34.7635697 L28.7816611,33.0267266 L26.9441528,31.0075072 L29.1486431,28.7245062 L27.1169819,27.143298 L29.1486431,25.0178865 L26.4880371,22.9773849 L28.0307583,21.0541825 L28.0307583,21.0541825 Z"/>
+
+  </group>
+
+</vector>

--- a/app/src/main/res/drawable/ic_favorite_empty.xml
+++ b/app/src/main/res/drawable/ic_favorite_empty.xml
@@ -1,9 +1,19 @@
-<vector xmlns:android="http://schemas.android.com/apk/res/android"
-  android:width="24dp"
-  android:height="24dp"
-  android:viewportWidth="24.0"
-  android:viewportHeight="24.0">
+<vector
+  xmlns:android="http://schemas.android.com/apk/res/android"
+  android:width="48dp"
+  android:height="48dp"
+  android:tint="?attr/colorControlNormal"
+  android:viewportHeight="56"
+  android:viewportWidth="56">
+
   <path
-    android:fillColor="?colorControlNormal"
-    android:pathData="M16.5,3c-1.74,0 -3.41,0.81 -4.5,2.09C10.91,3.81 9.24,3 7.5,3 4.42,3 2,5.42 2,8.5c0,3.78 3.4,6.86 8.55,11.54L12,21.35l1.45,-1.32C18.6,15.36 22,12.28 22,8.5 22,5.42 19.58,3 16.5,3zM12.1,18.55l-0.1,0.1 -0.1,-0.1C7.14,14.24 4,11.39 4,8.5 4,6.5 5.5,5 7.5,5c1.54,0 3.04,0.99 3.57,2.36h1.87C13.46,5.99 14.96,5 16.5,5c2,0 3.5,1.5 3.5,3.5 0,2.89 -3.14,5.74 -7.9,10.05z" />
+    android:pathData="M28.7194825,38.2960196 L25.6688233,35.5523072 C21.6213379,31.793335 18.0159912,28.8906251 18.0159912,24.845337 C18.0159912,21.5882568 20.6305373,19.9651315 23.6337891,19.9651442 C24.9985352,19.96515 26.7993165,21.180664 28.643982,23.1297608"
+    android:strokeColor="@android:color/white"
+    android:strokeWidth="2"/>
+
+  <path
+    android:pathData="M27.2310342,38.2944327 L30.7645263,35.2004395 C34.8336142,31.2354829 37.751709,29.1181308 38.0040283,25.0838624 C38.1681943,22.4590544 35.7730552,20.034668 33.3791503,20.034668 C30.4320068,20.034668 29.671997,21.0472412 27.2310342,23.1328126"
+    android:strokeColor="@android:color/white"
+    android:strokeWidth="2"/>
+
 </vector>

--- a/app/src/main/res/drawable/ic_favorite_filled.xml
+++ b/app/src/main/res/drawable/ic_favorite_filled.xml
@@ -1,9 +1,28 @@
-<vector xmlns:android="http://schemas.android.com/apk/res/android"
-  android:width="24dp"
-  android:height="24dp"
-  android:viewportWidth="24.0"
-  android:viewportHeight="24.0">
+<vector
+  xmlns:android="http://schemas.android.com/apk/res/android"
+  android:width="48dp"
+  android:height="48dp"
+  android:tint="?attr/colorControlNormal"
+  android:viewportHeight="56"
+  android:viewportWidth="56">
+
   <path
-    android:fillColor="?colorControlNormal"
-    android:pathData="M12,21.35l-1.45,-1.32C5.4,15.36 2,12.28 2,8.5 2,5.42 4.42,3 7.5,3c1.74,0 3.41,0.81 4.5,2.09C13.09,3.81 14.76,3 16.5,3 19.58,3 22,5.42 22,8.5c0,3.78 -3.4,6.86 -8.55,11.54L12,21.35z" />
+    android:pathData="M28.7194825,38.2960196 L25.6688233,35.5523072 C21.6213379,31.793335 18.0159912,28.8906251 18.0159912,24.845337 C18.0159912,21.5882568 20.6305373,19.9651315 23.6337891,19.9651442 C24.9985352,19.96515 26.7993165,21.180664 28.643982,23.1297608"
+    android:strokeColor="@android:color/white"
+    android:strokeWidth="2"/>
+
+  <path
+    android:pathData="M27.2310342,38.2944327 L30.7645263,35.2004395 C34.8336142,31.2354829 37.751709,29.1181308 38.0040283,25.0838624 C38.1681943,22.4590544 35.7730552,20.034668 33.3791503,20.034668 C30.4320068,20.034668 29.671997,21.0472412 27.2310342,23.1328126"
+    android:strokeColor="@android:color/white"
+    android:strokeWidth="2"/>
+
+  <group android:name="filled">
+    <clip-path
+      android:name="clip"
+      android:pathData="M18 37 L38 37 L38 37 L18 37 Z"/>
+    <path
+      android:fillColor="@android:color/white"
+      android:pathData="M28,39 L26.405,37.5667575 C20.74,32.4713896 17,29.1089918 17,24.9945504 C17,21.6321526 19.6565,19 23.05,19 C24.964,19 26.801,19.8828338 28,21.2724796 C29.199,19.8828338 31.036,19 32.95,19 C36.3435,19 39,21.6321526 39,24.9945504 C39,29.1089918 35.26,32.4713896 29.595,37.5667575 L28,39 L28,39 Z"/>
+  </group>
+
 </vector>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -274,7 +274,8 @@
     <item name="backgroundTint">@color/selector_color_primary</item>
     <item name="android:clickable">true</item>
     <item name="android:foreground">@drawable/white_circle_bound_touch_feedback</item>
-    <item name="android:src">@drawable/ic_favorite_empty</item>
+    <item name="android:src">@drawable/animselector_ic_favorite</item>
+    <item name="android:scaleType">center</item>
   </style>
 
   <style name="Tweets.EmptyView" parent="None">

--- a/app/src/test/java/net/squanchy/favorites/FavoritesSignedInEmptyLayoutPresenterTest.kt
+++ b/app/src/test/java/net/squanchy/favorites/FavoritesSignedInEmptyLayoutPresenterTest.kt
@@ -26,14 +26,13 @@ class FavoritesSignedInEmptyLayoutPresenterTest {
     fun `first time, return counter as 1, icon should be filled and no message displayed`() {
         //given
         val counter = 0
-        val filledIconProvider = { 2 }
 
         //when
-        presentButtonIcon(counter, view, filledIconProvider, { 0 })
+        presentButtonIcon(counter, view)
         presentAchievementMessage(counter, view, { "" }, { "" })
 
         //then
-        verify(view).setButtonImage(filledIconProvider())
+        verify(view).setButtonState(true)
         verify(view).updateCounter(1)
         verify(view, never()).showAchievement(anyString())
         verifyNoMoreInteractions(view)
@@ -43,14 +42,13 @@ class FavoritesSignedInEmptyLayoutPresenterTest {
     fun `when counter is odd, show empty icon`() {
         //given
         val counter = 1
-        val emptyIconProvider = { 4 }
 
         //when
-        presentButtonIcon(counter, view, { 0 }, emptyIconProvider)
+        presentButtonIcon(counter, view)
         presentAchievementMessage(counter, view, { "" }, { "" })
 
         //then
-        verify(view).setButtonImage(emptyIconProvider())
+        verify(view).setButtonState(false)
         verify(view).updateCounter(2)
         verify(view, never()).showAchievement(anyString())
         verifyNoMoreInteractions(view)
@@ -60,15 +58,14 @@ class FavoritesSignedInEmptyLayoutPresenterTest {
     fun `when counter is 4, show filled icon, show initial achievement`() {
         //given
         val counter = 4
-        val filledIconProvider = { 1 }
         val initialMessageProvider = { "initial" }
 
         //when
-        presentButtonIcon(counter, view, filledIconProvider, { 0 })
+        presentButtonIcon(counter, view)
         presentAchievementMessage(counter, view, initialMessageProvider, { "" })
 
         //then
-        verify(view).setButtonImage(filledIconProvider())
+        verify(view).setButtonState(true)
         verify(view).updateCounter(5)
         verify(view).showAchievement(initialMessageProvider())
         verifyNoMoreInteractions(view)
@@ -78,15 +75,14 @@ class FavoritesSignedInEmptyLayoutPresenterTest {
     fun `when counter is 14, show filled icon, show perseverant achievement`() {
         //given
         val counter = 14
-        val filledIconProvider = { 1 }
         val perseverantMessageProvider = { "perseverant" }
 
         //when
-        presentButtonIcon(counter, view, filledIconProvider, { 0 })
+        presentButtonIcon(counter, view)
         presentAchievementMessage(counter, view, { "" }, perseverantMessageProvider)
 
         //then
-        verify(view).setButtonImage(filledIconProvider())
+        verify(view).setButtonState(true)
         verify(view).updateCounter(15)
         verify(view).showAchievement(perseverantMessageProvider())
         verifyNoMoreInteractions(view)


### PR DESCRIPTION
## Problem

This is just cooler 😎

## Solution

Replaced the two `VectorDrawables` used for the FAB with an `AnimatedVectorDrawable` that animates between the two states.

### Test(s) added

Updated the tests for `FavoritesSignedInEmptyLayoutPresenterTest`. Found no tests for the other use case (`EventDetailsActivity`).

Can you please check if it works fine with the Event detail screen? Plus we should also check if the button is initialized properly (open an event that you previously liked).

### Screenshots

![ezgif-4-34d8069709](https://user-images.githubusercontent.com/3001957/38746660-75f98bb6-3f48-11e8-9959-dd926ed4f1f7.gif)

### Paired with

"Nobody"
