### PR TITLE
Set up workflows for CircleCI

### DIFF
--- a/.circleci/ci-scripts/ci-mock-google-services-setup.sh
+++ b/.circleci/ci-scripts/ci-mock-google-services-setup.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-export APP_MODULE_PATH="app"
+export APP_MODULE_PATH="workspace/repo/app"
 export JSON_PATH="$APP_MODULE_PATH/google-services.json"
 
 if [ ! -e ${JSON_PATH} ]; then

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,62 +1,150 @@
 version: 2
 
+aliases:
+  # Build Tools cache aliases
+  - &restore-build-tools-cache
+    name: Restore Android build tools cache
+    keys:
+      - v3-build-tools-{{ checksum "workspace/repo/.circleci/config.yml" }}-{{ checksum "workspace/repo/gradle.properties" }}-{{ checksum "workspace/repo/dependencies.gradle" }}
+  - &save-build-tools-cache
+    name: Save Android build tools cache
+    paths:
+      - /opt/android/sdk/build-tools
+    key: v3-build-tools-{{ checksum "workspace/repo/.circleci/config.yml" }}-{{ checksum "workspace/repo/gradle.properties" }}-{{ checksum "workspace/repo/dependencies.gradle" }}
+
+  # Gradle cache aliases
+  - &restore-gradle-cache
+    name: Restore Gradle cache
+    keys:
+      - v3-gradle-{{ checksum "workspace/repo/.circleci/config.yml" }}-{{ checksum "workspace/repo/gradle.properties" }}-{{ checksum "workspace/repo/dependencies.gradle" }}
+  - &save-gradle-cache
+    name: Save Gradle cache
+    paths:
+      - ~/.gradle/caches
+      - ~/.gradle/wrapper
+    key: v3-gradle-{{ checksum "workspace/repo/.circleci/config.yml" }}-{{ checksum "workspace/repo/gradle.properties" }}-{{ checksum "workspace/repo/dependencies.gradle" }}
+
+  # Android Gradle build cache aliases
+  - &restore-android-build-cache
+    name: Restore Android Gradle build cache
+    keys:
+      - v3-build-cache-{{ checksum "workspace/repo/.circleci/config.yml" }}-{{ checksum "workspace/repo/gradle.properties" }}-{{ checksum "workspace/repo/dependencies.gradle" }}
+  - &save-android-build-cache
+    name: Save Android Gradle build cache
+    paths:
+      - ~/.android/build-cache
+    key: v3-build-cache-{{ checksum "workspace/repo/.circleci/config.yml" }}-{{ checksum "workspace/repo/gradle.properties" }}-{{ checksum "workspace/repo/dependencies.gradle" }}
+
+  - &ensure-android-sdk-is-ready
+    name: Ensure Android SDK install is up-to-date
+    command: workspace/repo/.circleci/ci-scripts/ensure-sdkmanager.sh
+
+  - &download-gradle-dependencies
+    name: Download Gradle dependencies
+    command: cd workspace/repo/ && ./gradlew downloadDependencies
+
+circle_ci_android_container_config: &circle_ci_android_container_config
+  working_directory: ~/squanchy
+
+  docker:
+   - image: circleci/android:api-28-alpha
+
+  environment:
+   ANDROID_HOME: /opt/android/sdk
+   APPLICATION_ID: net.squanchy.example
+   FABRIC_API_KEY: 0000000000000000000000000000000000000000
+   ALGOLIA_APPLICATION_ID: ABCDEFGH12
+   ALGOLIA_API_KEY: 00000000000000000000000000000000
+
+attach_workspace: &attach_workspace
+  attach_workspace:
+    at: workspace
+
 jobs:
-  build:
-    working_directory: ~/squanchy
-
-    docker:
-      - image: circleci/android:api-27-alpha
-
-    environment:
-      ANDROID_HOME: /opt/android/sdk
-      APPLICATION_ID: net.squanchy.example
-      FABRIC_API_KEY: 0000000000000000000000000000000000000000
-      ALGOLIA_APPLICATION_ID: ABCDEFGH12
-      ALGOLIA_API_KEY: 00000000000000000000000000000000
-
+  checkout:
+    <<: *circle_ci_android_container_config
     steps:
