### PR TITLE
Hide level in event details for keynotes

### DIFF
--- a/app/src/main/java/net/squanchy/eventdetails/widget/EventDetailsLayout.kt
+++ b/app/src/main/java/net/squanchy/eventdetails/widget/EventDetailsLayout.kt
@@ -44,7 +44,7 @@ class EventDetailsLayout @JvmOverloads constructor(
     fun updateWith(event: Event) {
         updateWhen(event.startTime, event.timeZone)
         updateWhere(event.place)
-        updateLevel(event.experienceLevel)
+        updateLevel(event.experienceLevel, event.type)
         updateTrack(event.track)
         updateDescription(event.description)
     }
@@ -85,23 +85,22 @@ class EventDetailsLayout @JvmOverloads constructor(
         return ForegroundColorSpan(color)
     }
 
-    private fun updateLevel(level: Option<ExperienceLevel>) {
-        if (level.isDefined()) {
-            levelGroup.isVisible = true
+    private fun updateLevel(level: Option<ExperienceLevel>, type: Event.Type) {
+        when {
+            type == Event.Type.KEYNOTE -> {
+                levelGroup.isVisible = false
+            }
+            level.isDefined() -> {
+                levelGroup.isVisible = true
 
-            val experienceLevel = level.getOrThrow()
-            levelValue.setText(experienceLevel.labelStringResId)
-            val experienceColor = ContextCompat.getColor(context, experienceLevel.colorResId)
-            tintCompoundDrawableEnd(levelValue, experienceColor)
-        } else {
-            levelGroup.isVisible = false
+                val experienceLevel = level.getOrThrow()
+                levelValue.setText(experienceLevel.labelStringResId)
+
+                val experienceColor = ContextCompat.getColor(context, experienceLevel.colorResId)
+                levelValue.tintCompoundDrawableEnd(experienceColor)
+            }
+            else -> levelGroup.isVisible = false
         }
-    }
-
-    private fun tintCompoundDrawableEnd(textView: TextView, @ColorInt color: Int) {
-        val compoundDrawables = textView.compoundDrawablesRelative
-        val endCompoundDrawable = compoundDrawables[2]
-        endCompoundDrawable?.setTint(color)
     }
 
     private fun updateTrack(trackOption: Option<Track>) {
@@ -112,11 +111,17 @@ class EventDetailsLayout @JvmOverloads constructor(
             trackValue.text = track.name
             track.accentColor?.let {
                 val trackColor = Color.parseColor(it)
-                tintCompoundDrawableEnd(trackValue, trackColor)
+                trackValue.tintCompoundDrawableEnd(trackColor)
             }
         } else {
             trackGroup.isVisible = false
         }
+    }
+
+    private fun TextView.tintCompoundDrawableEnd(@ColorInt color: Int) {
+        val compoundDrawables = compoundDrawablesRelative
+        val endCompoundDrawable = compoundDrawables[2]
+        endCompoundDrawable?.setTint(color)
     }
 
     private fun updateDescription(description: Option<String>) {


### PR DESCRIPTION
## Problem

Keynotes shouldn't display a `level` (and arguably shouldn't have one in general, but it's too late for that)

## Solution

Hide the keynotes' level in event details

### Test(s) added

No

### Screenshots

![image](https://user-images.githubusercontent.com/153802/38777820-16a5936c-40a6-11e8-82a2-e600555910e1.png)

### Paired with

Nobody
