### PR TITLE
Move Algolia prefix to application.properties

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,6 +60,7 @@ circle_ci_android_container_config: &circle_ci_android_container_config
    FABRIC_API_KEY: 0000000000000000000000000000000000000000
    ALGOLIA_APPLICATION_ID: ABCDEFGH12
    ALGOLIA_API_KEY: 00000000000000000000000000000000
+   ALGOLIA_INDICES_PREFIX: squanchy_dev
 
 attach_workspace: &attach_workspace
   attach_workspace:

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -45,6 +45,7 @@ android {
 
         resValueString 'algolia_application_id', applicationProps['algoliaId'].or(envVars['ALGOLIA_APPLICATION_ID'])
         resValueString 'algolia_api_key', secretsProps['algoliaApiKey'].or(envVars['ALGOLIA_API_KEY'])
+        resValueString 'algolia_indices_prefix', applicationProps['algoliaIndicesPrefix'].or(envVars['ALGOLIA_INDICES_PREFIX'])
 
         resValueString 'deeplink_scheme', applicationProps['deeplinkScheme'].or("squanchy")
     }

--- a/app/src/main/java/net/squanchy/search/algolia/AlgoliaModule.kt
+++ b/app/src/main/java/net/squanchy/search/algolia/AlgoliaModule.kt
@@ -1,6 +1,7 @@
 package net.squanchy.search.algolia
 
 import android.app.Application
+import android.content.Context
 import com.algolia.search.saas.Client
 import com.squareup.moshi.JsonAdapter
 import com.squareup.moshi.Moshi
@@ -21,12 +22,22 @@ class AlgoliaModule {
     @Provides
     @ApplicationLifecycle
     @Named(EVENT_INDEX)
-    fun algoliaEventIndex(client: Client, parser: ResponseParser<AlgoliaSearchResponse>) = AlgoliaIndex(client.getIndex(EVENT_INDEX), parser)
+    fun algoliaEventIndex(app: Application, client: Client, parser: ResponseParser<AlgoliaSearchResponse>): AlgoliaIndex {
+        val indexName = composeIndexName(app, EVENT_INDEX)
+        return AlgoliaIndex(client.getIndex(indexName), parser)
+    }
 
     @Provides
     @ApplicationLifecycle
     @Named(SPEAKER_INDEX)
-    fun algoliaSpeakerIndex(client: Client, parser: ResponseParser<AlgoliaSearchResponse>) = AlgoliaIndex(client.getIndex(SPEAKER_INDEX), parser)
+    fun algoliaSpeakerIndex(app: Application, client: Client, parser: ResponseParser<AlgoliaSearchResponse>): AlgoliaIndex {
+        val indexName = composeIndexName(app, SPEAKER_INDEX)
+        return AlgoliaIndex(client.getIndex(indexName), parser)
+    }
+    private fun composeIndexName(app: Context, indexName: String): String {
+        val indexPrefix = app.getString(R.string.algolia_indices_prefix)
+        return "$indexPrefix-$indexName"
+    }
 
     @Provides
     @ApplicationLifecycle
@@ -39,7 +50,7 @@ class AlgoliaModule {
 
     @Provides
     @ApplicationLifecycle
-    fun moshi() = Moshi.Builder().build()
+    fun moshi(): Moshi = Moshi.Builder().build()
 
     @Provides
     @ApplicationLifecycle
@@ -49,7 +60,7 @@ class AlgoliaModule {
     fun responseParser(adapter: JsonAdapter<AlgoliaSearchResponse>): ResponseParser<AlgoliaSearchResponse> = MoshiResponseParser(adapter)
 
     companion object {
-        const val EVENT_INDEX = "squanchy_dev-events"
-        const val SPEAKER_INDEX = "squanchy_dev-speakers"
+        const val EVENT_INDEX = "events"
+        const val SPEAKER_INDEX = "speakers"
     }
 }

--- a/team-props/application.properties.sample
+++ b/team-props/application.properties.sample
@@ -7,5 +7,6 @@ applicationName=Squanchy
 # Scheme used for deeplinks into content
 deeplinkScheme=squanchy
 
-# Algolia App ID (used for search)
-algoliaId=
+# Algolia App ID and indices prefix (used for search)
+algoliaId=ABCDEFGH12
+algoliaIndicesPrefix=squanchy_dev


### PR DESCRIPTION
## Problem

The Algolia indices prefix was hardcoded and prevented the app from performing searches.

## Solution

Move it to the `application.properties` file.

### Test(s) added

No, but smoke tested

### Paired with

Nobody