### PR TITLE
Use ZonedDateTime to do notification work

### DIFF
--- a/app/src/main/java/net/squanchy/notification/NotificationComponent.kt
+++ b/app/src/main/java/net/squanchy/notification/NotificationComponent.kt
@@ -5,8 +5,11 @@ import dagger.Component
 import net.squanchy.injection.ActivityLifecycle
 import net.squanchy.injection.ApplicationComponent
 import net.squanchy.injection.applicationComponent
+import net.squanchy.notification.NotificationModule.Companion.NOTIFICATION_INTERVAL
 import net.squanchy.support.injection.CurrentTimeModule
 import net.squanchy.support.system.CurrentTime
+import org.threeten.bp.Duration
+import javax.inject.Named
 
 internal fun notificationComponent(context: Context): NotificationComponent =
     DaggerNotificationComponent.builder()
@@ -17,11 +20,14 @@ internal fun notificationComponent(context: Context): NotificationComponent =
 @Component(modules = [NotificationModule::class, CurrentTimeModule::class], dependencies = [ApplicationComponent::class])
 internal interface NotificationComponent {
 
-    fun service(): NotificationService
-
     fun notificationCreator(): NotificationCreator
 
     fun notifier(): Notifier
 
     fun currentTime(): CurrentTime
+
+    fun upcomingEventsService(): UpcomingEventsService
+
+    @Named(NOTIFICATION_INTERVAL)
+    fun notificationInterval(): Duration
 }

--- a/app/src/main/java/net/squanchy/notification/NotificationComponent.kt
+++ b/app/src/main/java/net/squanchy/notification/NotificationComponent.kt
@@ -5,7 +5,7 @@ import dagger.Component
 import net.squanchy.injection.ActivityLifecycle
 import net.squanchy.injection.ApplicationComponent
 import net.squanchy.injection.applicationComponent
-import net.squanchy.notification.NotificationModule.Companion.NOTIFICATION_INTERVAL
+import net.squanchy.notification.NotificationModule.Companion.UPCOMING_EVENT_THRESHOLD
 import net.squanchy.support.injection.CurrentTimeModule
 import net.squanchy.support.system.CurrentTime
 import org.threeten.bp.Duration
@@ -28,6 +28,6 @@ internal interface NotificationComponent {
 
     fun upcomingEventsService(): UpcomingEventsService
 
-    @Named(NOTIFICATION_INTERVAL)
-    fun notificationInterval(): Duration
+    @Named(UPCOMING_EVENT_THRESHOLD)
+    fun upcomingEventThreshold(): Duration
 }

--- a/app/src/main/java/net/squanchy/notification/NotificationModule.kt
+++ b/app/src/main/java/net/squanchy/notification/NotificationModule.kt
@@ -7,6 +7,9 @@ import dagger.Module
 import dagger.Provides
 import net.squanchy.service.repository.AuthService
 import net.squanchy.service.repository.EventRepository
+import net.squanchy.support.system.CurrentTime
+import org.threeten.bp.Duration
+import javax.inject.Named
 
 @Module
 internal class NotificationModule {
@@ -32,5 +35,26 @@ internal class NotificationModule {
     @Provides
     fun notifier(notificationManagerCompat: NotificationManagerCompat): Notifier {
         return Notifier(notificationManagerCompat)
+    }
+
+    @Provides
+    @Named(NOTIFICATION_INTERVAL)
+    fun provideNotificationInterval(): Duration = Duration.ofMinutes(10)
+
+    @Provides
+    fun upcomingEventsService(
+        notificationService: NotificationService,
+        currentTime: CurrentTime,
+        @Named(NOTIFICATION_INTERVAL) notificationInterval: Duration
+    ): UpcomingEventsService {
+        return UpcomingEventsService(
+            notificationService,
+            currentTime,
+            notificationInterval
+        )
+    }
+
+    companion object {
+        const val NOTIFICATION_INTERVAL = "NOTIFICATION_INTERVAL"
     }
 }

--- a/app/src/main/java/net/squanchy/notification/NotificationModule.kt
+++ b/app/src/main/java/net/squanchy/notification/NotificationModule.kt
@@ -38,23 +38,23 @@ internal class NotificationModule {
     }
 
     @Provides
-    @Named(NOTIFICATION_INTERVAL)
-    fun provideNotificationInterval(): Duration = Duration.ofMinutes(10)
+    @Named(UPCOMING_EVENT_THRESHOLD)
+    fun provideUpcomingEventThreshold(): Duration = Duration.ofMinutes(10)
 
     @Provides
     fun upcomingEventsService(
         notificationService: NotificationService,
         currentTime: CurrentTime,
-        @Named(NOTIFICATION_INTERVAL) notificationInterval: Duration
+        @Named(UPCOMING_EVENT_THRESHOLD) upcomingEventThreshold: Duration
     ): UpcomingEventsService {
         return UpcomingEventsService(
             notificationService,
             currentTime,
-            notificationInterval
+            upcomingEventThreshold
         )
     }
 
     companion object {
-        const val NOTIFICATION_INTERVAL = "NOTIFICATION_INTERVAL"
+        const val UPCOMING_EVENT_THRESHOLD = "UPCOMING_EVENT_THRESHOLD"
     }
 }

