### PR TITLE
Use checkbox instead of FAB

### DIFF
--- a/app/src/main/java/net/squanchy/eventdetails/widget/EventDetailsCoordinatorLayout.kt
+++ b/app/src/main/java/net/squanchy/eventdetails/widget/EventDetailsCoordinatorLayout.kt
@@ -20,9 +20,7 @@ class EventDetailsCoordinatorLayout @JvmOverloads constructor(
         eventDetailsLayout.updateWith(event)
 
         if (event.canBeFavorited) {
-            // Updates the FAB image state to trigger an AVD animation.
-            val stateSet = intArrayOf(android.R.attr.state_checked * if (event.favorite) 1 else -1)
-            favoriteFab.setImageState(stateSet, true)
+            favoriteFab.isChecked = event.favorite
             favoriteFab.setOnClickListener { listener.onFavoriteClick() }
             favoriteFab.isVisible = true
         } else {

--- a/app/src/main/res/drawable/ic_favorite_with_background.xml
+++ b/app/src/main/res/drawable/ic_favorite_with_background.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+  <item>
+    <shape
+      android:shape="oval" android:tint="@color/selector_color_primary" />
+  </item>
+  <item android:drawable="@drawable/animselector_ic_favorite" />
+</layer-list>

--- a/app/src/main/res/layout/activity_event_details.xml
+++ b/app/src/main/res/layout/activity_event_details.xml
@@ -72,7 +72,7 @@
 
   </androidx.core.widget.NestedScrollView>
 
-  <com.google.android.material.floatingactionbutton.FloatingActionButton
+  <CheckBox
     android:id="@+id/favoriteFab"
     style="@style/EventDetails.Fab"
     android:layout_width="wrap_content"

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -268,12 +268,9 @@
   </style>
 
   <style name="EventDetails.Fab" parent="None">
-    <item name="backgroundTint">@color/selector_color_primary</item>
-    <item name="maxImageSize">@dimen/event_details_fab_image_size</item>
     <item name="android:clickable">true</item>
     <item name="android:foreground">@drawable/white_circle_bound_touch_feedback</item>
-    <item name="android:src">@drawable/animselector_ic_favorite</item>
-    <item name="android:scaleType">center</item>
+    <item name="android:button">@drawable/ic_favorite_with_background</item>
   </style>
 
   <style name="Tweets.EmptyView" parent="None">


### PR DESCRIPTION
## Problem

#594 

## Solution

The default implementation of FAB seems like it doesn't keep the state after coming back from another activity. We decided to go for a simple checkbox as it does the trick and there's is plan to remove CoordinatorLayout altogether soon.
