### PR TITLE
Setting to show favourites in schedule

### DIFF
--- a/app/src/main/java/net/squanchy/analytics/Analytics.kt
+++ b/app/src/main/java/net/squanchy/analytics/Analytics.kt
@@ -46,9 +46,10 @@ class Analytics internal constructor(
     }
 
     private fun trackItemSelectedOnFirebaseAnalytics(contentType: ContentType, itemId: String) {
-        val params = Bundle()
-        params.putString(FirebaseAnalytics.Param.CONTENT_TYPE, contentType.rawContentType)
-        params.putString(FirebaseAnalytics.Param.ITEM_ID, itemId)
+        val params = Bundle().apply {
+            putString(FirebaseAnalytics.Param.CONTENT_TYPE, contentType.rawContentType)
+            putString(FirebaseAnalytics.Param.ITEM_ID, itemId)
+        }
         firebaseAnalytics.logEvent(FirebaseAnalytics.Event.SELECT_CONTENT, params)
     }
 
@@ -81,11 +82,25 @@ class Analytics internal constructor(
 
     fun trackNotificationsEnabled() {
         firebaseAnalytics.setUserProperty("notifications_status", "enabled")
+        firebaseAnalytics.logEvent("notifications_status_changed", flagEnabled("true"))
     }
 
     fun trackNotificationsDisabled() {
         firebaseAnalytics.setUserProperty("notifications_status", "disabled")
+        firebaseAnalytics.logEvent("notifications_status_changed", flagEnabled("false"))
     }
+
+    fun trackFavoritesInScheduleEnabled() {
+        firebaseAnalytics.setUserProperty("favorites_in_schedule", "enable")
+        firebaseAnalytics.logEvent("favorites_in_schedule_changed", flagEnabled("true"))
+    }
+
+    fun trackFavoritesInScheduleDisabled() {
+        firebaseAnalytics.setUserProperty("favorites_in_schedule", "disabled")
+        firebaseAnalytics.logEvent("favorites_in_schedule_changed", flagEnabled("false"))
+    }
+
+    private fun flagEnabled(value: String) = Bundle().apply { putString("enabled", value) }
 
     fun trackUserNotLoggedIn() {
         setUserLoginProperty(LoginStatus.NOT_LOGGED_IN)
@@ -105,9 +120,10 @@ class Analytics internal constructor(
     }
 
     fun trackWifiConfigurationEvent(isSuccess: Boolean, wifiConfigOrigin: WifiConfigOrigin) {
-        val params = Bundle()
-        params.putString("origin", wifiConfigOrigin.rawOrigin)
-        params.putBoolean("success", isSuccess)
+        val params = Bundle().apply {
+            putString("origin", wifiConfigOrigin.rawOrigin)
+            putBoolean("success", isSuccess)
+        }
         firebaseAnalytics.logEvent("wifi_config", params)
     }
 }

--- a/app/src/main/java/net/squanchy/analytics/Analytics.kt
+++ b/app/src/main/java/net/squanchy/analytics/Analytics.kt
@@ -82,22 +82,22 @@ class Analytics internal constructor(
 
     fun trackNotificationsEnabled() {
         firebaseAnalytics.setUserProperty("notifications_status", "enabled")
-        firebaseAnalytics.logEvent("notifications_status_changed", flagEnabled("true"))
+        firebaseAnalytics.logEvent("notifications_status_changed", flagEnabled(TRUE))
     }
 
     fun trackNotificationsDisabled() {
         firebaseAnalytics.setUserProperty("notifications_status", "disabled")
-        firebaseAnalytics.logEvent("notifications_status_changed", flagEnabled("false"))
+        firebaseAnalytics.logEvent("notifications_status_changed", flagEnabled(FALSE))
     }
 
     fun trackFavoritesInScheduleEnabled() {
         firebaseAnalytics.setUserProperty("favorites_in_schedule", "enable")
-        firebaseAnalytics.logEvent("favorites_in_schedule_changed", flagEnabled("true"))
+        firebaseAnalytics.logEvent("favorites_in_schedule_changed", flagEnabled(TRUE))
     }
 
     fun trackFavoritesInScheduleDisabled() {
         firebaseAnalytics.setUserProperty("favorites_in_schedule", "disabled")
-        firebaseAnalytics.logEvent("favorites_in_schedule_changed", flagEnabled("false"))
+        firebaseAnalytics.logEvent("favorites_in_schedule_changed", flagEnabled(FALSE))
     }
 
     private fun flagEnabled(value: String) = Bundle().apply { putString("enabled", value) }
@@ -125,5 +125,10 @@ class Analytics internal constructor(
             putBoolean("success", isSuccess)
         }
         firebaseAnalytics.logEvent("wifi_config", params)
+    }
+
+    companion object {
+        private const val TRUE = "true"
+        private const val FALSE = "false"
     }
 }