--- a/app/src/main/java/net/squanchy/notification/NotificationService.kt
+++ b/app/src/main/java/net/squanchy/notification/NotificationService.kt
@@ -6,7 +6,7 @@ import net.squanchy.schedule.domain.view.Event
 import net.squanchy.service.repository.AuthService
 import net.squanchy.service.repository.EventRepository
 
-internal class NotificationService(private val authService: AuthService, private val eventRepository: EventRepository) {
+class NotificationService(private val authService: AuthService, private val eventRepository: EventRepository) {
 
     fun sortedFavourites(): Single<List<Event>> {
         return authService.ifUserSignedInThenObservableFrom { userId ->

--- a/app/src/main/java/net/squanchy/notification/NotificationWorker.kt
+++ b/app/src/main/java/net/squanchy/notification/NotificationWorker.kt
@@ -22,7 +22,7 @@ class NotificationWorker(context: Context, parameters: WorkerParameters) : RxWor
     private val currentTime: CurrentTime
     private val preferences = PreferenceManager.getDefaultSharedPreferences(context)
     private val service: UpcomingEventsService
-    private val notificationInterval: Duration
+    private val upcomingEventThreshold: Duration
 
     init {
         notificationComponent(context).run {
@@ -30,7 +30,7 @@ class NotificationWorker(context: Context, parameters: WorkerParameters) : RxWor
             notifier = notifier()
             currentTime = currentTime()
             service = upcomingEventsService()
-            notificationInterval = notificationInterval()
+            upcomingEventThreshold = upcomingEventThreshold()
         }
     }
 
@@ -81,7 +81,7 @@ class NotificationWorker(context: Context, parameters: WorkerParameters) : RxWor
             return
         }
         val startTime = events[0].zonedStartTime
-        val serviceAlarm = startTime.minus(notificationInterval)
+        val serviceAlarm = startTime.minus(upcomingEventThreshold)
 
         Timber.d("Next alarm scheduled for %s", serviceAlarm.toString())
 

--- a/app/src/main/java/net/squanchy/notification/UpcomingEventsService.kt
+++ b/app/src/main/java/net/squanchy/notification/UpcomingEventsService.kt
@@ -16,9 +16,7 @@ class UpcomingEventsService(
         val notificationIntervalEnd = now.plus(notificationInterval)
 
         return service.sortedFavourites()
-            .map { events -> events.filter {
-                it.zonedStartTime.isAfter(now)
-            } }
+            .map { events -> events.filter { it.zonedStartTime.isAfter(now) } }
             .map { events -> events.filter { isBeforeOrEqualTo(it.zonedStartTime, notificationIntervalEnd) } }
     }
 

--- a/app/src/main/java/net/squanchy/notification/UpcomingEventsService.kt
+++ b/app/src/main/java/net/squanchy/notification/UpcomingEventsService.kt
@@ -11,6 +11,7 @@ class UpcomingEventsService(
     private val currentTime: CurrentTime,
     private val notificationInterval: Duration
 ) {
+
     fun upcomingEvents(): Single<List<Event>> {
         val now = currentTime.currentDateTime()
         val notificationIntervalEnd = now.plus(notificationInterval)

--- a/app/src/main/java/net/squanchy/notification/UpcomingEventsService.kt
+++ b/app/src/main/java/net/squanchy/notification/UpcomingEventsService.kt
@@ -1,0 +1,36 @@
+package net.squanchy.notification
+
+import io.reactivex.Single
+import net.squanchy.schedule.domain.view.Event
+import net.squanchy.support.system.CurrentTime
+import org.threeten.bp.Duration
+import org.threeten.bp.ZonedDateTime
+
+class UpcomingEventsService(
+    private val service: NotificationService,
+    private val currentTime: CurrentTime,
+    private val notificationInterval: Duration
+) {
+    fun upcomingEvents(): Single<List<Event>> {
+        val now = currentTime.currentDateTime()
+        val notificationIntervalEnd = now.plus(notificationInterval)
+
+        return service.sortedFavourites()
+            .map { events -> events.filter {
+                it.zonedStartTime.isAfter(now)
+            } }
+            .map { events -> events.filter { isBeforeOrEqualTo(it.zonedStartTime, notificationIntervalEnd) } }
+    }
+
+    private fun isBeforeOrEqualTo(start: ZonedDateTime, notificationIntervalEnd: ZonedDateTime): Boolean {
+        return start.isBefore(notificationIntervalEnd) || start.isEqual(notificationIntervalEnd)
+    }
+
+    fun nextEvents(): Single<List<Event>> {
+        val now = currentTime.currentDateTime()
+        val notificationIntervalEnd = now.plus(notificationInterval)
+
+        return service.sortedFavourites()
+            .map { events -> events.filter { it.zonedStartTime.isAfter(notificationIntervalEnd) } }
+    }
+}

--- a/app/src/main/java/net/squanchy/notification/UpcomingEventsService.kt
+++ b/app/src/main/java/net/squanchy/notification/UpcomingEventsService.kt
@@ -18,12 +18,11 @@ class UpcomingEventsService(
 
         return service.sortedFavourites()
             .map { events -> events.filter { it.zonedStartTime.isAfter(now) } }
-            .map { events -> events.filter { isBeforeOrEqualTo(it.zonedStartTime, notificationIntervalEnd) } }
+            .map { events -> events.filter { it.zonedStartTime.isBeforeOrEqualTo(notificationIntervalEnd) } }
     }
 
-    private fun isBeforeOrEqualTo(start: ZonedDateTime, notificationIntervalEnd: ZonedDateTime): Boolean {
-        return start.isBefore(notificationIntervalEnd) || start.isEqual(notificationIntervalEnd)
-    }
+    private fun ZonedDateTime.isBeforeOrEqualTo(other: ZonedDateTime) =
+        isBefore(other) || isEqual(other)
 
     fun nextEvents(): Single<List<Event>> {
         val now = currentTime.currentDateTime()

--- a/app/src/main/java/net/squanchy/notification/UpcomingEventsService.kt
+++ b/app/src/main/java/net/squanchy/notification/UpcomingEventsService.kt
@@ -9,16 +9,16 @@ import org.threeten.bp.ZonedDateTime
 class UpcomingEventsService(
     private val service: NotificationService,
     private val currentTime: CurrentTime,
-    private val notificationInterval: Duration
+    private val upcomingEventThreshold: Duration
 ) {
 
     fun upcomingEvents(): Single<List<Event>> {
         val now = currentTime.currentDateTime()
-        val notificationIntervalEnd = now.plus(notificationInterval)
+        val notificationEndTime = now.plus(upcomingEventThreshold)
 
         return service.sortedFavourites()
             .map { events -> events.filter { it.zonedStartTime.isAfter(now) } }
-            .map { events -> events.filter { it.zonedStartTime.isBeforeOrEqualTo(notificationIntervalEnd) } }
+            .map { events -> events.filter { it.zonedStartTime.isBeforeOrEqualTo(notificationEndTime) } }
     }
 
     private fun ZonedDateTime.isBeforeOrEqualTo(other: ZonedDateTime) =
@@ -26,9 +26,9 @@ class UpcomingEventsService(
 
     fun nextEvents(): Single<List<Event>> {
         val now = currentTime.currentDateTime()
-        val notificationIntervalEnd = now.plus(notificationInterval)
+        val notificationEndTime = now.plus(upcomingEventThreshold)
 
         return service.sortedFavourites()
-            .map { events -> events.filter { it.zonedStartTime.isAfter(notificationIntervalEnd) } }
+            .map { events -> events.filter { it.zonedStartTime.isAfter(notificationEndTime) } }
     }
 }

--- a/app/src/main/java/net/squanchy/schedule/domain/view/Event.kt
+++ b/app/src/main/java/net/squanchy/schedule/domain/view/Event.kt
@@ -5,6 +5,7 @@ import net.squanchy.eventdetails.domain.view.ExperienceLevel
 import net.squanchy.speaker.domain.view.Speaker
 import org.threeten.bp.LocalDateTime
 import org.threeten.bp.ZoneId
+import org.threeten.bp.ZonedDateTime
 
 @Suppress("LongParameterList") // This is just a big model - TODO refactor this to split it up
 data class Event(
@@ -23,7 +24,8 @@ data class Event(
     val timeZone: ZoneId
 ) {
 
-    fun isHappeningAt(time: LocalDateTime) = time.isAfter(startTime) && time.isBefore(endTime)
+    val zonedStartTime: ZonedDateTime
+        get() = startTime.atZone(timeZone)
 
     enum class Type(private val rawType: String) {
         REGISTRATION("registration"),

--- a/app/src/test/java/net/squanchy/notification/UpcomingEventsServiceTest.kt
+++ b/app/src/test/java/net/squanchy/notification/UpcomingEventsServiceTest.kt
@@ -1,0 +1,135 @@
+package net.squanchy.notification
+
+import io.reactivex.Single
+import net.squanchy.schedule.domain.view.Event
+import net.squanchy.schedule.domain.view.anEvent
+import net.squanchy.support.system.TestCurrentTime
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mock
+import org.mockito.Mockito
+import org.mockito.MockitoAnnotations
+import org.threeten.bp.Duration
+import org.threeten.bp.ZoneId
+import org.threeten.bp.ZoneOffset
+import org.threeten.bp.ZonedDateTime
+
+class UpcomingEventsServiceTest {
+
+    @Mock
+    lateinit var service: NotificationService
+
+    private val currentTime = TestCurrentTime(NOW)
+
+    lateinit var upcomingEventsService: UpcomingEventsService
+
+    @Before
+    fun setUp() {
+        MockitoAnnotations.initMocks(this)
+        upcomingEventsService = UpcomingEventsService(
+            service,
+            currentTime,
+            INTERVAL
+        )
+    }
+
+    @Test
+    fun upcomingEventsEmitsOnlyEventsStartingAfterNowInsideInterval() {
+        givenServiceWillReturn(
+            BEFORE_NOW,
+            BEFORE_NOW_OTHER_TIMEZONE,
+            AFTER_NOW_INSIDE_INTERVAL,
+            AFTER_NOW_INSIDE_INTERVAL_OTHER_TIMEZONE,
+            AFTER_NOW_OUTSIDE_INTERVAL,
+            AFTER_NOW_OUTSIDE_INTERVAL_OTHER_TIMEZONE
+        )
+
+        upcomingEventsService.upcomingEvents().test()
+            .assertValue(listOf(
+                AFTER_NOW_INSIDE_INTERVAL,
+                AFTER_NOW_INSIDE_INTERVAL_OTHER_TIMEZONE
+            ))
+    }
+
+    @Test
+    fun nextEventsEmitsOnlyEventsStartingAfterNowOutsideInterval() {
+        givenServiceWillReturn(
+            BEFORE_NOW,
+            BEFORE_NOW_OTHER_TIMEZONE,
+            AFTER_NOW_INSIDE_INTERVAL,
+            AFTER_NOW_INSIDE_INTERVAL_OTHER_TIMEZONE,
+            AFTER_NOW_OUTSIDE_INTERVAL,
+            AFTER_NOW_OUTSIDE_INTERVAL_OTHER_TIMEZONE
+        )
+
+        upcomingEventsService.nextEvents().test()
+            .assertValue(listOf(
+                AFTER_NOW_OUTSIDE_INTERVAL,
+                AFTER_NOW_OUTSIDE_INTERVAL_OTHER_TIMEZONE
+            ))
+    }
+
+    private fun givenServiceWillReturn(vararg events: Event) {
+        Mockito.`when`(service.sortedFavourites())
+            .thenReturn(Single.just(events.asList()))
+    }
+
+    companion object {
+        private val USER_ZONE_ID = ZoneId.ofOffset("UTC", ZoneOffset.ofHours(0))
+        private val ONE_HOUR_EARLIER_ZONE_ID = ZoneId.ofOffset("UTC", ZoneOffset.ofHours(1))
+
+        private val NOW = ZonedDateTime.of(
+            2018,
+            12,
+            20,
+            11,
+            25,
+            0,
+            0,
+            USER_ZONE_ID
+        )
+
+        val INTERVAL: Duration = Duration.ofMinutes(30)
+
+        val BEFORE_NOW = anEvent(
+            title = "Before now",
+            startTime = NOW.minusHours(1).toLocalDateTime(),
+            endTime = NOW.plusHours(4).toLocalDateTime(),
+            timeZone = USER_ZONE_ID
+        )
+
+        val BEFORE_NOW_OTHER_TIMEZONE = anEvent(
+            title = "Before now other timezone",
+            startTime = NOW.toLocalDateTime().plusMinutes(30),
+            endTime = NOW.plusHours(4).toLocalDateTime(),
+            timeZone = ONE_HOUR_EARLIER_ZONE_ID
+        )
+
+        val AFTER_NOW_INSIDE_INTERVAL = anEvent(
+            title = "After now inside interval",
+            startTime = NOW.plus(INTERVAL.dividedBy(2)).toLocalDateTime(),
+            endTime = NOW.plusHours(4).toLocalDateTime(),
+            timeZone = USER_ZONE_ID
+        )
+        val AFTER_NOW_INSIDE_INTERVAL_OTHER_TIMEZONE = anEvent(
+            title = "After now inside interval other timezone",
+            startTime = NOW.plusHours(1).plus(INTERVAL.dividedBy(2)).toLocalDateTime(),
+            endTime = NOW.plusHours(4).toLocalDateTime(),
+            timeZone = ONE_HOUR_EARLIER_ZONE_ID
+        )
+
+        val AFTER_NOW_OUTSIDE_INTERVAL = anEvent(
+            title = "After now outside interval",
+            startTime = NOW.plus(INTERVAL.multipliedBy(2)).toLocalDateTime(),
+            endTime = NOW.plusHours(4).toLocalDateTime(),
+            timeZone = USER_ZONE_ID
+        )
+
+        val AFTER_NOW_OUTSIDE_INTERVAL_OTHER_TIMEZONE = anEvent(
+            title = "After now outside interval other timezone",
+            startTime = NOW.plusHours(1).plus(INTERVAL.multipliedBy(2)).toLocalDateTime(),
+            endTime = NOW.plusHours(4).toLocalDateTime(),
+            timeZone = ONE_HOUR_EARLIER_ZONE_ID
+        )
+    }
+}

--- a/app/src/test/java/net/squanchy/notification/UpcomingEventsServiceTest.kt
+++ b/app/src/test/java/net/squanchy/notification/UpcomingEventsServiceTest.kt
@@ -33,7 +33,7 @@ class UpcomingEventsServiceTest {
         upcomingEventsService = UpcomingEventsService(
             service,
             currentTime,
-            INTERVAL
+            UPCOMING_EVENT_THRESHOLD
         )
     }
 
@@ -93,7 +93,7 @@ class UpcomingEventsServiceTest {
             USER_ZONE_ID
         )
 
-        val INTERVAL: Duration = Duration.ofMinutes(30)
+        val UPCOMING_EVENT_THRESHOLD: Duration = Duration.ofMinutes(30)
 
         val BEFORE_NOW = anEvent(
             title = "Before now",
@@ -111,28 +111,28 @@ class UpcomingEventsServiceTest {
 
         val AFTER_NOW_INSIDE_INTERVAL = anEvent(
             title = "After now inside interval",
-            startTime = NOW.plus(INTERVAL.dividedBy(2)).toLocalDateTime(),
+            startTime = NOW.plus(UPCOMING_EVENT_THRESHOLD.dividedBy(2)).toLocalDateTime(),
             endTime = NOW.plusHours(4).toLocalDateTime(),
             timeZone = USER_ZONE_ID
         )
         
         val AFTER_NOW_INSIDE_INTERVAL_OTHER_TIMEZONE = anEvent(
             title = "After now inside interval other timezone",
-            startTime = NOW.plusHours(1).plus(INTERVAL.dividedBy(2)).toLocalDateTime(),
+            startTime = NOW.plusHours(1).plus(UPCOMING_EVENT_THRESHOLD.dividedBy(2)).toLocalDateTime(),
             endTime = NOW.plusHours(4).toLocalDateTime(),
             timeZone = ONE_HOUR_EARLIER_ZONE_ID
         )
 
         val AFTER_NOW_OUTSIDE_INTERVAL = anEvent(
             title = "After now outside interval",
-            startTime = NOW.plus(INTERVAL.multipliedBy(2)).toLocalDateTime(),
+            startTime = NOW.plus(UPCOMING_EVENT_THRESHOLD.multipliedBy(2)).toLocalDateTime(),
             endTime = NOW.plusHours(4).toLocalDateTime(),
             timeZone = USER_ZONE_ID
         )
 
         val AFTER_NOW_OUTSIDE_INTERVAL_OTHER_TIMEZONE = anEvent(
             title = "After now outside interval other timezone",
-            startTime = NOW.plusHours(1).plus(INTERVAL.multipliedBy(2)).toLocalDateTime(),
+            startTime = NOW.plusHours(1).plus(UPCOMING_EVENT_THRESHOLD.multipliedBy(2)).toLocalDateTime(),
             endTime = NOW.plusHours(4).toLocalDateTime(),
             timeZone = ONE_HOUR_EARLIER_ZONE_ID
         )

--- a/app/src/test/java/net/squanchy/notification/UpcomingEventsServiceTest.kt
+++ b/app/src/test/java/net/squanchy/notification/UpcomingEventsServiceTest.kt
@@ -5,10 +5,12 @@ import net.squanchy.schedule.domain.view.Event
 import net.squanchy.schedule.domain.view.anEvent
 import net.squanchy.support.system.TestCurrentTime
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.mockito.Mock
 import org.mockito.Mockito
-import org.mockito.MockitoAnnotations
+import org.mockito.junit.MockitoJUnit
+import org.mockito.junit.MockitoRule
 import org.threeten.bp.Duration
 import org.threeten.bp.ZoneId
 import org.threeten.bp.ZoneOffset
@@ -16,6 +18,9 @@ import org.threeten.bp.ZonedDateTime
 
 class UpcomingEventsServiceTest {
 
+    @get:Rule
+    val mockitoRule: MockitoRule = MockitoJUnit.rule()
+    
     @Mock
     lateinit var service: NotificationService
 
@@ -25,7 +30,6 @@ class UpcomingEventsServiceTest {
 
     @Before
     fun setUp() {
-        MockitoAnnotations.initMocks(this)
         upcomingEventsService = UpcomingEventsService(
             service,
             currentTime,

--- a/app/src/test/java/net/squanchy/notification/UpcomingEventsServiceTest.kt
+++ b/app/src/test/java/net/squanchy/notification/UpcomingEventsServiceTest.kt
@@ -115,6 +115,7 @@ class UpcomingEventsServiceTest {
             endTime = NOW.plusHours(4).toLocalDateTime(),
             timeZone = USER_ZONE_ID
         )
+        
         val AFTER_NOW_INSIDE_INTERVAL_OTHER_TIMEZONE = anEvent(
             title = "After now inside interval other timezone",
             startTime = NOW.plusHours(1).plus(INTERVAL.dividedBy(2)).toLocalDateTime(),

--- a/app/src/test/java/net/squanchy/support/system/TestCurrentTime.kt
+++ b/app/src/test/java/net/squanchy/support/system/TestCurrentTime.kt
@@ -3,5 +3,6 @@ package net.squanchy.support.system
 import org.threeten.bp.ZonedDateTime
 
 class TestCurrentTime(private val time: ZonedDateTime) : CurrentTime {
+
     override fun currentDateTime() = time
 }

--- a/app/src/test/java/net/squanchy/support/system/TestCurrentTime.kt
+++ b/app/src/test/java/net/squanchy/support/system/TestCurrentTime.kt
@@ -1,0 +1,7 @@
+package net.squanchy.support.system
+
+import org.threeten.bp.ZonedDateTime
+
+class TestCurrentTime(private val time: ZonedDateTime) : CurrentTime {
+    override fun currentDateTime() = time
+}


### PR DESCRIPTION
## Problem

I was tinkering with `NotificationWorker`, and I noticed we used `LocalDateTime` to compare dates. Now if the user is at a different timezone than the conference, times might be off and comparisons might be inaccurate. A use case is a remote user who favourited the event to watch it online.

I'm not sure this is correct so this PR is also to open a discussion about it and check if what I'm doing is correct :smile: 

## Solution

Use `CurrentTime.currentDateTime()` to retrieve the current time at the user's timezone, and use `Event.zonedStartTime` to retrieve the event at the event's timezone.
