### PR TITLE
Use single brackets for if in git hooks

### DIFF
--- a/team-props/git-hooks/pre-push.sh
+++ b/team-props/git-hooks/pre-push.sh
@@ -7,7 +7,7 @@ echo "Running static analysis..."
 
 status=$?
 
-if [[ "$status" = 0 ]] ; then
+if [ "$status" = 0 ] ; then
     echo "Static analysis found no issues. Proceeding with push."
     exit 0
 else


### PR DESCRIPTION
## Problem

I noticed that the double brackets in the if statements in the pre-push hooks weren't picked up by my machine, then I found out that they're not portable.

http://mywiki.wooledge.org/BashFAQ/031

## Solution

Revert to a single bracket as it works for this case