### PR TITLE
Receive firestore callbacks on different thread

### DIFF
--- a/app/src/main/java/net/squanchy/schedule/ScheduleService.kt
+++ b/app/src/main/java/net/squanchy/schedule/ScheduleService.kt
@@ -1,10 +1,8 @@
 package net.squanchy.schedule
 
 import io.reactivex.Observable
-import io.reactivex.Scheduler
 import io.reactivex.functions.BiFunction
 import io.reactivex.functions.Function3
-import io.reactivex.schedulers.Schedulers
 import net.squanchy.schedule.domain.view.Event
 import net.squanchy.schedule.domain.view.Schedule
 import net.squanchy.schedule.domain.view.SchedulePage
@@ -32,11 +30,8 @@ class FirestoreScheduleService(
     private val checksum: Checksum
 ) : ScheduleService {
 
-    override fun schedule(): Observable<Schedule> = schedule(Schedulers.io())
-
-    fun schedule(observeScheduler: Scheduler): Observable<Schedule> {
+    override fun schedule(): Observable<Schedule> {
         val filteredDbSchedulePages = dbService.scheduleView()
-            .observeOn(observeScheduler)
             .filterByTracks(tracksFilter.selectedTracks)
 
         val domainSchedulePages = Observable.combineLatest(

--- a/app/src/main/java/net/squanchy/service/repository/firestore/FirestoreEventRepository.kt
+++ b/app/src/main/java/net/squanchy/service/repository/firestore/FirestoreEventRepository.kt
@@ -3,7 +3,6 @@ package net.squanchy.service.repository.firestore
 import io.reactivex.Completable
 import io.reactivex.Observable
 import io.reactivex.functions.Function3
-import io.reactivex.schedulers.Schedulers
 import net.squanchy.schedule.domain.view.Event
 import net.squanchy.service.firebase.FirestoreDbService
 import net.squanchy.service.firebase.model.conferenceinfo.FirestoreVenue
@@ -29,7 +28,7 @@ class FirestoreEventRepository(
             timeZoneObservable,
             favoritesObservable,
             Function3(::combineIntoEvent)
-        ).subscribeOn(Schedulers.io())
+        )
     }
 
     private fun FirestoreVenue.extractTimeZone() = DateTimeZone.forID(timezone)

--- a/app/src/test/java/net/squanchy/schedule/FirestoreScheduleServiceTest.kt
+++ b/app/src/test/java/net/squanchy/schedule/FirestoreScheduleServiceTest.kt
@@ -2,7 +2,6 @@ package net.squanchy.schedule
 
 import arrow.core.Option
 import io.reactivex.Observable
-import io.reactivex.schedulers.Schedulers
 import io.reactivex.subjects.BehaviorSubject
 import net.squanchy.A_DATE
 import net.squanchy.A_TIMEZONE
@@ -73,7 +72,7 @@ class FirestoreScheduleServiceTest {
         `when`(tracksFilter.selectedTracks).thenReturn(BehaviorSubject.createDefault(allowedTracks))
         `when`(checksum.getChecksumOf("event_${aFirestoreEvent().id}")).thenReturn(1234)
 
-        scheduleService.schedule(observeScheduler = Schedulers.trampoline())
+        scheduleService.schedule()
             .test()
             .assertValue(
                 aSchedule(
@@ -125,7 +124,7 @@ class FirestoreScheduleServiceTest {
         `when`(checksum.getChecksumOf("event_5")).thenReturn(5)
         `when`(checksum.getChecksumOf("event_6")).thenReturn(6)
 
-        scheduleService.schedule(observeScheduler = Schedulers.trampoline())
+        scheduleService.schedule()
             .test()
             .assertValue(
                 aSchedule(
@@ -200,7 +199,7 @@ class FirestoreScheduleServiceTest {
         val favorites = listOf(aFirestoreFavorite(id = "2"))
         `when`(dbService.favorites(UID)).thenReturn(Observable.just(favorites))
 
-        scheduleService.schedule(observeScheduler = Schedulers.trampoline())
+        scheduleService.schedule()
             .test()
             .assertValue(
                 aSchedule(
@@ -229,7 +228,7 @@ class FirestoreScheduleServiceTest {
         `when`(tracksFilter.selectedTracks).thenReturn(BehaviorSubject.createDefault(allowedTracks))
         `when`(checksum.getChecksumOf("event_${aFirestoreEvent().id}")).thenReturn(1)
 
-        scheduleService.schedule(observeScheduler = Schedulers.trampoline())
+        scheduleService.schedule()
             .test()
             .assertValue(
                 aSchedule(
@@ -258,7 +257,7 @@ class FirestoreScheduleServiceTest {
         `when`(tracksFilter.selectedTracks).thenReturn(BehaviorSubject.createDefault(allowedTracks))
         `when`(checksum.getChecksumOf("event_${aFirestoreEvent().id}")).thenReturn(1)
 
-        scheduleService.schedule(observeScheduler = Schedulers.trampoline())
+        scheduleService.schedule()
             .test()
             .assertValue(
                 aSchedule(
@@ -285,7 +284,7 @@ class FirestoreScheduleServiceTest {
         val allowedTracks = setOf(aTrack(id = "A"), aTrack("C"))
         `when`(tracksFilter.selectedTracks).thenReturn(BehaviorSubject.createDefault(allowedTracks))
 
-        scheduleService.schedule(observeScheduler = Schedulers.trampoline())
+        scheduleService.schedule()
             .test()
             .assertValue(
                 aSchedule(
@@ -309,7 +308,7 @@ class FirestoreScheduleServiceTest {
         `when`(tracksFilter.selectedTracks).thenReturn(BehaviorSubject.createDefault(allowedTracks))
         `when`(checksum.getChecksumOf("event_${aFirestoreEvent().id}")).thenReturn(1)
 
-        scheduleService.schedule(observeScheduler = Schedulers.trampoline())
+        scheduleService.schedule()
             .test()
             .assertValue(
                 aSchedule(
@@ -339,7 +338,7 @@ class FirestoreScheduleServiceTest {
         `when`(tracksFilter.selectedTracks).thenReturn(BehaviorSubject.createDefault(allowedTracks))
         `when`(checksum.getChecksumOf("event_${aFirestoreEvent().id}")).thenReturn(1)
 
-        scheduleService.schedule(observeScheduler = Schedulers.trampoline())
+        scheduleService.schedule()
             .test()
             .assertValue(
                 aSchedule(


### PR DESCRIPTION
## Problem

By default Firestore will invoke the callbacks on the main thread of the app. That means we needed to do thread jumping just after to be sure our RX pipeline doesn't run on it.

## Solution

Providing an executor which will post to a certain `Handler`, and running the subscription code in a thread with a `Looper` did the trick.

### Test(s) added

No behavior changes.

