### PR TITLE
Remove a lot of unneeded module construction

### DIFF
--- a/app/src/main/java/net/squanchy/about/AboutComponent.kt
+++ b/app/src/main/java/net/squanchy/about/AboutComponent.kt
@@ -7,10 +7,9 @@ import net.squanchy.injection.ActivityLifecycle
 import net.squanchy.navigation.NavigationModule
 import net.squanchy.navigation.Navigator
 
-fun aboutComponent(activity: AppCompatActivity) =
+fun aboutComponent(activity: AppCompatActivity): AboutComponent =
     DaggerAboutComponent.builder()
         .activityContextModule(ActivityContextModule(activity))
-        .navigationModule(NavigationModule())
         .build()
 
 @ActivityLifecycle

--- a/app/src/main/java/net/squanchy/eventdetails/EventDetailsComponent.kt
+++ b/app/src/main/java/net/squanchy/eventdetails/EventDetailsComponent.kt
@@ -11,9 +11,7 @@ import net.squanchy.navigation.Navigator
 internal fun eventDetailsComponent(activity: EventDetailsActivity) =
     DaggerEventDetailsComponent.builder()
         .applicationComponent(activity.applicationComponent)
-        .eventDetailsModule(EventDetailsModule())
         .activityContextModule(ActivityContextModule(activity))
-        .navigationModule(NavigationModule())
         .build()
 
 @ActivityLifecycle