--- a/app/src/main/java/net/squanchy/favorites/view/FavoritesAdapter.kt
+++ b/app/src/main/java/net/squanchy/favorites/view/FavoritesAdapter.kt
@@ -64,7 +64,7 @@ internal class FavoritesAdapter(
 
     @Deprecated(
         message = "Use updateWith() instead",
-        replaceWith = ReplaceWith("updateWith(list, showRoom, eventClickListener)"),
+        replaceWith = ReplaceWith("updateWith(list, showRoom, favoriteClickListener)"),
         level = DeprecationLevel.ERROR
     )
     override fun submitList(list: MutableList<FavoritesItem>?) {

--- a/app/src/main/java/net/squanchy/schedule/SchedulePageView.kt
+++ b/app/src/main/java/net/squanchy/schedule/SchedulePageView.kt
@@ -1,7 +1,7 @@
 package net.squanchy.schedule
 
 import android.content.Context
-import android.support.design.widget.CoordinatorLayout
+import android.support.constraint.ConstraintLayout
 import android.support.design.widget.TabLayout
 import android.text.Spanned
 import android.util.AttributeSet
@@ -35,7 +35,7 @@ class SchedulePageView @JvmOverloads constructor(
     context: Context,
     attrs: AttributeSet,
     defStyleAttr: Int = 0
-) : CoordinatorLayout(context, attrs, defStyleAttr), Loadable {
+) : ConstraintLayout(context, attrs, defStyleAttr), Loadable {
 
     private val viewPagerAdapter: ScheduleViewPagerAdapter
     private val service: ScheduleService
@@ -59,7 +59,7 @@ class SchedulePageView @JvmOverloads constructor(
     override fun onFinishInflate() {
         super.onFinishInflate()
 
-        tabstrip.setupWithViewPager(viewpager)
+        tabstrip.setupWithViewPager(viewPager)
         hackToApplyTypefaces(tabstrip)
 
         setupToolbar()
@@ -107,25 +107,25 @@ class SchedulePageView @JvmOverloads constructor(
     }
 
     private fun updateWith(schedule: Schedule, showRoom: Boolean, showFavorites: Boolean, onEventClicked: (Event) -> Unit) {
-        progressbar.isVisible = false
+        progressBar.isVisible = false
 
         if (schedule.isEmpty) {
-            viewpager.isVisible = false
+            viewPager.isVisible = false
             tabstrip.isVisible = false
             emptyView.isVisible = true
             return
         }
 
-        viewpager.isVisible = true
+        viewPager.isVisible = true
         tabstrip.isVisible = true
         emptyView.isVisible = false
 
         viewPagerAdapter.updateWith(schedule.pages, showRoom, showFavorites, onEventClicked)
-        if (viewpager.adapter == null) {
-            viewpager.adapter = viewPagerAdapter
+        if (viewPager.adapter == null) {
+            viewPager.adapter = viewPagerAdapter
         }
 
-        progressbar.isVisible = false
+        progressBar.isVisible = false
     }
 
     private fun onEventClicked(event: Event) {

--- a/app/src/main/java/net/squanchy/schedule/view/EventsAdapter.kt
+++ b/app/src/main/java/net/squanchy/schedule/view/EventsAdapter.kt
@@ -17,11 +17,20 @@ internal class EventsAdapter(context: Context) : ListAdapter<Event, EventViewHol
 
     private val layoutInflater: LayoutInflater = LayoutInflater.from(context)
     private var showRoom = false
+    private var showFavorites = false
     private var eventClickListener: OnEventClickListener? = null
 
-    fun updateWith(list: List<Event>, showRoom: Boolean, listener: OnEventClickListener) {
+    fun updateWith(list: List<Event>, showRoom: Boolean, showFavorites: Boolean, listener: OnEventClickListener) {
         this.showRoom = showRoom
         this.eventClickListener = listener
+
+        if (this.showFavorites != showFavorites) {
+            // We want to refresh the favourite visualization too which is not part of the model and thus
+            // would get ignored by the DiffCallback when comparing things. We go nuclear and trigger
+            // a full dataset change notification.
+            this.showFavorites = showFavorites
+            notifyDataSetChanged()
+        }
         super.submitList(list)
     }
 
@@ -52,7 +61,7 @@ internal class EventsAdapter(context: Context) : ListAdapter<Event, EventViewHol
     }
 
     override fun onBindViewHolder(holder: EventViewHolder, position: Int) {
-        holder.updateWith(getItem(position), showRoom, eventClickListener)
+        holder.updateWith(getItem(position), showRoom, showFavorites, eventClickListener)
     }
 
     @Deprecated(
@@ -67,8 +76,8 @@ internal class EventsAdapter(context: Context) : ListAdapter<Event, EventViewHol
 
 internal class EventViewHolder(itemView: EventItemView) : RecyclerView.ViewHolder(itemView) {
 
-    fun updateWith(event: Event, showRoom: Boolean, listener: OnEventClickListener?) {
-        (itemView as EventItemView).updateWith(event, showRoom)
+    fun updateWith(event: Event, showRoom: Boolean, showFavorites: Boolean, listener: OnEventClickListener?) {
+        (itemView as EventItemView).updateWith(event, showRoom = showRoom, showFavorite = showFavorites)
         itemView.setOnClickListener { listener?.invoke(event) }
     }
 }

--- a/app/src/main/java/net/squanchy/schedule/view/ScheduleDayPageView.kt
+++ b/app/src/main/java/net/squanchy/schedule/view/ScheduleDayPageView.kt
@@ -29,8 +29,8 @@ class ScheduleDayPageView @JvmOverloads constructor(
         addItemDecoration(CardSpacingItemDecorator(horizontalSpacing, verticalSpacing))
     }
 
-    fun updateWith(newData: List<Event>, showRoom: Boolean, listener: (Event) -> Unit) {
+    fun updateWith(newData: List<Event>, showRoom: Boolean, showFavorites: Boolean, listener: (Event) -> Unit) {
         setAdapterIfNone(adapter)
-        adapter.updateWith(newData, showRoom, listener)
+        adapter.updateWith(newData, showRoom, showFavorites, listener)
     }
 }

--- a/app/src/main/java/net/squanchy/schedule/view/ScheduleViewPagerAdapter.kt
+++ b/app/src/main/java/net/squanchy/schedule/view/ScheduleViewPagerAdapter.kt
@@ -20,11 +20,13 @@ class ScheduleViewPagerAdapter(context: Context) : ViewPagerAdapter<ScheduleDayP
     private val inflater = LayoutInflater.from(context)
     private val viewPool = RecyclerView.RecycledViewPool()
     private var showRoom: Boolean = false
+    private var showFavorites: Boolean = false
 
-    fun updateWith(pages: List<SchedulePage>, showRoom: Boolean, listener: (Event) -> Unit) {
+    fun updateWith(pages: List<SchedulePage>, showRoom: Boolean, showFavorites: Boolean, listener: (Event) -> Unit) {
         this.pages = pages
-        this.listener = listener
         this.showRoom = showRoom
+        this.showFavorites = showFavorites
+        this.listener = listener
         notifyDataSetChanged()
     }
 
@@ -38,7 +40,7 @@ class ScheduleViewPagerAdapter(context: Context) : ViewPagerAdapter<ScheduleDayP
 
     override fun bindView(view: ScheduleDayPageView, position: Int) {
         val events = pages[position].events
-        view.updateWith(events, showRoom, listener)
+        view.updateWith(events, showRoom, showFavorites, listener)
     }
 
     override fun getPageTitle(position: Int): CharSequence? {

--- a/app/src/main/java/net/squanchy/settings/SettingsFragment.kt
+++ b/app/src/main/java/net/squanchy/settings/SettingsFragment.kt
@@ -40,9 +40,6 @@ class SettingsFragment : PreferenceFragment() {
     private lateinit var accountEmailPreference: Preference
     private lateinit var accountSignInSignOutPreference: Preference
 
-    private val viewOrThrow: View
-        get() = this.view ?: throw IllegalStateException("You cannot access the fragment's view when it doesn't exist yet")
-
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
@@ -169,6 +166,9 @@ class SettingsFragment : PreferenceFragment() {
             return@setOnPreferenceClickListener true
         }
     }
+
+    private val viewOrThrow: View
+        get() = this.view ?: throw IllegalStateException("You cannot access the fragment's view when it doesn't exist yet")
 
     private fun onSignedOut() {
         accountCategory.removePreference(accountEmailPreference)

--- a/app/src/main/java/net/squanchy/settings/SettingsFragment.kt
+++ b/app/src/main/java/net/squanchy/settings/SettingsFragment.kt
@@ -82,6 +82,16 @@ class SettingsFragment : PreferenceFragment() {
             true
         }
 
+        val favoritesInSchedulePreference = findPreference(getString(R.string.favorites_in_schedule_preference_key))
+        favoritesInSchedulePreference.setOnPreferenceChangeListener { _, enabled ->
+            if (enabled as Boolean) {
+                analytics.trackFavoritesInScheduleEnabled()
+            } else {
+                analytics.trackFavoritesInScheduleDisabled()
+            }
+            true
+        }
+
         setupWifiConfigPreference()
     }
 

--- a/app/src/main/java/net/squanchy/settings/preferences/LocalPreferences.kt
+++ b/app/src/main/java/net/squanchy/settings/preferences/LocalPreferences.kt
@@ -1,0 +1,24 @@
+package net.squanchy.settings.preferences
+
+import android.content.Context
+import android.content.SharedPreferences
+import android.preference.PreferenceManager
+import io.reactivex.Observable
+
+fun showFavoritesInScheduleObservable(context: Context) =
+    context.defaultSharedPreferences.observeFlag("favorites_in_schedule_preference_key", false)
+
+private val Context.defaultSharedPreferences
+    get() = PreferenceManager.getDefaultSharedPreferences(this)
+
+private fun SharedPreferences.observeFlag(key: String, defaultValue: Boolean = false): Observable<Boolean> = Observable.create { emitter ->
+    val listener = SharedPreferences.OnSharedPreferenceChangeListener { _, changedKey ->
+        if (key == changedKey) {
+            emitter.onNext(getBoolean(key, defaultValue))
+        }
+    }
+
+    emitter.onNext(getBoolean(key, defaultValue))
+    registerOnSharedPreferenceChangeListener(listener)
+    emitter.setCancellable { unregisterOnSharedPreferenceChangeListener(listener) }
+}

--- a/app/src/main/res/drawable/ic_favorite_settings.xml
+++ b/app/src/main/res/drawable/ic_favorite_settings.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+  android:width="24dp"
+  android:height="24dp"
+  android:viewportWidth="24.0"
+  android:viewportHeight="24.0">
+  <path
+    android:fillColor="@color/selector_color_primary"
+    android:pathData="M12,21.35l-1.45,-1.32C5.4,15.36 2,12.28 2,8.5 2,5.42 4.42,3 7.5,3c1.74,0 3.41,0.81 4.5,2.09C13.09,3.81 14.76,3 16.5,3 19.58,3 22,5.42 22,8.5c0,3.78 -3.4,6.86 -8.55,11.54L12,21.35z" />
+</vector>

--- a/app/src/main/res/layout/view_page_schedule.xml
+++ b/app/src/main/res/layout/view_page_schedule.xml
@@ -9,42 +9,55 @@
   tools:context="net.squanchy.home.HomeActivity">
 
   <android.support.design.widget.AppBarLayout
+    android:id="@+id/appBarLayout"
     style="@style/Squanchy.Appbar"
     android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"
-    android:layout_width="match_parent"
-    android:layout_height="wrap_content">
+    android:layout_width="@dimen/match_constraint"
+    android:layout_height="wrap_content"
+    app:layout_constraintStart_toStartOf="parent"
+    app:layout_constraintTop_toTopOf="parent"
+    app:layout_constraintEnd_toEndOf="parent">
 
     <android.support.v7.widget.Toolbar
       android:id="@+id/toolbar"
       android:layout_width="match_parent"
-      android:layout_height="?attr/actionBarSize" />
+      android:layout_height="wrap_content" />
 
     <android.support.design.widget.TabLayout
       android:id="@+id/tabstrip"
       style="@style/Squanchy.Tabs.Schedule"
       android:layout_width="match_parent"
-      android:layout_height="?attr/actionBarSize" />
+      android:layout_height="wrap_content" />
 
   </android.support.design.widget.AppBarLayout>
 
   <android.support.v4.view.ViewPager
-    android:id="@+id/viewpager"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    app:layout_behavior="@string/appbar_scrolling_view_behavior" />
+    android:id="@+id/viewPager"
+    android:layout_width="@dimen/match_constraint"
+    android:layout_height="@dimen/match_constraint"
+    app:layout_constraintStart_toStartOf="parent"
+    app:layout_constraintTop_toBottomOf="@+id/appBarLayout"
+    app:layout_constraintEnd_toEndOf="parent"
+    app:layout_constraintBottom_toBottomOf="parent" />
 
   <ProgressBar
-    android:id="@+id/progressbar"
+    android:id="@+id/progressBar"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
-    android:layout_gravity="center" />
+    app:layout_constraintStart_toStartOf="parent"
+    app:layout_constraintTop_toTopOf="@+id/viewPager"
+    app:layout_constraintEnd_toEndOf="parent"
+    app:layout_constraintBottom_toBottomOf="parent" />
 
   <TextView
     android:id="@+id/emptyView"
     style="@style/Schedule.EmptyView"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
-    android:layout_gravity="center"
-    android:visibility="gone" />
+    android:visibility="gone"
+    app:layout_constraintStart_toStartOf="parent"
+    app:layout_constraintTop_toBottomOf="@+id/appBarLayout"
+    app:layout_constraintEnd_toEndOf="parent"
+    app:layout_constraintBottom_toBottomOf="parent" />
 
 </net.squanchy.schedule.SchedulePageView>

--- a/app/src/main/res/values-en-rGB/strings.xml
+++ b/app/src/main/res/values-en-rGB/strings.xml
@@ -9,5 +9,6 @@
   <string name="licenses_label">Open source licences</string>
   <string name="favorites_empty_state_signed_out_blurb">Pick your favourite talks, synced across devices, and get notifications when they’re about to start.</string>
   <string name="favorites_empty_state_signed_in_blurb">You haven’t picked any favourites yet.\n\n1️⃣ Find a talk you fancy.\n2️⃣ Aim for the big ♥ button.\n3️⃣ That’s it. Really.</string>
+  <string name="favorites_in_schedule_title">Show favourites in schedule</string>
 
 </resources>

--- a/app/src/main/res/values/preference_keys.xml
+++ b/app/src/main/res/values/preference_keys.xml
@@ -3,6 +3,7 @@
 
   <string name="about_to_start_notification_preference_key">about_to_start_notification_preference_key</string>
   <string name="auto_wifi_preference_key">auto_wifi_preference_key</string>
+  <string name="favorites_in_schedule_preference_key">favorites_in_schedule_preference_key</string>
   <string name="build_version_preference_key">build_version_preference_key</string>
   <string name="account_category_key">account_category_key</string>
   <string name="account_email_preference_key">account_email_preference_key</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -68,6 +68,7 @@
   <string name="settings_message_wifi_success">Wi-Fi network successfully configured</string>
   <string name="about_title">About</string>
   <string name="auto_wifi_title">Configure Wi-Fi</string>
+  <string name="favorites_in_schedule_title">Show favorites in schedule</string>
   <string name="settings_account_not_signed_in">Not signed in</string>
   <string name="settings_header_not_signed_in">You’re not signed in</string>
   <string name="version_x">Version: %1$s</string>

--- a/app/src/main/res/xml/settings_preferences.xml
+++ b/app/src/main/res/xml/settings_preferences.xml
@@ -39,17 +39,17 @@
       android:summaryOff="@string/settings_notifications_about_to_start_summary_off"
       android:order="0"/>
 
-    <Preference
-      android:key="@string/auto_wifi_preference_key"
-      android:title="@string/auto_wifi_title"
-      android:icon="@drawable/ic_wifi"
-      android:order="1" />
-
     <SwitchPreference
       android:key="@string/favorites_in_schedule_preference_key"
       android:title="@string/favorites_in_schedule_title"
       android:icon="@drawable/ic_favorite_settings"
       android:defaultValue="false"
+      android:order="1" />
+
+    <Preference
+      android:key="@string/auto_wifi_preference_key"
+      android:title="@string/auto_wifi_title"
+      android:icon="@drawable/ic_wifi"
       android:order="2" />
 
     <Preference

--- a/app/src/main/res/xml/settings_preferences.xml
+++ b/app/src/main/res/xml/settings_preferences.xml
@@ -32,9 +32,9 @@
 
     <SwitchPreference
       android:key="@string/about_to_start_notification_preference_key"
-      android:defaultValue="true"
-      android:icon="@drawable/ic_notifications"
       android:title="@string/settings_notifications_title"
+      android:icon="@drawable/ic_notifications"
+      android:defaultValue="true"
       android:summaryOn="@string/settings_notifications_about_to_start_summary_on"
       android:summaryOff="@string/settings_notifications_about_to_start_summary_off"
       android:order="0"/>
@@ -45,11 +45,18 @@
       android:icon="@drawable/ic_wifi"
       android:order="1" />
 
+    <SwitchPreference
+      android:key="@string/favorites_in_schedule_preference_key"
+      android:title="@string/favorites_in_schedule_title"
+      android:icon="@drawable/ic_favorite_settings"
+      android:defaultValue="false"
+      android:order="2" />
+
     <Preference
       android:key="@string/about_preference_key"
       android:title="@string/about_title"
       android:icon="@drawable/ic_about"
-      android:order="2" />
+      android:order="3" />
 
     <Preference
       android:key="@string/build_version_preference_key"


### PR DESCRIPTION
## Problem

We have the ability to show favourites in the schedule, but we want it to be an opt-in thing. We also want to improve analytics tracking in settings.

## Solution

Add an item in settings to opt-in to showing favourites in the schedule, add analytics for it. General boy scouting around those areas too.

### Test(s) added

No.

### Screenshots

![image](https://user-images.githubusercontent.com/153802/38773164-22a3a8a6-403e-11e8-97c0-0545d3049a11.png)

### Paired with

Nobody