### PR TITLE
User opt out analytics

### DIFF
--- a/app/src/main/java/net/squanchy/SquanchyApplication.kt
+++ b/app/src/main/java/net/squanchy/SquanchyApplication.kt
@@ -30,7 +30,7 @@ class SquanchyApplication : Application() {
         initializeFabric()
 
         with(applicationComponent.analytics()) {
-            enableExceptionLogging()
+            setupExceptionLogging()
             initializeStaticUserProperties()
             trackFirstStartUserNotLoggedIn()
             trackFirstStartNotificationsEnabled()

--- a/app/src/main/java/net/squanchy/analytics/Analytics.kt
+++ b/app/src/main/java/net/squanchy/analytics/Analytics.kt
@@ -12,7 +12,7 @@ interface Analytics {
     fun trackItemSelected(contentType: ContentType, itemId: String)
     fun trackItemSelectedOnFirebaseAnalytics(contentType: ContentType, itemId: String)
     fun trackItemSelectedOnCrashlytics(contentType: ContentType, itemId: String)
-    fun enableExceptionLogging()
+    fun setupExceptionLogging()
     fun trackFirstStartUserNotLoggedIn()
     fun trackFirstStartNotificationsEnabled()
     fun trackNotificationsEnabled()

--- a/app/src/main/java/net/squanchy/analytics/Analytics.kt
+++ b/app/src/main/java/net/squanchy/analytics/Analytics.kt
@@ -1,16 +1,8 @@
 package net.squanchy.analytics
 
 import android.app.Activity
-import android.os.Bundle
-import com.crashlytics.android.Crashlytics
-import com.crashlytics.android.answers.ContentViewEvent
-import com.crashlytics.android.answers.CustomEvent
-import com.google.firebase.analytics.FirebaseAnalytics
-import net.squanchy.BuildConfig
 import net.squanchy.signin.SignInOrigin
 import net.squanchy.wificonfig.WifiConfigOrigin
-import timber.log.Timber
-import java.util.Locale
 
 interface Analytics {
     fun initializeStaticUserProperties()
@@ -27,129 +19,8 @@ interface Analytics {
     fun trackNotificationsDisabled()
     fun trackFavoritesInScheduleEnabled()
     fun trackFavoritesInScheduleDisabled()
-    fun flagEnabled(value: String): Bundle
     fun trackUserNotLoggedIn()
     fun trackUserLoggedInFrom(signInOrigin: SignInOrigin)
     fun setUserLoginProperty(loginStatus: LoginStatus)
     fun trackWifiConfigurationEvent(isSuccess: Boolean, wifiConfigOrigin: WifiConfigOrigin)
-}
-
-class EnabledAnalytics internal constructor(
-    private val firebaseAnalytics: FirebaseAnalytics,
-    private val crashlytics: Crashlytics,
-    private val firstStartDetector: FirstStartDetector
-) : Analytics {
-
-    override fun initializeStaticUserProperties() {
-        firebaseAnalytics.setUserProperty("debug_build", BuildConfig.DEBUG.toString())
-    }
-
-    override fun trackPageView(activity: Activity, screenName: String, screenClassOverride: String?) {
-        trackPageViewOnFirebaseAnalytics(activity, screenName, screenClassOverride)
-        trackPageViewOnCrashlytics(screenName)
-    }
-
-    override fun trackPageViewOnFirebaseAnalytics(activity: Activity, screenName: String, screenClassOverride: String?) {
-        firebaseAnalytics.setCurrentScreen(activity, screenName, screenClassOverride)
-    }
-
-    override fun trackPageViewOnCrashlytics(screenName: String) {
-        val viewEvent = ContentViewEvent()
-        viewEvent.putContentName(screenName.toLowerCase(Locale.US))
-        viewEvent.putContentId(screenName)
-        viewEvent.putContentType("screen")
-        crashlytics.answers.logContentView(viewEvent)
-    }
-
-    override fun trackItemSelected(contentType: ContentType, itemId: String) {
-        trackItemSelectedOnFirebaseAnalytics(contentType, itemId)
-        trackItemSelectedOnCrashlytics(contentType, itemId)
-    }
-
-    override fun trackItemSelectedOnFirebaseAnalytics(contentType: ContentType, itemId: String) {
-        val params = Bundle().apply {
-            putString(FirebaseAnalytics.Param.CONTENT_TYPE, contentType.rawContentType)
-            putString(FirebaseAnalytics.Param.ITEM_ID, itemId)
-        }
-        firebaseAnalytics.logEvent(FirebaseAnalytics.Event.SELECT_CONTENT, params)
-    }
-
-    override fun trackItemSelectedOnCrashlytics(contentType: ContentType, itemId: String) {
-        val event = CustomEvent("item_selected")
-        event.putCustomAttribute("content_type", contentType.rawContentType)
-        event.putCustomAttribute("item_id", itemId)
-        crashlytics.answers.logCustom(event)
-    }
-
-    override fun enableExceptionLogging() {
-        Timber.plant(CrashlyticsErrorsTree())
-    }
-
-    override fun trackFirstStartUserNotLoggedIn() {
-        if (firstStartDetector.isFirstStartNotLoggedInStatusTracked()) {
-            return
-        }
-        trackUserNotLoggedIn()
-        firstStartDetector.setFirstStartNotLoggedInStatusTracked()
-    }
-
-    override fun trackFirstStartNotificationsEnabled() {
-        if (firstStartDetector.isFirstStartNotificationsEnabledTracked()) {
-            return
-        }
-        trackNotificationsEnabled()
-        firstStartDetector.setFirstStartNotificationsEnabledTracked()
-    }
-
-    override fun trackNotificationsEnabled() {
-        firebaseAnalytics.setUserProperty("notifications_status", "enabled")
-        firebaseAnalytics.logEvent("notifications_status_changed", flagEnabled(TRUE))
-    }
-
-    override fun trackNotificationsDisabled() {
-        firebaseAnalytics.setUserProperty("notifications_status", "disabled")
-        firebaseAnalytics.logEvent("notifications_status_changed", flagEnabled(FALSE))
-    }
-
-    override fun trackFavoritesInScheduleEnabled() {
-        firebaseAnalytics.setUserProperty("favorites_in_schedule", "enable")
-        firebaseAnalytics.logEvent("favorites_in_schedule_changed", flagEnabled(TRUE))
-    }
-
-    override fun trackFavoritesInScheduleDisabled() {
-        firebaseAnalytics.setUserProperty("favorites_in_schedule", "disabled")
-        firebaseAnalytics.logEvent("favorites_in_schedule_changed", flagEnabled(FALSE))
-    }
-
-    override fun flagEnabled(value: String) = Bundle().apply { putString("enabled", value) }
-
-    override fun trackUserNotLoggedIn() {
-        setUserLoginProperty(LoginStatus.NOT_LOGGED_IN)
-    }
-
-    override fun trackUserLoggedInFrom(signInOrigin: SignInOrigin) {
-        when (signInOrigin) {
-            SignInOrigin.ONBOARDING -> setUserLoginProperty(LoginStatus.LOGGED_IN_ONBOARDING)
-            SignInOrigin.FAVORITES -> setUserLoginProperty(LoginStatus.LOGGED_IN_FAVORITES)
-            SignInOrigin.EVENT_DETAILS -> setUserLoginProperty(LoginStatus.LOGGED_IN_EVENT_DETAILS)
-            SignInOrigin.SETTINGS -> setUserLoginProperty(LoginStatus.LOGGED_IN_SETTINGS)
-        }
-    }
-
-    override fun setUserLoginProperty(loginStatus: LoginStatus) {
-        firebaseAnalytics.setUserProperty("login_status", loginStatus.rawLoginStatus)
-    }
-
-    override fun trackWifiConfigurationEvent(isSuccess: Boolean, wifiConfigOrigin: WifiConfigOrigin) {
-        val params = Bundle().apply {
-            putString("origin", wifiConfigOrigin.rawOrigin)
-            putBoolean("success", isSuccess)
-        }
-        firebaseAnalytics.logEvent("wifi_config", params)
-    }
-
-    companion object {
-        private const val TRUE = "true"
-        private const val FALSE = "false"
-    }
 }

--- a/app/src/main/java/net/squanchy/analytics/AnalyticsModule.kt
+++ b/app/src/main/java/net/squanchy/analytics/AnalyticsModule.kt
@@ -28,7 +28,7 @@ class AnalyticsModule {
         crashlytics: Crashlytics,
         firstStartDetector: FirstStartDetector
     ): Analytics {
-        return Analytics(firebaseAnalytics, crashlytics, firstStartDetector)
+        return EnabledAnalytics(firebaseAnalytics, crashlytics, firstStartDetector)
     }
 
     companion object {

--- a/app/src/main/java/net/squanchy/analytics/AnalyticsModule.kt
+++ b/app/src/main/java/net/squanchy/analytics/AnalyticsModule.kt
@@ -2,10 +2,12 @@ package net.squanchy.analytics
 
 import android.app.Application
 import android.content.Context
+import android.preference.PreferenceManager
 import com.crashlytics.android.Crashlytics
 import com.google.firebase.analytics.FirebaseAnalytics
 import dagger.Module
 import dagger.Provides
+import net.squanchy.R
 
 @Module
 class AnalyticsModule {
@@ -24,11 +26,22 @@ class AnalyticsModule {
 
     @Provides
     internal fun analytics(
+        application: Application,
         firebaseAnalytics: FirebaseAnalytics,
         crashlytics: Crashlytics,
         firstStartDetector: FirstStartDetector
     ): Analytics {
+        if (analyticsDisabledByUser(application)) {
+            return DisabledAnalytics()
+        }
+
         return EnabledAnalytics(firebaseAnalytics, crashlytics, firstStartDetector)
+    }
+
+    private fun analyticsDisabledByUser(application: Application): Boolean {
+        val preferenceKey = application.getString(R.string.disable_analytics_key)
+        return PreferenceManager.getDefaultSharedPreferences(application)
+            .getBoolean(preferenceKey, false)
     }
 
     companion object {

--- a/app/src/main/java/net/squanchy/analytics/DisabledAnalytics.kt
+++ b/app/src/main/java/net/squanchy/analytics/DisabledAnalytics.kt
@@ -21,11 +21,9 @@ class DisabledAnalytics : Analytics {
     override fun trackItemSelectedOnCrashlytics(contentType: ContentType, itemId: String) = Unit
 
     override fun setupExceptionLogging() {
-        Timber.forest().find {
-            it is CrashlyticsErrorsTree
-        }?.let {
-            Timber.uproot(it)
-        }
+        Timber.forest()
+            .find { it is CrashlyticsErrorsTree }
+            ?.let { Timber.uproot(it) }
     }
 
     override fun trackFirstStartUserNotLoggedIn() = Unit

--- a/app/src/main/java/net/squanchy/analytics/DisabledAnalytics.kt
+++ b/app/src/main/java/net/squanchy/analytics/DisabledAnalytics.kt
@@ -1,0 +1,50 @@
+package net.squanchy.analytics
+
+import android.app.Activity
+import net.squanchy.signin.SignInOrigin
+import net.squanchy.wificonfig.WifiConfigOrigin
+import timber.log.Timber
+
+class DisabledAnalytics : Analytics {
+    override fun initializeStaticUserProperties() = Unit
+
+    override fun trackPageView(activity: Activity, screenName: String, screenClassOverride: String?) = Unit
+
+    override fun trackPageViewOnFirebaseAnalytics(activity: Activity, screenName: String, screenClassOverride: String?) = Unit
+
+    override fun trackPageViewOnCrashlytics(screenName: String) = Unit
+
+    override fun trackItemSelected(contentType: ContentType, itemId: String) = Unit
+
+    override fun trackItemSelectedOnFirebaseAnalytics(contentType: ContentType, itemId: String) = Unit
+
+    override fun trackItemSelectedOnCrashlytics(contentType: ContentType, itemId: String) = Unit
+
+    override fun setupExceptionLogging() {
+        Timber.forest().find {
+            it is CrashlyticsErrorsTree
+        }?.let {
+            Timber.uproot(it)
+        }
+    }
+
+    override fun trackFirstStartUserNotLoggedIn() = Unit
+
+    override fun trackFirstStartNotificationsEnabled() = Unit
+
+    override fun trackNotificationsEnabled() = Unit
+
+    override fun trackNotificationsDisabled() = Unit
+
+    override fun trackFavoritesInScheduleEnabled() = Unit
+
+    override fun trackFavoritesInScheduleDisabled() = Unit
+
+    override fun trackUserNotLoggedIn() = Unit
+
+    override fun trackUserLoggedInFrom(signInOrigin: SignInOrigin) = Unit
+
+    override fun setUserLoginProperty(loginStatus: LoginStatus) = Unit
+
+    override fun trackWifiConfigurationEvent(isSuccess: Boolean, wifiConfigOrigin: WifiConfigOrigin) = Unit
+}

--- a/app/src/main/java/net/squanchy/analytics/EnabledAnalytics.kt
+++ b/app/src/main/java/net/squanchy/analytics/EnabledAnalytics.kt
@@ -59,7 +59,7 @@ class EnabledAnalytics internal constructor(
         crashlytics.answers.logCustom(event)
     }
 
-    override fun enableExceptionLogging() {
+    override fun setupExceptionLogging() {
         Timber.plant(CrashlyticsErrorsTree())
     }
 

--- a/app/src/main/java/net/squanchy/analytics/EnabledAnalytics.kt
+++ b/app/src/main/java/net/squanchy/analytics/EnabledAnalytics.kt
@@ -1,0 +1,133 @@
+package net.squanchy.analytics
+
+import android.app.Activity
+import android.os.Bundle
+import com.crashlytics.android.Crashlytics
+import com.crashlytics.android.answers.ContentViewEvent
+import com.crashlytics.android.answers.CustomEvent
+import com.google.firebase.analytics.FirebaseAnalytics
+import net.squanchy.BuildConfig
+import net.squanchy.signin.SignInOrigin
+import net.squanchy.wificonfig.WifiConfigOrigin
+import timber.log.Timber
+import java.util.Locale
+
+class EnabledAnalytics internal constructor(
+    private val firebaseAnalytics: FirebaseAnalytics,
+    private val crashlytics: Crashlytics,
+    private val firstStartDetector: FirstStartDetector
+) : Analytics {
+
+    override fun initializeStaticUserProperties() {
+        firebaseAnalytics.setUserProperty("debug_build", BuildConfig.DEBUG.toString())
+    }
+
+    override fun trackPageView(activity: Activity, screenName: String, screenClassOverride: String?) {
+        trackPageViewOnFirebaseAnalytics(activity, screenName, screenClassOverride)
+        trackPageViewOnCrashlytics(screenName)
+    }
+
+    override fun trackPageViewOnFirebaseAnalytics(activity: Activity, screenName: String, screenClassOverride: String?) {
+        firebaseAnalytics.setCurrentScreen(activity, screenName, screenClassOverride)
+    }
+
+    override fun trackPageViewOnCrashlytics(screenName: String) {
+        val viewEvent = ContentViewEvent()
+        viewEvent.putContentName(screenName.toLowerCase(Locale.US))
+        viewEvent.putContentId(screenName)
+        viewEvent.putContentType("screen")
+        crashlytics.answers.logContentView(viewEvent)
+    }
+
+    override fun trackItemSelected(contentType: ContentType, itemId: String) {
+        trackItemSelectedOnFirebaseAnalytics(contentType, itemId)
+        trackItemSelectedOnCrashlytics(contentType, itemId)
+    }
+
+    override fun trackItemSelectedOnFirebaseAnalytics(contentType: ContentType, itemId: String) {
+        val params = Bundle().apply {
+            putString(FirebaseAnalytics.Param.CONTENT_TYPE, contentType.rawContentType)
+            putString(FirebaseAnalytics.Param.ITEM_ID, itemId)
+        }
+        firebaseAnalytics.logEvent(FirebaseAnalytics.Event.SELECT_CONTENT, params)
+    }
+
+    override fun trackItemSelectedOnCrashlytics(contentType: ContentType, itemId: String) {
+        val event = CustomEvent("item_selected")
+        event.putCustomAttribute("content_type", contentType.rawContentType)
+        event.putCustomAttribute("item_id", itemId)
+        crashlytics.answers.logCustom(event)
+    }
+
+    override fun enableExceptionLogging() {
+        Timber.plant(CrashlyticsErrorsTree())
+    }
+
+    override fun trackFirstStartUserNotLoggedIn() {
+        if (firstStartDetector.isFirstStartNotLoggedInStatusTracked()) {
+            return
+        }
+        trackUserNotLoggedIn()
+        firstStartDetector.setFirstStartNotLoggedInStatusTracked()
+    }
+
+    override fun trackFirstStartNotificationsEnabled() {
+        if (firstStartDetector.isFirstStartNotificationsEnabledTracked()) {
+            return
+        }
+        trackNotificationsEnabled()
+        firstStartDetector.setFirstStartNotificationsEnabledTracked()
+    }
+
+    override fun trackNotificationsEnabled() {
+        firebaseAnalytics.setUserProperty("notifications_status", "enabled")
+        firebaseAnalytics.logEvent("notifications_status_changed", flagEnabled(TRUE))
+    }
+
+    override fun trackNotificationsDisabled() {
+        firebaseAnalytics.setUserProperty("notifications_status", "disabled")
+        firebaseAnalytics.logEvent("notifications_status_changed", flagEnabled(FALSE))
+    }
+
+    override fun trackFavoritesInScheduleEnabled() {
+        firebaseAnalytics.setUserProperty("favorites_in_schedule", "enable")
+        firebaseAnalytics.logEvent("favorites_in_schedule_changed", flagEnabled(TRUE))
+    }
+
+    override fun trackFavoritesInScheduleDisabled() {
+        firebaseAnalytics.setUserProperty("favorites_in_schedule", "disabled")
+        firebaseAnalytics.logEvent("favorites_in_schedule_changed", flagEnabled(FALSE))
+    }
+
+    private fun flagEnabled(value: String) = Bundle().apply { putString("enabled", value) }
+
+    override fun trackUserNotLoggedIn() {
+        setUserLoginProperty(LoginStatus.NOT_LOGGED_IN)
+    }
+
+    override fun trackUserLoggedInFrom(signInOrigin: SignInOrigin) {
+        when (signInOrigin) {
+            SignInOrigin.ONBOARDING -> setUserLoginProperty(LoginStatus.LOGGED_IN_ONBOARDING)
+            SignInOrigin.FAVORITES -> setUserLoginProperty(LoginStatus.LOGGED_IN_FAVORITES)
+            SignInOrigin.EVENT_DETAILS -> setUserLoginProperty(LoginStatus.LOGGED_IN_EVENT_DETAILS)
+            SignInOrigin.SETTINGS -> setUserLoginProperty(LoginStatus.LOGGED_IN_SETTINGS)
+        }
+    }
+
+    override fun setUserLoginProperty(loginStatus: LoginStatus) {
+        firebaseAnalytics.setUserProperty("login_status", loginStatus.rawLoginStatus)
+    }
+
+    override fun trackWifiConfigurationEvent(isSuccess: Boolean, wifiConfigOrigin: WifiConfigOrigin) {
+        val params = Bundle().apply {
+            putString("origin", wifiConfigOrigin.rawOrigin)
+            putBoolean("success", isSuccess)
+        }
+        firebaseAnalytics.logEvent("wifi_config", params)
+    }
+
+    companion object {
+        private const val TRUE = "true"
+        private const val FALSE = "false"
+    }
+}

--- a/app/src/main/java/net/squanchy/settings/SettingsFragment.kt
+++ b/app/src/main/java/net/squanchy/settings/SettingsFragment.kt
@@ -95,6 +95,15 @@ class SettingsFragment : PreferenceFragment() {
         }
 
         setupWifiConfigPreference()
+
+        val disableAnalyticsPreferences = findPreference(getString(R.string.disable_analytics_key))
+        disableAnalyticsPreferences.setOnPreferenceChangeListener { _, _ ->
+            with(settingsFragmentComponent(activity)) {
+                analytics = analytics()
+            }
+            analytics.setupExceptionLogging()
+            true
+        }
     }
 
     private fun displayBuildVersion() {

--- a/app/src/main/res/drawable/ic_analytics.xml
+++ b/app/src/main/res/drawable/ic_analytics.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:fillColor="@color/selector_color_primary"
+      android:pathData="M9,17L7,17v-7h2v7zM13,17h-2L11,7h2v10zM17,17h-2v-4h2v4zM19.5,19.1h-15L4.5,5h15v14.1zM19.5,3h-15c-1.1,0 -2,0.9 -2,2v14c0,1.1 0.9,2 2,2h15c1.1,0 2,-0.9 2,-2L21.5,5c0,-1.1 -0.9,-2 -2,-2z"/>
+</vector>

--- a/app/src/main/res/values/preference_keys.xml
+++ b/app/src/main/res/values/preference_keys.xml
@@ -12,5 +12,6 @@
   <string name="about_preference_key" translatable="false">about_preference_key</string>
   <string name="debug_category_preference_key" translatable="false">debug_category_preference_key</string>
   <string name="open_debug_preference_key" translatable="false">open_debug_preference_key</string>
+  <string name="disable_analytics_key" translatable="false">disable_analytics_key</string>
 
 </resources>

--- a/app/src/main/res/values/preference_keys.xml
+++ b/app/src/main/res/values/preference_keys.xml
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
-  <string name="about_to_start_notification_preference_key">about_to_start_notification_preference_key</string>
-  <string name="auto_wifi_preference_key">auto_wifi_preference_key</string>
-  <string name="favorites_in_schedule_preference_key">favorites_in_schedule_preference_key</string>
-  <string name="build_version_preference_key">build_version_preference_key</string>
-  <string name="account_category_key">account_category_key</string>
-  <string name="account_email_preference_key">account_email_preference_key</string>
-  <string name="account_signin_signout_preference_key">account_signin_signout_preference_key</string>
-  <string name="settings_category_key">settings_category_key</string>
-  <string name="about_preference_key">about_preference_key</string>
-  <string name="debug_category_preference_key">debug_category_preference_key</string>
-  <string name="open_debug_preference_key">open_debug_preference_key</string>
+  <string name="about_to_start_notification_preference_key" translatable="false">about_to_start_notification_preference_key</string>
+  <string name="auto_wifi_preference_key" translatable="false">auto_wifi_preference_key</string>
+  <string name="favorites_in_schedule_preference_key" translatable="false">favorites_in_schedule_preference_key</string>
+  <string name="build_version_preference_key" translatable="false">build_version_preference_key</string>
+  <string name="account_category_key" translatable="false">account_category_key</string>
+  <string name="account_email_preference_key" translatable="false">account_email_preference_key</string>
+  <string name="account_signin_signout_preference_key" translatable="false">account_signin_signout_preference_key</string>
+  <string name="settings_category_key" translatable="false">settings_category_key</string>
+  <string name="about_preference_key" translatable="false">about_preference_key</string>
+  <string name="debug_category_preference_key" translatable="false">debug_category_preference_key</string>
+  <string name="open_debug_preference_key" translatable="false">open_debug_preference_key</string>
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -69,6 +69,7 @@
   <string name="settings_message_wifi_success">Wi-Fi network successfully configured</string>
   <string name="about_title">About</string>
   <string name="auto_wifi_title">Configure Wi-Fi</string>
+  <string name="disable_analytics_title">Do not track me</string>
   <string name="favorites_in_schedule_title">Show favorites in schedule</string>
   <string name="settings_account_not_signed_in">Not signed in</string>
   <string name="settings_header_not_signed_in">You’re not signed in</string>

--- a/app/src/main/res/xml/settings_preferences.xml
+++ b/app/src/main/res/xml/settings_preferences.xml
@@ -46,23 +46,29 @@
       android:defaultValue="false"
       android:order="1" />
 
+    <SwitchPreference
+      android:key="@string/disable_analytics_key"
+      android:title="@string/disable_analytics_title"
+      android:icon="@drawable/ic_analytics"
+      android:order="2" />
+
     <Preference
       android:key="@string/auto_wifi_preference_key"
       android:title="@string/auto_wifi_title"
       android:icon="@drawable/ic_wifi"
-      android:order="2" />
+      android:order="3" />
 
     <Preference
       android:key="@string/about_preference_key"
       android:title="@string/about_title"
       android:icon="@drawable/ic_about"
-      android:order="3" />
+      android:order="4" />
 
     <Preference
       android:key="@string/build_version_preference_key"
       android:selectable="false"
       android:icon="@android:color/transparent"
-      android:order="4"
+      android:order="5"
       tools:title="Version: 1.0.0" />
 
   </PreferenceCategory>


### PR DESCRIPTION
## Problem

#515 

## Solution

I extracted a common interface: `Analytics`, and 2 implementations: `EnabledAnalytics` and `DisabledAnalytics`. I also changed `Analytics::enableExceptionLogging()` to `Analytics::setupExceptionLogging()`, where `DisabledAnalytics` will look up a `CrashlyticsErrorsTree` instance in `Timber` and possibly uproot it. 

Since our analytics class isn't a singleton, this should work out of the box, I made sure to re-invoke the setup for the exception logging after the preference changes (so it gets planted or uprooted as necessary).

### Test(s) added

Didn't test, mostly Android preference related things.

### Screenshots

![image](https://user-images.githubusercontent.com/1263058/50044733-5d288680-0088-11e9-8f78-8f988abc7d35.png)