--- a/app/src/main/java/net/squanchy/favorites/FavoritesComponent.kt
+++ b/app/src/main/java/net/squanchy/favorites/FavoritesComponent.kt
@@ -27,8 +27,6 @@ internal interface FavoritesComponent {
 internal fun favoritesComponent(activity: AppCompatActivity): FavoritesComponent {
     return DaggerFavoritesComponent.builder()
         .applicationComponent(activity.application.applicationComponent)
-        .favoritesModule(FavoritesModule())
-        .navigationModule(NavigationModule())
         .activityContextModule(ActivityContextModule(activity))
         .build()
 }

--- a/app/src/main/java/net/squanchy/navigation/RoutingComponent.kt
+++ b/app/src/main/java/net/squanchy/navigation/RoutingComponent.kt
@@ -17,10 +17,6 @@ internal fun routingComponent(activity: AppCompatActivity) =
     DaggerRoutingComponent.builder()
         .activityContextModule(ActivityContextModule(activity))
         .applicationComponent(activity.applicationComponent)
-        .deepLinkModule(DeepLinkModule())
-        .navigationModule(NavigationModule())
-        .signInModule(SignInModule())
-        .routingModule(RoutingModule())
         .build()
 
 @ActivityLifecycle

--- a/app/src/main/java/net/squanchy/schedule/ScheduleComponent.kt
+++ b/app/src/main/java/net/squanchy/schedule/ScheduleComponent.kt
@@ -17,10 +17,7 @@ import net.squanchy.support.system.CurrentTime
 
 internal fun scheduleComponent(activity: AppCompatActivity): ScheduleComponent = DaggerScheduleComponent.builder()
     .applicationComponent(activity.applicationComponent)
-    .scheduleModule(ScheduleModule())
-    .navigationModule(NavigationModule())
     .activityContextModule(ActivityContextModule(activity))
-    .currentTimeModule(CurrentTimeModule())
     .build()
 
 @ActivityLifecycle

--- a/app/src/main/java/net/squanchy/search/SearchComponent.kt
+++ b/app/src/main/java/net/squanchy/search/SearchComponent.kt
@@ -12,9 +12,7 @@ import net.squanchy.injection.applicationComponent
 internal fun searchComponent(activity: SearchActivity) =
     DaggerSearchComponent.builder()
         .applicationComponent(activity.applicationComponent)
-        .searchModule(SearchModule())
         .activityContextModule(ActivityContextModule(activity))
-        .navigationModule(NavigationModule())
         .build()
 
 @ActivityLifecycle

--- a/app/src/main/java/net/squanchy/settings/SettingsActivityComponent.kt
+++ b/app/src/main/java/net/squanchy/settings/SettingsActivityComponent.kt
@@ -11,7 +11,6 @@ import net.squanchy.signin.SignInService
 internal fun settingsActivityComponent(activity: Activity) =
     DaggerSettingsActivityComponent.builder()
         .applicationComponent(activity.applicationComponent)
-        .signInModule(SignInModule())
         .build()
 
 @ActivityLifecycle

--- a/app/src/main/java/net/squanchy/settings/SettingsFragmentComponent.kt
+++ b/app/src/main/java/net/squanchy/settings/SettingsFragmentComponent.kt
@@ -19,9 +19,6 @@ internal fun settingsFragmentComponent(activity: AppCompatActivity) =
     DaggerSettingsFragmentComponent.builder()
         .activityContextModule(ActivityContextModule(activity))
         .applicationComponent(activity.applicationComponent)
-        .navigationModule(NavigationModule())
-        .signInModule(SignInModule())
-        .wifiConfigModule(WifiConfigModule())
         .build()
 
 @ActivityLifecycle

--- a/app/src/main/java/net/squanchy/signin/SignInComponent.kt
+++ b/app/src/main/java/net/squanchy/signin/SignInComponent.kt
@@ -10,7 +10,6 @@ import net.squanchy.injection.applicationComponent
 fun signInComponent(activity: Activity): SignInComponent =
     DaggerSignInComponent.builder()
         .applicationComponent(activity.applicationComponent)
-        .signInModule(SignInModule())
         .build()
 
 @ActivityLifecycle

--- a/app/src/main/java/net/squanchy/speaker/SpeakerDetailsComponent.kt
+++ b/app/src/main/java/net/squanchy/speaker/SpeakerDetailsComponent.kt
@@ -12,9 +12,7 @@ import net.squanchy.injection.applicationComponent
 internal fun speakerDetailsComponent(activity: SpeakerDetailsActivity): SpeakerDetailsComponent =
     DaggerSpeakerDetailsComponent.builder()
         .applicationComponent(activity.applicationComponent)
-        .speakerDetailsModule(SpeakerDetailsModule())
         .activityContextModule(ActivityContextModule(activity))
-        .navigationModule(NavigationModule())
         .build()
 
 @ActivityLifecycle

--- a/app/src/main/java/net/squanchy/tweets/TwitterComponent.kt
+++ b/app/src/main/java/net/squanchy/tweets/TwitterComponent.kt
@@ -14,8 +14,6 @@ internal fun twitterComponent(activity: AppCompatActivity): TwitterComponent {
     return DaggerTwitterComponent.builder()
         .applicationComponent(activity.applicationComponent)
         .activityContextModule(ActivityContextModule(activity))
-        .twitterModule(TwitterModule())
-        .navigationModule(NavigationModule())
         .build()
 }
 

--- a/app/src/main/java/net/squanchy/venue/VenueInfoComponent.kt
+++ b/app/src/main/java/net/squanchy/venue/VenueInfoComponent.kt
@@ -12,8 +12,6 @@ import net.squanchy.navigation.Navigator
 internal fun venueInfoComponent(activity: AppCompatActivity) =
     DaggerVenueInfoComponent.builder()
             .applicationComponent(activity.applicationComponent)
-            .navigationModule(NavigationModule())
-            .venueInfoModule(VenueInfoModule())
             .activityContextModule(ActivityContextModule(activity))
             .build()
 


### PR DESCRIPTION
## Problem

Dagger is able to create an instance of a module on its own, so we have a few lines of code that are not really needed right now.

This is part of a series of PRs about optimising Dagger

## Solution

Just remove those lines

### Test(s) added

In this case the fact that it builds is our test

### Paired with

Nobody