-      - checkout
-
-      # Restore cached dependencies (if any)
-      - restore_cache:
-          key: jars-{{ checksum "build.gradle" }}-{{ checksum "app/build.gradle" }}
+      - checkout:
+          path: workspace/repo
 
       # Prepare the container for the build
-      - run:
-          name: Ensure Android SDK install is up-to-date
-          command: .circleci/ci-scripts/ensure-sdkmanager.sh
+      - run: *ensure-android-sdk-is-ready
       - run:
           name: Create mock Play Services JSON
-          command: .circleci/ci-scripts/ci-mock-google-services-setup.sh
+          command: workspace/repo/.circleci/ci-scripts/ci-mock-google-services-setup.sh
 
-      # Run the main job commands, delegating to Gradle
+      # Persist repo code
+      - persist_to_workspace:
+          root: workspace
+          paths:
+            - repo
+
+  prepare_for_checks:
+    <<: *circle_ci_android_container_config
+    steps:
+      - *attach_workspace
+      - restore_cache: *restore-gradle-cache
+      - restore_cache: *restore-android-build-cache
+      - restore_cache: *restore-build-tools-cache
+
+      - run: *download-gradle-dependencies
+
+      - save_cache: *save-android-build-cache
+      - save_cache: *save-gradle-cache
+      - save_cache: *save-build-tools-cache
+
+      # Persist built app code
+      - persist_to_workspace:
+          root: workspace
+          paths:
+            - repo/app/build
+
+  static_analysis:
+    <<: *circle_ci_android_container_config
+    steps:
+      - *attach_workspace
+      - restore_cache: *restore-gradle-cache
+      - restore_cache: *restore-android-build-cache
+      - restore_cache: *restore-build-tools-cache
+
       # See https://issuetracker.google.com/issues/62217354 for the parallelism option
       - run:
           name: Run static analysis
-          command: ./gradlew evaluateViolations -Djava.util.concurrent.ForkJoinPool.common.parallelism=2
-      - run:
-          name: Run tests
-          command: ./gradlew testRelease -Djava.util.concurrent.ForkJoinPool.common.parallelism=2
-
-      # Store all the downloaded dependencies in the CI cache
-      - save_cache:
-          paths:
-            # Android SDK
-            - /usr/local/android-sdk-linux/tools
-            - /usr/local/android-sdk-linux/platform-tools
-            - /usr/local/android-sdk-linux/build-tools
-            - /usr/local/android-sdk-linux/licenses
-            - /usr/local/android-sdk-linux/extras/google/m2repository
-
-            # Gradle dependencies
-            - ~/.gradle
-          key: jars-{{ checksum "build.gradle" }}-{{ checksum "app/build.gradle" }}
+          command: cd workspace/repo && ./gradlew evaluateViolations -Djava.util.concurrent.ForkJoinPool.common.parallelism=2
 
       # Collect static analysis reports as build artifacts
       - store_artifacts:
-          path: app/build/reports
+          path: workspace/repo/app/build/reports
           destination: reports
+
+  tests:
+    <<: *circle_ci_android_container_config
+    steps:
+      - *attach_workspace
+      - restore_cache: *restore-gradle-cache
+      - restore_cache: *restore-android-build-cache
+      - restore_cache: *restore-build-tools-cache
+
+      # See https://issuetracker.google.com/issues/62217354 for the parallelism option
+      - run:
+          name: Run unit tests
+          command: cd workspace/repo && ./gradlew testRelease -Djava.util.concurrent.ForkJoinPool.common.parallelism=2
 
       # Collect JUnit test results
       - store_test_results:
-          path: app/build/test-results
+          path: workspace/repo/app/build/test-results
+
+workflows:
+  version: 2
+  build_and_test:
+    jobs:
+      - checkout
+      - prepare_for_checks:
+          requires:
+            - checkout
+      - static_analysis:
+          requires:
+            - prepare_for_checks
+      - tests:
+          requires:
+            - prepare_for_checks

