### PR TITLE
Use motion layout in event details

### DIFF
--- a/app/src/main/java/net/squanchy/eventdetails/EventDetailsActivity.kt
+++ b/app/src/main/java/net/squanchy/eventdetails/EventDetailsActivity.kt
@@ -10,7 +10,7 @@ import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.disposables.CompositeDisposable
 import kotlinx.android.synthetic.main.activity_event_details.*
 import net.squanchy.R
-import net.squanchy.eventdetails.widget.EventDetailsCoordinatorLayout
+import net.squanchy.eventdetails.widget.EventDetailsRootLayout
 import net.squanchy.navigation.Navigator
 import net.squanchy.notification.NotificationsIntentService
 import net.squanchy.schedule.domain.view.Event
@@ -73,8 +73,8 @@ class EventDetailsActivity : AppCompatActivity() {
         )
     }
 
-    private fun onEventDetailsClickListener(event: Event): EventDetailsCoordinatorLayout.OnEventDetailsClickListener =
-        object : EventDetailsCoordinatorLayout.OnEventDetailsClickListener {
+    private fun onEventDetailsClickListener(event: Event): EventDetailsRootLayout.OnEventDetailsClickListener =
+        object : EventDetailsRootLayout.OnEventDetailsClickListener {
             override fun onSpeakerClicked(speaker: Speaker) {
                 navigator.toSpeakerDetails(speaker.id)
             }

--- a/app/src/main/java/net/squanchy/eventdetails/widget/EventDetailsRootLayout.kt
+++ b/app/src/main/java/net/squanchy/eventdetails/widget/EventDetailsRootLayout.kt
@@ -2,18 +2,18 @@ package net.squanchy.eventdetails.widget
 
 import android.content.Context
 import android.util.AttributeSet
-import androidx.coordinatorlayout.widget.CoordinatorLayout
+import androidx.constraintlayout.motion.widget.MotionLayout
 import androidx.core.view.isVisible
 import kotlinx.android.synthetic.main.activity_event_details.view.*
 import net.squanchy.schedule.domain.view.Event
 import net.squanchy.schedule.domain.view.Event.Type
 import net.squanchy.support.widget.SpeakerView
 
-class EventDetailsCoordinatorLayout @JvmOverloads constructor(
+class EventDetailsRootLayout @JvmOverloads constructor(
     context: Context,
     attrs: AttributeSet,
     defStyleAttr: Int = 0
-) : CoordinatorLayout(context, attrs, defStyleAttr) {
+) : MotionLayout(context, attrs, defStyleAttr) {
 
     internal fun updateWith(event: Event, listener: OnEventDetailsClickListener) {
         eventDetailsHeaderLayout.updateWith(event, listener)

--- a/app/src/main/res/layout/activity_event_details.xml
+++ b/app/src/main/res/layout/activity_event_details.xml
@@ -62,8 +62,8 @@
 
   <androidx.core.widget.NestedScrollView
     android:id="@+id/eventDetailsScrollView"
-    android:layout_width="0dp"
-    android:layout_height="0dp"
+    android:layout_width="@dimen/match_constraint"
+    android:layout_height="@dimen/match_constraint"
     app:layout_constraintTop_toBottomOf="@id/eventDetailsHeaderLayout"
     app:layout_constraintStart_toStartOf="parent"
     app:layout_constraintEnd_toEndOf="parent"

--- a/app/src/main/res/layout/activity_event_details.xml
+++ b/app/src/main/res/layout/activity_event_details.xml
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
-<net.squanchy.eventdetails.widget.EventDetailsCoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<net.squanchy.eventdetails.widget.EventDetailsRootLayout xmlns:android="http://schemas.android.com/apk/res/android"
   xmlns:app="http://schemas.android.com/apk/res-auto"
   xmlns:tools="http://schemas.android.com/tools"
   android:id="@+id/eventDetailsRoot"
   android:layout_width="match_parent"
-  android:layout_height="match_parent">
+  android:layout_height="match_parent"
+  app:layoutDescription="@xml/scene_event_details">
 
   <net.squanchy.eventdetails.widget.EventDetailsHeaderLayout
     android:id="@+id/eventDetailsHeaderLayout"
@@ -60,9 +61,13 @@
   </net.squanchy.eventdetails.widget.EventDetailsHeaderLayout>
 
   <androidx.core.widget.NestedScrollView
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    app:layout_behavior="@string/appbar_scrolling_view_behavior">
+    android:id="@+id/eventDetailsScrollView"
+    android:layout_width="0dp"
+    android:layout_height="0dp"
+    app:layout_constraintTop_toBottomOf="@id/eventDetailsHeaderLayout"
+    app:layout_constraintStart_toStartOf="parent"
+    app:layout_constraintEnd_toEndOf="parent"
+    app:layout_constraintBottom_toBottomOf="parent">
 
     <net.squanchy.eventdetails.widget.EventDetailsLayout
       android:id="@+id/eventDetailsLayout"
@@ -78,8 +83,9 @@
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
     android:layout_margin="@dimen/event_details_fab_margin"
-    android:layout_gravity="end|bottom"
+    app:layout_constraintEnd_toEndOf="parent"
+    app:layout_constraintBottom_toBottomOf="parent"
     android:visibility="gone"
     tools:visibility="visible" />
 
-</net.squanchy.eventdetails.widget.EventDetailsCoordinatorLayout>
+</net.squanchy.eventdetails.widget.EventDetailsRootLayout>

--- a/app/src/main/res/layout/merge_event_details_layout.xml
+++ b/app/src/main/res/layout/merge_event_details_layout.xml
@@ -21,6 +21,8 @@
     android:orientation="vertical"
     app:layout_constraintGuide_begin="@dimen/event_details_body_label_margin_start" />
 
+  <!-- region WHEN -->
+
   <TextView
     android:id="@+id/whenLabel"
     style="@style/EventDetails.Body.Label.When"
@@ -57,6 +59,10 @@
     app:constraint_referenced_ids="whenValue,whenLabel"
     tools:visibility="visible" />
 
+  <!-- endregion -->
+
+  <!-- region WHERE -->
+
   <TextView
     android:id="@+id/whereLabel"
     style="@style/EventDetails.Body.Label.Where"
@@ -72,7 +78,6 @@
     android:layout_width="@dimen/match_constraint"
     android:layout_height="wrap_content"
     app:layout_constraintStart_toEndOf="@+id/valuesBarrier"
-    app:layout_constraintEnd_toEndOf="@+id/whenValue"
     app:layout_constraintBaseline_toBaselineOf="@+id/whereLabel"
     tools:text="EZ PZ lemon squeezy" />
 
@@ -91,6 +96,10 @@
     android:visibility="gone"
     app:constraint_referenced_ids="whereValue,whereLabel"
     tools:visibility="visible" />
+
+  <!-- endregion -->
+
+  <!-- region LEVEL -->
 
   <TextView
     android:id="@+id/levelLabel"
@@ -127,6 +136,10 @@
     app:constraint_referenced_ids="levelValue,levelLabel"
     tools:visibility="visible" />
 
+  <!-- endregion -->
+
+  <!-- region TRACK -->
+
   <TextView
     android:id="@+id/trackLabel"
     style="@style/EventDetails.Body.Label.Track"
@@ -162,6 +175,10 @@
     app:constraint_referenced_ids="trackValue,trackLabel"
     tools:visibility="visible" />
 
+  <!-- endregion -->
+
+  <!-- region DESCRIPTION -->
+
   <TextView
     android:id="@+id/descriptionLabel"
     style="@style/EventDetails.Body.Label.About"
@@ -193,5 +210,7 @@
     android:visibility="gone"
     app:constraint_referenced_ids="descriptionValue,descriptionLabel"
     tools:visibility="visible" />
+
+  <!-- endregion -->
 
 </merge>

--- a/app/src/main/res/xml/scene_event_details.xml
+++ b/app/src/main/res/xml/scene_event_details.xml
@@ -3,8 +3,7 @@
   xmlns:app="http://schemas.android.com/apk/res-auto">
   <Transition
     app:constraintSetStart="@id/event_details_expanded"
-    app:constraintSetEnd="@id/event_details_collapsed"
-    >
+    app:constraintSetEnd="@id/event_details_collapsed">
     <OnSwipe
       app:dragDirection="dragUp"
       app:touchAnchorId="@id/eventDetailsScrollView"
@@ -16,8 +15,7 @@
     <Constraint
       android:id="@id/eventDetailsHeaderLayout"
       android:layout_width="match_parent"
-      android:layout_height="wrap_content"
-      />
+      android:layout_height="wrap_content" />
     <Constraint
       android:id="@id/favoriteFab"
       android:layout_width="wrap_content"
@@ -25,9 +23,7 @@
       android:layout_marginEnd="@dimen/event_details_fab_margin"
       android:layout_marginBottom="@dimen/event_details_fab_margin"
       app:layout_constraintEnd_toEndOf="parent"
-      app:layout_constraintBottom_toBottomOf="parent"
-      />
-
+      app:layout_constraintBottom_toBottomOf="parent" />
   </ConstraintSet>
 
   <ConstraintSet
@@ -35,8 +31,7 @@
     <Constraint
       android:id="@id/eventDetailsHeaderLayout"
       android:layout_width="match_parent"
-      android:layout_height="?attr/actionBarSize"
-      />
+      android:layout_height="?attr/actionBarSize" />
     <Constraint
       android:id="@id/favoriteFab"
       android:layout_width="wrap_content"
@@ -44,7 +39,6 @@
       android:layout_marginEnd="@dimen/event_details_fab_margin"
       android:layout_marginBottom="@dimen/event_details_fab_margin"
       app:layout_constraintEnd_toEndOf="parent"
-      app:layout_constraintBottom_toBottomOf="parent"
-      />
+      app:layout_constraintBottom_toBottomOf="parent" />
   </ConstraintSet>
 </MotionScene>

--- a/app/src/main/res/xml/scene_event_details.xml
+++ b/app/src/main/res/xml/scene_event_details.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="utf-8"?>
+<MotionScene xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:app="http://schemas.android.com/apk/res-auto">
+  <Transition
+    app:constraintSetStart="@id/expanded"
+    app:constraintSetEnd="@id/collapsed"
+    >
+    <OnSwipe
+      app:dragDirection="dragUp"
+      app:touchAnchorId="@id/eventDetailsScrollView"
+      app:touchAnchorSide="top" />
+  </Transition>
+
+  <ConstraintSet
+    android:id="@+id/expanded">
+    <Constraint
+      android:id="@id/eventDetailsHeaderLayout"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      />
+    <Constraint
+      android:id="@id/favoriteFab"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:layout_marginEnd="@dimen/event_details_fab_margin"
+      android:layout_marginBottom="@dimen/event_details_fab_margin"
+      app:layout_constraintEnd_toEndOf="parent"
+      app:layout_constraintBottom_toBottomOf="parent"
+      />
+
+  </ConstraintSet>
+
+  <ConstraintSet
+    android:id="@+id/collapsed">
+    <Constraint
+      android:id="@id/eventDetailsHeaderLayout"
+      android:layout_width="match_parent"
+      android:layout_height="?attr/actionBarSize"
+      />
+    <Constraint
+      android:id="@id/favoriteFab"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:layout_marginEnd="@dimen/event_details_fab_margin"
+      android:layout_marginBottom="@dimen/event_details_fab_margin"
+      app:layout_constraintEnd_toEndOf="parent"
+      app:layout_constraintBottom_toBottomOf="parent"
+      />
+  </ConstraintSet>
+</MotionScene>

--- a/app/src/main/res/xml/scene_event_details.xml
+++ b/app/src/main/res/xml/scene_event_details.xml
@@ -2,8 +2,8 @@
 <MotionScene xmlns:android="http://schemas.android.com/apk/res/android"
   xmlns:app="http://schemas.android.com/apk/res-auto">
   <Transition
-    app:constraintSetStart="@id/expanded"
-    app:constraintSetEnd="@id/collapsed"
+    app:constraintSetStart="@id/event_details_expanded"
+    app:constraintSetEnd="@id/event_details_collapsed"
     >
     <OnSwipe
       app:dragDirection="dragUp"
@@ -12,7 +12,7 @@
   </Transition>
 
   <ConstraintSet
-    android:id="@+id/expanded">
+    android:id="@+id/event_details_expanded">
     <Constraint
       android:id="@id/eventDetailsHeaderLayout"
       android:layout_width="match_parent"
@@ -31,7 +31,7 @@
   </ConstraintSet>
 
   <ConstraintSet
-    android:id="@+id/collapsed">
+    android:id="@+id/event_details_collapsed">
     <Constraint
       android:id="@id/eventDetailsHeaderLayout"
       android:layout_width="match_parent"


### PR DESCRIPTION
## Problem

We wanted to transition from `CoordinatorLayout` to `MotionLayout` for our event details page.

## Solution

Do eet! It was pretty straightforward after giving a look at [Mark's excellent post](https://blog.stylingandroid.com/motionlayout-collapsing-toolbar-part-1/). This is in no way complete. I think it's ok as a step 1 but it's missing:

1. Transitions of header view (what should happen? where do the avatar and name go? and the title?). This probably requires us to unwrap the header view and apply transitions to the individual views.
2. Timing: right now the transition is completely linear, we should use keyframes to make it better, thankfully [Mark has our back once again](https://blog.stylingandroid.com/motionlayout-collapsing-toolbar-part-2/) :smile: 

Note: the extra constraints on the FAB are there because it stopped showing once adding the transitions for the header. My suspect is that it goes behind the other views (because it's not the last child anymore) but that's something to confirm.

### Screenshots

![device-2018-12-17-122754](https://user-images.githubusercontent.com/1263058/50084842-9849c780-01f8-11e9-9a4d-1b9ebb70bb38.gif)

