### PR TITLE
Hide (empty) image for 'other' items in schedule

### DIFF
--- a/app/src/main/java/net/squanchy/schedule/view/OtherEventItemView.kt
+++ b/app/src/main/java/net/squanchy/schedule/view/OtherEventItemView.kt
@@ -3,6 +3,7 @@ package net.squanchy.schedule.view
 import android.content.Context
 import android.support.annotation.DrawableRes
 import android.util.AttributeSet
+import androidx.view.isVisible
 import kotlinx.android.synthetic.main.item_schedule_event_other.view.*
 import net.squanchy.R
 import net.squanchy.schedule.domain.view.Event
@@ -19,7 +20,14 @@ class OtherEventItemView @JvmOverloads constructor(
 
         timestamp.text = startTimeAsFormattedString(event)
         title.text = event.title
-        illustration.setImageResource(illustrationFor(event.type))
+
+        if (event.type != Event.Type.OTHER) {
+            illustration.isVisible = true
+            illustration.setImageResource(illustrationFor(event.type))
+        } else {
+            illustration.isVisible = false
+            illustration.setImageDrawable(null)
+        }
     }
 
     private fun Event.Type.ensureSupported() {
@@ -47,12 +55,7 @@ class OtherEventItemView @JvmOverloads constructor(
         Event.Type.COFFEE_BREAK -> R.drawable.coffee_break
         Event.Type.LUNCH -> R.drawable.lunch
         Event.Type.REGISTRATION -> R.drawable.registration
-        Event.Type.OTHER -> NO_DRAWABLE
         Event.Type.SOCIAL -> R.drawable.social
         else -> throw IllegalArgumentException("Type not supported: ${type.name}")
-    }
-
-    companion object {
-        private const val NO_DRAWABLE = 0
     }
 }

--- a/app/src/main/res/layout/item_schedule_event_other.xml
+++ b/app/src/main/res/layout/item_schedule_event_other.xml
@@ -2,6 +2,7 @@
 <!-- We do only want the padding on the start side -->
 <net.squanchy.schedule.view.OtherEventItemView
   xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:app="http://schemas.android.com/apk/res-auto"
   xmlns:tools="http://schemas.android.com/tools"
   android:layout_width="match_parent"
   android:layout_height="wrap_content"
@@ -11,42 +12,45 @@
   tools:layout_margin="16dp"
   tools:ignore="RtlSymmetry">
 
-  <LinearLayout
+  <android.support.constraint.ConstraintLayout
+    android:id="@+id/linearLayout"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    android:orientation="horizontal">
+    android:layout_height="wrap_content">
 
-    <LinearLayout
-      android:layout_width="0dp"
+    <TextView
+      android:id="@+id/title"
+      style="@style/Schedule.Card.Title"
+      android:layout_width="@dimen/match_constraint"
       android:layout_height="wrap_content"
-      android:layout_weight="1"
-      android:layout_gravity="center_vertical"
-      android:orientation="vertical">
+      app:layout_constraintStart_toStartOf="parent"
+      app:layout_constraintTop_toTopOf="@+id/illustration"
+      app:layout_constraintEnd_toStartOf="@+id/illustration"
+      app:layout_constraintBottom_toTopOf="@+id/timestamp"
+      app:layout_constraintVertical_chainStyle="packed"
+      app:layout_goneMarginEnd="@dimen/card_padding_horizontal"
+      tools:text="Designing for an Android future" />
 
-      <TextView
-        android:id="@+id/title"
-        style="@style/Schedule.Card.Title"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        tools:text="Designing for an Android future" />
-
-      <TextView
-        android:id="@+id/timestamp"
-        style="@style/Schedule.Card.Timestamp"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="@dimen/card_timestamp_margin_top"
-        tools:text="12:00" />
-
-    </LinearLayout>
+    <TextView
+      android:id="@+id/timestamp"
+      style="@style/Schedule.Card.Timestamp"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:layout_marginTop="@dimen/card_timestamp_margin_top"
+      app:layout_constraintStart_toStartOf="@+id/title"
+      app:layout_constraintTop_toBottomOf="@+id/title"
+      app:layout_constraintBottom_toBottomOf="@+id/illustration"
+      tools:text="12:00" />
 
     <ImageView
       android:id="@+id/illustration"
       android:layout_width="@dimen/card_other_illustration_width"
       android:layout_height="@dimen/card_other_illustration_height"
       android:scaleType="centerInside"
+      app:layout_constraintTop_toTopOf="parent"
+      app:layout_constraintEnd_toEndOf="parent"
+      app:layout_constraintBottom_toBottomOf="parent"
       tools:src="@drawable/lunch" />
 
-  </LinearLayout>
+  </android.support.constraint.ConstraintLayout>
 
 </net.squanchy.schedule.view.OtherEventItemView>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -17,7 +17,7 @@
   <dimen name="card_pressed_z_translation">2dp</dimen>
   <dimen name="card_padding_horizontal">16dp</dimen>
   <dimen name="card_padding_top">12dp</dimen>
-  <dimen name="card_padding_bottom">8dp</dimen>
+  <dimen name="card_padding_bottom">12dp</dimen>
   <dimen name="card_timestamp">14sp</dimen>
   <dimen name="card_timestamp_margin_top">4dp</dimen>
   <dimen name="card_favourite_size">20dp</dimen>


### PR DESCRIPTION
## Problem

For events with type `other` we have an empty image that makes text wrap too early.

## Solution

Hide the image view when there is no illustration to show, convert to `ConstraintLayout`.

### Test(s) added

No

### Screenshots

 Before | After
 ------ | -----
 ![others_before](https://user-images.githubusercontent.com/153802/38801071-bf8f2be0-4160-11e8-96b2-d57898d66971.png) | ![others_after](https://user-images.githubusercontent.com/153802/38801962-1f6bd250-4163-11e8-9a93-e0eb70d0d359.png)

### Paired with

Nobody
