### PR TITLE
Fix crash on Xiaomi because of missing nullability on a return

### DIFF
--- a/app/src/main/java/net/squanchy/schedule/tracksfilter/widget/FilterChipView.kt
+++ b/app/src/main/java/net/squanchy/schedule/tracksfilter/widget/FilterChipView.kt
@@ -198,7 +198,7 @@ class FilterChipView @JvmOverloads constructor(
         }
     }
 
-    override fun getBackgroundTintList(): ColorStateList {
+    override fun getBackgroundTintList(): ColorStateList? {
         return allowOnlyWhileInitializing("Can't obtain the background color of a FilterChipView, use the color property") {
             return@allowOnlyWhileInitializing super.getBackgroundTintList()
         }


### PR DESCRIPTION
## Problem

Crash one on Xiaomi in prod due to something weird going on on their Android 5 ROM: http://crashes.to/s/182c12e7ffa but the issue it uncovers is real

## Solution

Add missing `?`

### Test(s) added

No

### Paired with

Nobody