--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,7 +1,6 @@
 <component name="ProjectCodeStyleConfiguration">
   <code_scheme name="Project" version="173">
     <option name="RIGHT_MARGIN" value="150" />
-    <option name="WRAP_WHEN_TYPING_REACHES_RIGHT_MARGIN" value="true" />
     <AndroidXmlCodeStyleSettings>
       <option name="USE_CUSTOM_SETTINGS" value="true" />
       <option name="MANIFEST_SETTINGS">

--- a/build.gradle
+++ b/build.gradle
@@ -51,3 +51,4 @@ subprojects {
 }
 
 apply from: teamPropsFile('setup-root-tasks.gradle')
+apply from: teamPropsFile('warm-gradle-caches.gradle')

--- a/team-props/warm-gradle-caches.gradle
+++ b/team-props/warm-gradle-caches.gradle
@@ -1,0 +1,35 @@
+// Adapted from: https://gist.github.com/matthiasbalke/3c9ecccbea1d460ee4c3fbc5843ede4a
+
+task downloadDependencies {
+    dependsOn ':app:androidDependencies'
+    dependsOn 'app:dependencies'
+    doLast {
+        project.rootProject.allprojects.each { subProject ->
+            subProject.buildscript.configurations.each { configuration ->
+                resolveConfiguration(configuration)
+            }
+            subProject.configurations.each { configuration ->
+                resolveConfiguration(configuration)
+            }
+        }
+    }
+}
+
+private static void resolveConfiguration(configuration) {
+    if (isResolveableConfiguration(configuration)) {
+        configuration.resolve()
+    }
+}
+
+private static boolean isResolveableConfiguration(configuration) {
+    if (configuration.isCanBeResolved() == false) {
+        return false
+    }
+
+    def blacklistedConfigurations = [
+        'detekt', 'ktlint', 'apiElements', 'implementation', 'runtimeelements', 'runtimeonly', 'testimplementation', 'testruntimeonly',
+        'generatedimplementation', 'generatedruntimeonly', 'classpath'
+    ]
+    def configurationName = configuration.name.toLowerCase(Locale.US)
+    return !blacklistedConfigurations.any { configurationName.contains(it) }
+}


### PR DESCRIPTION
## Problem

I wanted to play around with CircleCI workflows to see if we could have a nicer and more flexible build.

## Solution

I did! The CI is now using a nice workflow to split up the work and execute tests and building in parallel.

#### First-ever build (no caches) — [8'](https://circleci.com/workflow-run/2e1e328f-545a-4eea-a0ee-a6e3fb9f6ed5)
![First ever build](https://user-images.githubusercontent.com/153802/44631194-a4b3c700-a960-11e8-8bd1-44ffd12ed482.png)

#### Regular build (caches) — [4'](https://circleci.com/workflow-run/93e345ad-4c58-4745-bf89-f1192e63c8f5)
![image](https://user-images.githubusercontent.com/153802/44631237-273c8680-a961-11e8-8619-4e0e52628d46.png)

Build times are pretty much unchanged from the previous setup, because we don't have enough parallelisation yet to have this making much difference. If we wanted PRs to also build APKs and so on, we could then easily add more parallel steps to the build.

Note that the caches (`~/.gradle`, `~/.android/build-cache` and `$ANDROID_HOME/build_tools`) are only invalidated when one of these three files change:
 * `workspace/repo/.circleci/config.yml`
 * `workspace/repo/gradle.properties`
 * `workspace/repo/dependencies.gradle`

What we're caching is basically only dependent on the dependencies versions, the Android build configuration (minSdk, targetSdk, etc) and the cache configuration itself (held in the CircleCI setup).

This setup is inspired by, and heavily modified from, the [Litho repository](https://github.com/facebook/litho)'s [setup](https://github.com/facebook/litho/blob/master/.circleci/config.yml).

### Paired with

Nobody