### PR TITLE
Comment out stuff in the play closure to prevent accidental shipping

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -96,7 +96,13 @@ private static boolean isNotRunningOnCI() {
 }
 
 play {
-    jsonFile = teamPropsFile('play-store-keys.json')
+    // TODO uncomment these lines if you want to be able to publish to the Play Store, but *ONLY* do it
+    // on a release branch or you'll risk shipping random stuff to the Store (don't ask)
+
+//    jsonFile = teamPropsFile('play-store-keys.json')
+//    errorOnSizeLimit = true
+//    uploadImages = true
+//    track = 'production'
 }
 
 detekt {


### PR DESCRIPTION
## Problem

Don't be like me, kids, practice safe build script maintenance. It's technically possible to mistakenly ship stuff to the Play Store from non-release branches cause the json file with the API config is not versioned and doesn't get dumped when you switch branches.

## Solution

Comment out the whole block so it won't work from develop. It will be uncommented on release branches, such as `droidcon_turin_2018`.

### Test(s) added

No, but tried it and seems to work

### Paired with

Nobody but my guilty conscience