### PR TITLE
Fix favourites icon in schedule after AVD changes broke them

### DIFF
--- a/app/src/main/res/layout/item_schedule_event_talk.xml
+++ b/app/src/main/res/layout/item_schedule_event_talk.xml
@@ -87,7 +87,7 @@
       android:id="@+id/favoriteIcon"
       android:layout_width="@dimen/card_favourite_size"
       android:layout_height="@dimen/card_favourite_size"
-      android:src="@drawable/ic_favorite_filled"
+      android:src="@drawable/ic_favorite_settings"
       android:tint="?colorPrimary"
       android:visibility="gone"
       app:layout_constraintTop_toTopOf="@+id/timestamp"


### PR DESCRIPTION
## Problem

#557 broke the favourites icons in the schedule

## Solution

Use the right drawable, ezpz

### Test(s) added

No

### Screenshots

 Before | After
 ------ | -----
 ![faves-before](https://user-images.githubusercontent.com/153802/38802153-9cd894bc-4163-11e8-9a74-f7a557aefd97.png) | ![faves-after](https://user-images.githubusercontent.com/153802/38802152-9cc121e2-4163-11e8-844c-4a3d942fe4b5.png)

### Paired with

Nobody