### PR TITLE
Add favourites in schedule

### DIFF
--- a/app/src/debug/java/net/squanchy/support/debug/DebugActivity.kt
+++ b/app/src/debug/java/net/squanchy/support/debug/DebugActivity.kt
@@ -75,7 +75,7 @@ class DebugActivity : AppCompatActivity() {
             experienceLevel = Option(ExperienceLevel.ADVANCED),
             speakers = createTalkSpeakers(),
             type = Event.Type.TALK,
-            favorited = true,
+            favorite = true,
             description = Option.empty(),
             track = Option(createTrack()),
             timeZone = DateTimeZone.forID("Europe/Rome")

--- a/app/src/main/java/net/squanchy/eventdetails/EventDetailsService.kt
+++ b/app/src/main/java/net/squanchy/eventdetails/EventDetailsService.kt
@@ -33,7 +33,7 @@ internal class EventDetailsService(
     }
 
     private fun toggleFavoriteOn(event: Event): Completable {
-        return if (event.favorited) {
+        return if (event.favorite) {
             removeFavorite(event.id)
         } else {
             favorite(event.id)

--- a/app/src/main/java/net/squanchy/eventdetails/widget/EventDetailsCoordinatorLayout.kt
+++ b/app/src/main/java/net/squanchy/eventdetails/widget/EventDetailsCoordinatorLayout.kt
@@ -22,7 +22,7 @@ class EventDetailsCoordinatorLayout @JvmOverloads constructor(
 
         if (canBeFavorited(event)) {
             favoriteFab.setImageResource(
-                    if (event.favorited)
+                    if (event.favorite)
                         R.drawable.ic_favorite_filled
                     else R.drawable.ic_favorite_empty
             )

--- a/app/src/main/java/net/squanchy/favorites/FavoritesComponent.kt
+++ b/app/src/main/java/net/squanchy/favorites/FavoritesComponent.kt
@@ -9,6 +9,7 @@ import net.squanchy.injection.ApplicationComponent
 import net.squanchy.injection.applicationComponent
 import net.squanchy.navigation.NavigationModule
 import net.squanchy.navigation.Navigator
+import net.squanchy.remoteconfig.FeatureFlags
 
 @ActivityLifecycle
 @Component(modules = [FavoritesModule::class, NavigationModule::class], dependencies = [ApplicationComponent::class])
@@ -19,6 +20,8 @@ internal interface FavoritesComponent {
     fun navigator(): Navigator
 
     fun analytics(): Analytics
+
+    fun featureFlags(): FeatureFlags
 }
 
 internal fun favoritesComponent(activity: AppCompatActivity): FavoritesComponent {

--- a/app/src/main/java/net/squanchy/favorites/FavoritesService.kt
+++ b/app/src/main/java/net/squanchy/favorites/FavoritesService.kt
@@ -33,7 +33,7 @@ internal class FirestoreFavoritesService(
 
     private fun SchedulePage.asFavouritesDayViewModel(): List<FavoritesItem> {
         val eventsAsFavoriteItems = this.events
-            .filter { it.favorited }
+            .filter { it.favorite }
             .map { it.toFavoriteItem() }
 
         if (eventsAsFavoriteItems.isNotEmpty()) {

--- a/app/src/main/java/net/squanchy/favorites/view/FavoritesAdapter.kt
+++ b/app/src/main/java/net/squanchy/favorites/view/FavoritesAdapter.kt
@@ -17,7 +17,8 @@ internal class FavoritesAdapter(
         private const val VIEW_TYPE_HEADER: Int = 2
     }
 
-    lateinit var favoriteClickListener: OnFavoriteClickListener
+    private var favoriteClickListener: OnFavoriteClickListener? = null
+    private var showRoom = false
 
     private val layoutInflater = LayoutInflater.from(context)
 
@@ -50,9 +51,24 @@ internal class FavoritesAdapter(
 
     override fun onBindViewHolder(holder: FavoritesViewHolder<*>, position: Int) {
         when (holder) {
-            is EventViewHolder -> holder.updateWith((getItem(position) as FavoritesItem.Favorite).event, favoriteClickListener)
+            is EventViewHolder -> holder.updateWith((getItem(position) as FavoritesItem.Favorite).event, showRoom, favoriteClickListener)
             is HeaderViewHolder -> holder.updateWith((getItem(position) as FavoritesItem.Header).date)
         }
+    }
+
+    fun updateWith(list: List<FavoritesItem>, showRoom: Boolean, listener: OnFavoriteClickListener) {
+        this.showRoom = showRoom
+        this.favoriteClickListener = listener
+        super.submitList(list)
+    }
+
+    @Deprecated(
+        message = "Use updateWith() instead",
+        replaceWith = ReplaceWith("updateWith(list, showRoom, eventClickListener)"),
+        level = DeprecationLevel.ERROR
+    )
+    override fun submitList(list: MutableList<FavoritesItem>?) {
+        throw UnsupportedOperationException("Use updateWith() instead")
     }
 }
 

--- a/app/src/main/java/net/squanchy/favorites/view/FavoritesListView.kt
+++ b/app/src/main/java/net/squanchy/favorites/view/FavoritesListView.kt
@@ -27,10 +27,8 @@ internal class FavoritesListView @JvmOverloads constructor(
         addItemDecoration(CardSpacingItemDecorator(horizontalSpacing, verticalSpacing))
     }
 
-    fun updateWith(newData: List<FavoritesItem>, listener: OnFavoriteClickListener) {
-        adapter.favoriteClickListener = listener
+    fun updateWith(newData: List<FavoritesItem>, showRoom: Boolean, listener: OnFavoriteClickListener) {
         setAdapterIfNone(adapter)
-
-        adapter.submitList(newData)
+        adapter.updateWith(newData, showRoom, listener)
     }
 }

--- a/app/src/main/java/net/squanchy/favorites/view/FavoritesViewHolders.kt
+++ b/app/src/main/java/net/squanchy/favorites/view/FavoritesViewHolders.kt
@@ -19,7 +19,7 @@ sealed class FavoritesViewHolder<T : View>(itemView: T) : RecyclerView.ViewHolde
 class EventViewHolder(itemView: EventItemView) : FavoritesViewHolder<EventItemView>(itemView) {
 
     fun updateWith(event: Event, listener: OnEventClickListener?) {
-        (itemView as EventItemView).updateWith(event, false) // TODO import the feature flag here as well
+        (itemView as EventItemView).updateWith(event, showRoom = true, showFavorite = false)
         itemView.setOnClickListener { listener?.invoke(event) }
     }
 }

--- a/app/src/main/java/net/squanchy/favorites/view/FavoritesViewHolders.kt
+++ b/app/src/main/java/net/squanchy/favorites/view/FavoritesViewHolders.kt
@@ -18,8 +18,8 @@ sealed class FavoritesViewHolder<T : View>(itemView: T) : RecyclerView.ViewHolde
 
 class EventViewHolder(itemView: EventItemView) : FavoritesViewHolder<EventItemView>(itemView) {
 
-    fun updateWith(event: Event, listener: OnEventClickListener?) {
-        (itemView as EventItemView).updateWith(event, showRoom = true, showFavorite = false)
+    fun updateWith(event: Event, showRoom: Boolean, listener: OnEventClickListener?) {
+        (itemView as EventItemView).updateWith(event, showRoom, showFavorite = false)
         itemView.setOnClickListener { listener?.invoke(event) }
     }
 }

--- a/app/src/main/java/net/squanchy/notification/NotificationService.kt
+++ b/app/src/main/java/net/squanchy/notification/NotificationService.kt
@@ -11,7 +11,7 @@ internal class NotificationService(private val authService: AuthService, private
     fun sortedFavourites(): Observable<List<Event>> {
         return authService.ifUserSignedInThenObservableFrom { userId ->
             eventRepository.events(userId)
-                .map { it.filter { it.favorited } }
+                .map { it.filter { it.favorite } }
                 .map { it.sortedBy { it.startTime } }
                 .take(1)
                 .subscribeOn(Schedulers.io())

--- a/app/src/main/java/net/squanchy/schedule/SchedulePageView.kt
+++ b/app/src/main/java/net/squanchy/schedule/SchedulePageView.kt
@@ -101,6 +101,28 @@ class SchedulePageView @JvmOverloads constructor(
 
     private fun combineInPair(): BiFunction<Schedule, Boolean, Pair<Schedule, Boolean>> = BiFunction(::Pair)
 
+    private fun updateWith(schedule: Schedule, showRoom: Boolean, onEventClicked: (Event) -> Unit) {
+        progressbar.isVisible = false
+
+        if (schedule.isEmpty) {
+            viewpager.isVisible = false
+            tabstrip.isVisible = false
+            emptyView.isVisible = true
+            return
+        }
+
+        viewpager.isVisible = true
+        tabstrip.isVisible = true
+        emptyView.isVisible = false
+
+        viewPagerAdapter.updateWith(schedule.pages, showRoom, onEventClicked)
+        if (viewpager.adapter == null) {
+            viewpager.adapter = viewPagerAdapter
+        }
+
+        progressbar.isVisible = false
+    }
+
     private fun onEventClicked(event: Event) {
         analytics.trackItemSelected(ContentType.SCHEDULE_ITEM, event.id)
         navigate.toEventDetails(event.id)
@@ -128,26 +150,4 @@ class SchedulePageView @JvmOverloads constructor(
     }
 
     private fun hasTypefaceSpan(text: CharSequence?) = (text as? Spanned)?.hasTypefaceSpan() ?: false
-
-    fun updateWith(schedule: Schedule, showRoom: Boolean, onEventClicked: (Event) -> Unit) {
-        progressbar.isVisible = false
-
-        if (schedule.isEmpty) {
-            viewpager.isVisible = false
-            tabstrip.isVisible = false
-            emptyView.isVisible = true
-            return
-        }
-
-        viewpager.isVisible = true
-        tabstrip.isVisible = true
-        emptyView.isVisible = false
-
-        viewPagerAdapter.updateWith(schedule.pages, showRoom, onEventClicked)
-        if (viewpager.adapter == null) {
-            viewpager.adapter = viewPagerAdapter
-        }
-
-        progressbar.isVisible = false
-    }
 }

--- a/app/src/main/java/net/squanchy/schedule/domain/view/Event.kt
+++ b/app/src/main/java/net/squanchy/schedule/domain/view/Event.kt
@@ -18,7 +18,7 @@ data class Event(
     val speakers: List<Speaker>,
     val experienceLevel: Option<ExperienceLevel>,
     val type: Type,
-    val favorited: Boolean,
+    val favorite: Boolean,
     val description: Option<String>,
     val timeZone: DateTimeZone
 ) {

--- a/app/src/main/java/net/squanchy/schedule/view/EventItemView.kt
+++ b/app/src/main/java/net/squanchy/schedule/view/EventItemView.kt
@@ -12,5 +12,5 @@ abstract class EventItemView : CardLayout {
 
     constructor(context: Context, attrs: AttributeSet, defStyleAttr: Int) : super(context, attrs, defStyleAttr)
 
-    abstract fun updateWith(event: Event, showRoom: Boolean = false, showDay: Boolean = false)
+    abstract fun updateWith(event: Event, showRoom: Boolean = false, showDay: Boolean = false, showFavorite: Boolean = true)
 }

--- a/app/src/main/java/net/squanchy/schedule/view/OtherEventItemView.kt
+++ b/app/src/main/java/net/squanchy/schedule/view/OtherEventItemView.kt
@@ -14,7 +14,7 @@ class OtherEventItemView @JvmOverloads constructor(
     defStyleAttr: Int = R.attr.cardViewDefaultStyle
 ) : EventItemView(context, attrs, defStyleAttr) {
 
-    override fun updateWith(event: Event, showRoom: Boolean, showDay: Boolean) {
+    override fun updateWith(event: Event, showRoom: Boolean, showDay: Boolean, showFavorite: Boolean) {
         event.type.ensureSupported()
 
         timestamp.text = startTimeAsFormattedString(event)

--- a/app/src/main/java/net/squanchy/schedule/view/TalkEventItemView.kt
+++ b/app/src/main/java/net/squanchy/schedule/view/TalkEventItemView.kt
@@ -20,7 +20,7 @@ class TalkEventItemView @JvmOverloads constructor(
     private val timeFormatter = DateTimeFormat.shortTime()
     private val dateFormatter = DateTimeFormat.forPattern("EEE d")
 
-    override fun updateWith(event: Event, showRoom: Boolean, showDay: Boolean) {
+    override fun updateWith(event: Event, showRoom: Boolean, showDay: Boolean, showFavorite: Boolean) {
         ensureSupportedType(event.type)
 
         timestamp.text = startTimeAsFormattedString(event, showDay)
@@ -40,7 +40,7 @@ class TalkEventItemView @JvmOverloads constructor(
         speaker_container.visibility = if (event.speakers.isEmpty()) View.GONE else View.VISIBLE
         speaker_container.updateWith(event.speakers, null)
 
-        favoriteIcon.isVisible = event.favorite
+        favoriteIcon.isVisible = if (showFavorite) event.favorite else false
     }
 
     private fun Place?.toPlaceLabel(): CharSequence? = if (this != null) " • ${this.name}" else null

--- a/app/src/main/java/net/squanchy/schedule/view/TalkEventItemView.kt
+++ b/app/src/main/java/net/squanchy/schedule/view/TalkEventItemView.kt
@@ -40,7 +40,7 @@ class TalkEventItemView @JvmOverloads constructor(
         speaker_container.visibility = if (event.speakers.isEmpty()) View.GONE else View.VISIBLE
         speaker_container.updateWith(event.speakers, null)
 
-        favoriteIcon.isVisible = event.favorited
+        favoriteIcon.isVisible = event.favorite
     }
 
     private fun Place?.toPlaceLabel(): CharSequence? = if (this != null) " • ${this.name}" else null

--- a/app/src/main/java/net/squanchy/schedule/view/TalkEventItemView.kt
+++ b/app/src/main/java/net/squanchy/schedule/view/TalkEventItemView.kt
@@ -32,13 +32,15 @@ class TalkEventItemView @JvmOverloads constructor(
 
         if (event.experienceLevel.isDefined()) {
             experience_level.setExperienceLevel(event.experienceLevel.getOrThrow())
-            experience_level.visibility = View.VISIBLE
+            experience_level.isVisible = true
         } else {
-            experience_level.visibility = View.INVISIBLE
+            experience_level.isVisible = false
         }
 
         speaker_container.visibility = if (event.speakers.isEmpty()) View.GONE else View.VISIBLE
         speaker_container.updateWith(event.speakers, null)
+
+        favoriteIcon.isVisible = event.favorited
     }
 
     private fun Place?.toPlaceLabel(): CharSequence? = if (this != null) " • ${this.name}" else null

--- a/app/src/main/java/net/squanchy/service/firebase/FirestoreMappers.kt
+++ b/app/src/main/java/net/squanchy/service/firebase/FirestoreMappers.kt
@@ -59,7 +59,7 @@ fun FirestoreEvent.toEvent(checksum: Checksum, timeZone: DateTimeZone, isFavorit
     experienceLevel = experienceLevel.toExperienceLevel(),
     speakers = speakers.map { it.toSpeaker(checksum) },
     type = type.toEventType(),
-    favorited = isFavorite,
+    favorite = isFavorite,
     description = description.option(),
     track = track?.toTrack(checksum).option(),
     timeZone = timeZone

--- a/app/src/main/res/drawable/ic_avatar_placeholder.xml
+++ b/app/src/main/res/drawable/ic_avatar_placeholder.xml
@@ -2,6 +2,6 @@
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
   android:shape="rectangle">
 
-  <solid android:color="#c9c9c9" />
+  <solid android:color="#dedede" />
 
 </shape>

--- a/app/src/main/res/layout/item_schedule_event_talk.xml
+++ b/app/src/main/res/layout/item_schedule_event_talk.xml
@@ -92,7 +92,8 @@
       android:visibility="gone"
       app:layout_constraintTop_toTopOf="@+id/timestamp"
       app:layout_constraintEnd_toEndOf="parent"
-      app:layout_constraintBottom_toBottomOf="@+id/timestamp" />
+      app:layout_constraintBottom_toBottomOf="@+id/timestamp"
+      tools:visibility="visible" />
 
   </android.support.constraint.ConstraintLayout>
 

--- a/app/src/main/res/layout/item_schedule_event_talk.xml
+++ b/app/src/main/res/layout/item_schedule_event_talk.xml
@@ -68,6 +68,8 @@
       android:layout_marginTop="@dimen/card_timestamp_margin_top"
       app:layout_constraintStart_toStartOf="parent"
       app:layout_constraintTop_toBottomOf="@+id/title"
+      app:layout_constraintEnd_toStartOf="@id/room"
+      app:layout_constraintHorizontal_chainStyle="packed"
       tools:text="12:00" />
 
     <TextView
@@ -80,6 +82,17 @@
       app:layout_constraintBottom_toBottomOf="@+id/timestamp"
       tools:text=" • Main room"
       tools:visibility="visible" />
+
+    <ImageView
+      android:id="@+id/favoriteIcon"
+      android:layout_width="@dimen/card_favourite_size"
+      android:layout_height="@dimen/card_favourite_size"
+      android:src="@drawable/ic_favorite_filled"
+      android:tint="?colorPrimary"
+      android:visibility="gone"
+      app:layout_constraintTop_toTopOf="@+id/timestamp"
+      app:layout_constraintEnd_toEndOf="parent"
+      app:layout_constraintBottom_toBottomOf="@+id/timestamp" />
 
   </android.support.constraint.ConstraintLayout>
 

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -20,6 +20,7 @@
   <dimen name="card_padding_bottom">8dp</dimen>
   <dimen name="card_timestamp">14sp</dimen>
   <dimen name="card_timestamp_margin_top">4dp</dimen>
+  <dimen name="card_favourite_size">20dp</dimen>
   <dimen name="card_experience">12sp</dimen>
   <dimen name="card_experience_corner_radius">2dp</dimen>
   <dimen name="card_experience_padding_horizontal">4dp</dimen>

--- a/app/src/test/java/net/squanchy/FakeAuthService.kt
+++ b/app/src/test/java/net/squanchy/FakeAuthService.kt
@@ -1,0 +1,37 @@
+package net.squanchy
+
+import arrow.core.Option
+import com.google.android.gms.auth.api.signin.GoogleSignInAccount
+import io.reactivex.Completable
+import io.reactivex.Observable
+import net.squanchy.service.repository.AuthService
+import net.squanchy.service.repository.User
+
+class FakeAuthService(
+    private val uid: String = "uid"
+) : AuthService {
+
+    override fun signInWithGoogle(account: GoogleSignInAccount): Completable {
+        TODO("not implemented")
+    }
+
+    override fun <T> ifUserSignedInThenObservableFrom(observable: (String) -> Observable<T>): Observable<T> {
+        return observable(uid)
+    }
+
+    override fun ifUserSignedInThenCompletableFrom(completable: (String) -> Completable): Completable {
+        return completable(uid)
+    }
+
+    override fun currentUser(): Observable<Option<User>> {
+        TODO("not implemented")
+    }
+
+    override fun signOut(): Completable {
+        TODO("not implemented")
+    }
+
+    override fun signInAnonymously(): Completable {
+        TODO("not implemented")
+    }
+}

--- a/app/src/test/java/net/squanchy/favorites/FirestoreFavoritesServiceTest.kt
+++ b/app/src/test/java/net/squanchy/favorites/FirestoreFavoritesServiceTest.kt
@@ -38,9 +38,54 @@ class FirestoreFavoritesServiceTest {
     }
 
     @Test
+    fun `should exclude events that are not favorites`() {
+        val schedule = aSchedule(
+            pages = listOf(
+                aSchedulePage(
+                    date = aDay().date,
+                    events = listOf(
+                        anEvent(id = "day 1 event 1", favorited = true),
+                        anEvent(id = "day 1 event 2", favorited = false),
+                        anEvent(id = "day 1 event 3", favorited = false)
+                    )
+                ),
+                aSchedulePage(
+                    date = aDay().date.plusDays(1),
+                    events = listOf(
+                        anEvent(id = "day 2 event 1", favorited = false),
+                        anEvent(id = "day 2 event 2", favorited = false),
+                        anEvent(id = "day 2 event 3", favorited = false)
+                    )
+                ),
+                aSchedulePage(
+                    date = aDay().date.plusDays(2),
+                    events = listOf(
+                        anEvent(id = "day 3 event 1", favorited = false),
+                        anEvent(id = "day 3 event 2", favorited = true),
+                        anEvent(id = "day 3 event 3", favorited = true)
+                    )
+                )
+            )
+        )
+        `when`(scheduleService.schedule()).thenReturn(Observable.just(schedule))
+
+        favoritesService.favorites()
+            .test()
+            .assertValue(
+                listOf(
+                    aFavoriteHeaderListItem(aDay().date),
+                    aFavoriteItemListItem(anEvent(id = "day 1 event 1", favorited = true)),
+                    aFavoriteHeaderListItem(aDay().date.plusDays(2)),
+                    aFavoriteItemListItem(anEvent(id = "day 3 event 2", favorited = true)),
+                    aFavoriteItemListItem(anEvent(id = "day 3 event 3", favorited = true))
+                )
+            )
+    }
+
+    @Test
     fun `should return an empty list when there are no favorite events`() {
         val schedule = aSchedule(pages = emptyList())
-        `when`(scheduleService.schedule(onlyFavorites = true)).thenReturn(Observable.just(schedule))
+        `when`(scheduleService.schedule()).thenReturn(Observable.just(schedule))
 
         favoritesService.favorites()
             .test()
@@ -53,25 +98,25 @@ class FirestoreFavoritesServiceTest {
             pages = listOf(
                 aSchedulePage(
                     date = aDay().date,
-                    events = listOf(anEvent(id = "day 1 event 1"), anEvent(id = "day 1 event 2"))
+                    events = listOf(anEvent(id = "day 1 event 1", favorited = true), anEvent(id = "day 1 event 2", favorited = true))
                 ),
                 aSchedulePage(
                     date = aDay().date.plusDays(1),
-                    events = listOf(anEvent(id = "day 2 event 1"))
+                    events = listOf(anEvent(id = "day 2 event 1", favorited = true))
                 )
             )
         )
-        `when`(scheduleService.schedule(onlyFavorites = true)).thenReturn(Observable.just(schedule))
+        `when`(scheduleService.schedule()).thenReturn(Observable.just(schedule))
 
         favoritesService.favorites()
             .test()
             .assertValue(
                 listOf(
                     aFavoriteHeaderListItem(aDay().date),
-                    aFavoriteItemListItem(anEvent(id = "day 1 event 1")),
-                    aFavoriteItemListItem(anEvent(id = "day 1 event 2")),
+                    aFavoriteItemListItem(anEvent(id = "day 1 event 1", favorited = true)),
+                    aFavoriteItemListItem(anEvent(id = "day 1 event 2", favorited = true)),
                     aFavoriteHeaderListItem(aDay().date.plusDays(1)),
-                    aFavoriteItemListItem(anEvent(id = "day 2 event 1"))
+                    aFavoriteItemListItem(anEvent(id = "day 2 event 1", favorited = true))
                 )
             )
     }
@@ -83,7 +128,7 @@ class FirestoreFavoritesServiceTest {
                 aSchedulePage(events = emptyList())
             )
         )
-        `when`(scheduleService.schedule(onlyFavorites = true)).thenReturn(Observable.just(schedule))
+        `when`(scheduleService.schedule()).thenReturn(Observable.just(schedule))
 
         favoritesService.favorites()
             .test()

--- a/app/src/test/java/net/squanchy/schedule/domain/view/ScheduleFixtures.kt
+++ b/app/src/test/java/net/squanchy/schedule/domain/view/ScheduleFixtures.kt
@@ -63,7 +63,7 @@ fun anEvent(
     description = description,
     track = track,
     timeZone = timeZone,
-    favorited = favorited
+    favorite = favorited
 )
 
 fun aPlace(

--- a/app/src/test/java/net/squanchy/search/SearchServiceTest.kt
+++ b/app/src/test/java/net/squanchy/search/SearchServiceTest.kt
@@ -1,18 +1,14 @@
 package net.squanchy.search
 
-import arrow.core.Option
-import com.google.android.gms.auth.api.signin.GoogleSignInAccount
-import io.reactivex.Completable
 import io.reactivex.Observable
+import net.squanchy.FakeAuthService
 import net.squanchy.schedule.domain.view.anEvent
-import net.squanchy.search.algolia.AlgoliaSearchEngine
-import net.squanchy.search.algolia.model.AlgoliaSearchResult
 import net.squanchy.search.SearchListElement.EventElement
 import net.squanchy.search.SearchListElement.SpeakerElement
-import net.squanchy.service.repository.AuthService
+import net.squanchy.search.algolia.AlgoliaSearchEngine
+import net.squanchy.search.algolia.model.AlgoliaSearchResult
 import net.squanchy.service.repository.EventRepository
 import net.squanchy.service.repository.SpeakerRepository
-import net.squanchy.service.repository.User
 import net.squanchy.speaker.domain.view.aSpeaker
 import org.junit.Before
 import org.junit.Rule
@@ -28,20 +24,20 @@ class SearchServiceTest {
     @JvmField
     var rule: MockitoRule = MockitoJUnit.rule()
 
-    lateinit var searchService: SearchService
+    private lateinit var searchService: SearchService
 
     @Mock
-    lateinit var eventRepository: EventRepository
+    private lateinit var eventRepository: EventRepository
 
     @Mock
-    lateinit var speakerRepository: SpeakerRepository
+    private lateinit var speakerRepository: SpeakerRepository
 
     @Mock
-    lateinit var algoliaSearchEngine: AlgoliaSearchEngine
+    private lateinit var algoliaSearchEngine: AlgoliaSearchEngine
 
     @Before
     fun setup() {
-        searchService = SearchService(eventRepository, speakerRepository, FakeAuthService, algoliaSearchEngine)
+        searchService = SearchService(eventRepository, speakerRepository, FakeAuthService(UID), algoliaSearchEngine)
     }
 
     @Test
@@ -98,32 +94,5 @@ class SearchServiceTest {
     companion object {
         private const val QUERY = "A"
         private const val UID = "uid"
-    }
-
-    private object FakeAuthService : AuthService {
-
-        override fun signInWithGoogle(account: GoogleSignInAccount): Completable {
-            TODO("not implemented")
-        }
-
-        override fun <T> ifUserSignedInThenObservableFrom(observable: (String) -> Observable<T>): Observable<T> {
-            return observable(UID)
-        }
-
-        override fun ifUserSignedInThenCompletableFrom(completable: (String) -> Completable): Completable {
-            TODO("not implemented")
-        }
-
-        override fun currentUser(): Observable<Option<User>> {
-            TODO("not implemented")
-        }
-
-        override fun signOut(): Completable {
-            TODO("not implemented")
-        }
-
-        override fun signInAnonymously(): Completable {
-            TODO("not implemented")
-        }
     }
 }

--- a/app/src/test/java/net/squanchy/service/firebase/FirestoreFixtures.kt
+++ b/app/src/test/java/net/squanchy/service/firebase/FirestoreFixtures.kt
@@ -6,6 +6,7 @@ import net.squanchy.service.firebase.model.conferenceinfo.FirestoreConferenceInf
 import net.squanchy.service.firebase.model.conferenceinfo.FirestoreVenue
 import net.squanchy.service.firebase.model.schedule.FirestoreDay
 import net.squanchy.service.firebase.model.schedule.FirestoreEvent
+import net.squanchy.service.firebase.model.schedule.FirestoreFavorite
 import net.squanchy.service.firebase.model.schedule.FirestorePlace
 import net.squanchy.service.firebase.model.schedule.FirestoreSchedulePage
 import net.squanchy.service.firebase.model.schedule.FirestoreSpeaker
@@ -111,6 +112,10 @@ fun aFirestoreEvent(
     this.description = description
     this.experienceLevel = experienceLevel
 }
+
+fun aFirestoreFavorite(
+    id: String = "walrus"
+) = FirestoreFavorite().apply { this.id = id }
 
 fun aFirestoreSchedulePage(
     day: FirestoreDay = aFirestoreDay(),


### PR DESCRIPTION
## Problem

We've been requested to show favourites in the schedule

## Solution

Show them! Should likely be a setting item though. Not 100% convinced it makes sense, since we have a favourites screen too.

In this PR we finally complete decoupling the `ScheduleService` from any favourites duty. All that is left is schedule.

### Test(s) added

Ish, there's been a lot of refactoring to make this happen and all tests changed in affected areas.

### Screenshots

 Schedule | Search
 ------ | -----
 ![schedule_faves](https://user-images.githubusercontent.com/153802/38767995-493231c2-3fe4-11e8-8704-5d89612711de.png) | ![search_faves](https://user-images.githubusercontent.com/153802/38767996-4946c4ca-3fe4-11e8-8782-aa807c75cd3f.png)


### Paired with

Nobody