### PR TITLE
Update CircleCI config to 2.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ commands:
           name: Install FOSSA CLI
           command: workspace/repo/.circleci/ci-scripts/install-fossa.sh
 
-  # Build Tools cache aliases
+  # Build Tools cache commands
   restore_build_tools_cache:
     steps:
       - restore_cache:
@@ -36,7 +36,7 @@ commands:
             - /opt/android/sdk/build-tools
           key: v3-build-tools-{{ checksum "workspace/repo/.circleci/config.yml" }}-{{ checksum "workspace/repo/gradle.properties" }}-{{ checksum "workspace/repo/dependencies.gradle" }}
 
-  # Gradle cache aliases
+  # Gradle cache commands
   restore_gradle_cache:
     steps:
       - restore_cache:
@@ -60,7 +60,7 @@ commands:
             - ~/.gradle/wrapper
           key: v1-gradle-wrapper-{{ checksum "workspace/repo/.circleci/config.yml" }}-{{ checksum "workspace/repo/gradle/wrapper/gradle-wrapper.properties" }}
 
-  # Android Gradle build cache aliases
+  # Android Gradle build cache commands
   restore_android_build_cache:
     steps:
       - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,17 +40,25 @@ commands:
   restore_gradle_cache:
     steps:
       - restore_cache:
-          name: Restore Gradle cache
+          name: Restore Gradle dependencies cache
           keys:
-            - v3-gradle-{{ checksum "workspace/repo/.circleci/config.yml" }}-{{ checksum "workspace/repo/gradle.properties" }}-{{ checksum "workspace/repo/dependencies.gradle" }}
+            - v1-gradle-dependencies-{{ checksum "workspace/repo/.circleci/config.yml" }}-{{ checksum "workspace/repo/gradle.properties" }}-{{ checksum "workspace/repo/dependencies.gradle" }}
+      - restore_cache:
+          name: Restore Gradle wrapper cache
+          keys:
+            - v1-gradle-wrapper-{{ checksum "workspace/repo/.circleci/config.yml" }}-{{ checksum "workspace/repo/gradle/wrapper/gradle-wrapper.properties" }}
   save_gradle_cache:
     steps:
       - save_cache:
-          name: Save Gradle cache
+          name: Save Gradle dependencies cache
           paths:
             - ~/.gradle/caches
+          key: v1-gradle-dependencies-{{ checksum "workspace/repo/.circleci/config.yml" }}-{{ checksum "workspace/repo/gradle.properties" }}-{{ checksum "workspace/repo/dependencies.gradle" }}
+      - save_cache:
+          name: Save Gradle wrapper cache
+          paths:
             - ~/.gradle/wrapper
-          key: v3-gradle-{{ checksum "workspace/repo/.circleci/config.yml" }}-{{ checksum "workspace/repo/gradle.properties" }}-{{ checksum "workspace/repo/dependencies.gradle" }}
+          key: v1-gradle-wrapper-{{ checksum "workspace/repo/.circleci/config.yml" }}-{{ checksum "workspace/repo/gradle/wrapper/gradle-wrapper.properties" }}
 
   # Android Gradle build cache aliases
   restore_android_build_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,53 +1,5 @@
 version: 2.1
 
-aliases:
-  # FOSSA CLI install
-  - &install-fossa-cli
-    name: Install FOSSA CLI
-    command: workspace/repo/.circleci/ci-scripts/install-fossa.sh
-
-  # Build Tools cache aliases
-  - &restore-build-tools-cache
-    name: Restore Android build tools cache
-    keys:
-      - v3-build-tools-{{ checksum "workspace/repo/.circleci/config.yml" }}-{{ checksum "workspace/repo/gradle.properties" }}-{{ checksum "workspace/repo/dependencies.gradle" }}
-  - &save-build-tools-cache
-    name: Save Android build tools cache
-    paths:
-      - /opt/android/sdk/build-tools
-    key: v3-build-tools-{{ checksum "workspace/repo/.circleci/config.yml" }}-{{ checksum "workspace/repo/gradle.properties" }}-{{ checksum "workspace/repo/dependencies.gradle" }}
-
-  # Gradle cache aliases
-  - &restore-gradle-cache
-    name: Restore Gradle cache
-    keys:
-      - v3-gradle-{{ checksum "workspace/repo/.circleci/config.yml" }}-{{ checksum "workspace/repo/gradle.properties" }}-{{ checksum "workspace/repo/dependencies.gradle" }}
-  - &save-gradle-cache
-    name: Save Gradle cache
-    paths:
-      - ~/.gradle/caches
-      - ~/.gradle/wrapper
-    key: v3-gradle-{{ checksum "workspace/repo/.circleci/config.yml" }}-{{ checksum "workspace/repo/gradle.properties" }}-{{ checksum "workspace/repo/dependencies.gradle" }}
-
-  # Android Gradle build cache aliases
-  - &restore-android-build-cache
-    name: Restore Android Gradle build cache
-    keys:
-      - v3-build-cache-{{ checksum "workspace/repo/.circleci/config.yml" }}-{{ checksum "workspace/repo/gradle.properties" }}-{{ checksum "workspace/repo/dependencies.gradle" }}
-  - &save-android-build-cache
-    name: Save Android Gradle build cache
-    paths:
-      - ~/.android/build-cache
-    key: v3-build-cache-{{ checksum "workspace/repo/.circleci/config.yml" }}-{{ checksum "workspace/repo/gradle.properties" }}-{{ checksum "workspace/repo/dependencies.gradle" }}
-
-  - &ensure-android-sdk-is-ready
-    name: Ensure Android SDK install is up-to-date
-    command: workspace/repo/.circleci/ci-scripts/ensure-sdkmanager.sh
-
-  - &download-gradle-dependencies
-    name: Download Gradle dependencies
-    command: cd workspace/repo/ && ./gradlew downloadDependencies
-
 executors:
   android:
     working_directory: ~/squanchy
@@ -61,9 +13,76 @@ executors:
       ALGOLIA_API_KEY: 00000000000000000000000000000000
       ALGOLIA_INDICES_PREFIX: squanchy_dev
 
-attach_workspace: &attach_workspace
-  attach_workspace:
-    at: workspace
+commands:
+  # FOSSA CLI install
+  install_fossa_cli:
+    steps:
+      - run:
+          name: Install FOSSA CLI
+          command: workspace/repo/.circleci/ci-scripts/install-fossa.sh
+
+  # Build Tools cache aliases
+  restore_build_tools_cache:
+    steps:
+      - restore_cache:
+          name: Restore Android build tools cache
+          keys:
+            - v3-build-tools-{{ checksum "workspace/repo/.circleci/config.yml" }}-{{ checksum "workspace/repo/gradle.properties" }}-{{ checksum "workspace/repo/dependencies.gradle" }}
+  save_build_tools_cache:
+    steps:
+      - save_cache:
+          name: Save Android build tools cache
+          paths:
+            - /opt/android/sdk/build-tools
+          key: v3-build-tools-{{ checksum "workspace/repo/.circleci/config.yml" }}-{{ checksum "workspace/repo/gradle.properties" }}-{{ checksum "workspace/repo/dependencies.gradle" }}
+
+  # Gradle cache aliases
+  restore_gradle_cache:
+    steps:
+      - restore_cache:
+          name: Restore Gradle cache
+          keys:
+            - v3-gradle-{{ checksum "workspace/repo/.circleci/config.yml" }}-{{ checksum "workspace/repo/gradle.properties" }}-{{ checksum "workspace/repo/dependencies.gradle" }}
+  save_gradle_cache:
+    steps:
+      - save_cache:
+          name: Save Gradle cache
+          paths:
+            - ~/.gradle/caches
+            - ~/.gradle/wrapper
+          key: v3-gradle-{{ checksum "workspace/repo/.circleci/config.yml" }}-{{ checksum "workspace/repo/gradle.properties" }}-{{ checksum "workspace/repo/dependencies.gradle" }}
+
+  # Android Gradle build cache aliases
+  restore_android_build_cache:
+    steps:
+      - restore_cache:
+          name: Restore Android Gradle build cache
+          keys:
+            - v3-build-cache-{{ checksum "workspace/repo/.circleci/config.yml" }}-{{ checksum "workspace/repo/gradle.properties" }}-{{ checksum "workspace/repo/dependencies.gradle" }}
+  save_android_build_cache:
+    steps:
+      - save_cache:
+          name: Save Android Gradle build cache
+          paths:
+            - ~/.android/build-cache
+          key: v3-build-cache-{{ checksum "workspace/repo/.circleci/config.yml" }}-{{ checksum "workspace/repo/gradle.properties" }}-{{ checksum "workspace/repo/dependencies.gradle" }}
+
+  ensure_android_sdk_is_ready:
+    steps:
+      - run:
+          name: Ensure Android SDK install is up-to-date
+          command: workspace/repo/.circleci/ci-scripts/ensure-sdkmanager.sh
+
+  download_gradle_dependencies:
+    steps:
+      - run:
+          name: Download Gradle dependencies
+          command: cd workspace/repo/ && ./gradlew downloadDependencies
+
+  restore_workspace:
+    steps:
+      - attach_workspace:
+          at: workspace
 
 jobs:
   checkout:
@@ -73,7 +92,7 @@ jobs:
           path: workspace/repo
 
       # Prepare the container for the build
-      - run: *ensure-android-sdk-is-ready
+      - ensure_android_sdk_is_ready
       - run:
           name: Create mock Play Services JSON
           command: workspace/repo/.circleci/ci-scripts/ci-mock-google-services-setup.sh
@@ -87,16 +106,16 @@ jobs:
   prepare_for_checks:
     executor: android
     steps:
-      - *attach_workspace
-      - restore_cache: *restore-gradle-cache
-      - restore_cache: *restore-android-build-cache
-      - restore_cache: *restore-build-tools-cache
+      - restore_workspace
+      - restore_gradle_cache
+      - restore_android_build_cache
+      - restore_build_tools_cache
 
-      - run: *download-gradle-dependencies
+      - download_gradle_dependencies
 
-      - save_cache: *save-android-build-cache
-      - save_cache: *save-gradle-cache
-      - save_cache: *save-build-tools-cache
+      - save_android_build_cache
+      - save_gradle_cache
+      - save_build_tools_cache
 
       # Persist built app code
       - persist_to_workspace:
@@ -107,10 +126,10 @@ jobs:
   static_analysis:
     executor: android
     steps:
-      - *attach_workspace
-      - restore_cache: *restore-gradle-cache
-      - restore_cache: *restore-android-build-cache
-      - restore_cache: *restore-build-tools-cache
+      - restore_workspace
+      - restore_gradle_cache
+      - restore_android_build_cache
+      - restore_build_tools_cache
 
       # See https://issuetracker.google.com/issues/62217354 for the parallelism option
       - run:
@@ -125,10 +144,10 @@ jobs:
   tests:
     executor: android
     steps:
-      - *attach_workspace
-      - restore_cache: *restore-gradle-cache
-      - restore_cache: *restore-android-build-cache
-      - restore_cache: *restore-build-tools-cache
+      - restore_workspace
+      - restore_gradle_cache
+      - restore_android_build_cache
+      - restore_build_tools_cache
 
       # See https://issuetracker.google.com/issues/62217354 for the parallelism option
       - run:
@@ -142,12 +161,12 @@ jobs:
   license_checks:
     executor: android
     steps:
-      - *attach_workspace
-      - restore_cache: *restore-gradle-cache
-      - restore_cache: *restore-android-build-cache
-      - restore_cache: *restore-build-tools-cache
+      - restore_workspace
+      - restore_gradle_cache
+      - restore_android_build_cache
+      - restore_build_tools_cache
 
-      - run: *install-fossa-cli
+      - install_fossa_cli
 
       - run:
           name: Run FOSSA license check

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,4 @@
-version: 2
+version: 2.1
 
 aliases:
   # FOSSA CLI install
@@ -48,19 +48,18 @@ aliases:
     name: Download Gradle dependencies
     command: cd workspace/repo/ && ./gradlew downloadDependencies
 
-circle_ci_android_container_config: &circle_ci_android_container_config
-  working_directory: ~/squanchy
-
-  docker:
-   - image: circleci/android:api-28-alpha
-
-  environment:
-   ANDROID_HOME: /opt/android/sdk
-   APPLICATION_ID: net.squanchy.example
-   FABRIC_API_KEY: 0000000000000000000000000000000000000000
-   ALGOLIA_APPLICATION_ID: ABCDEFGH12
-   ALGOLIA_API_KEY: 00000000000000000000000000000000
-   ALGOLIA_INDICES_PREFIX: squanchy_dev
+executors:
+  android:
+    working_directory: ~/squanchy
+    docker:
+      - image: circleci/android:api-28-alpha
+    environment:
+      ANDROID_HOME: /opt/android/sdk
+      APPLICATION_ID: net.squanchy.example
+      FABRIC_API_KEY: 0000000000000000000000000000000000000000
+      ALGOLIA_APPLICATION_ID: ABCDEFGH12
+      ALGOLIA_API_KEY: 00000000000000000000000000000000
+      ALGOLIA_INDICES_PREFIX: squanchy_dev
 
 attach_workspace: &attach_workspace
   attach_workspace:
@@ -68,7 +67,7 @@ attach_workspace: &attach_workspace
 
 jobs:
   checkout:
-    <<: *circle_ci_android_container_config
+    executor: android
     steps:
       - checkout:
           path: workspace/repo
@@ -86,7 +85,7 @@ jobs:
             - repo
 
   prepare_for_checks:
-    <<: *circle_ci_android_container_config
+    executor: android
     steps:
       - *attach_workspace
       - restore_cache: *restore-gradle-cache
@@ -106,7 +105,7 @@ jobs:
             - repo/app/build
 
   static_analysis:
-    <<: *circle_ci_android_container_config
+    executor: android
     steps:
       - *attach_workspace
       - restore_cache: *restore-gradle-cache
@@ -124,7 +123,7 @@ jobs:
           destination: reports
 
   tests:
-    <<: *circle_ci_android_container_config
+    executor: android
     steps:
       - *attach_workspace
       - restore_cache: *restore-gradle-cache
@@ -141,7 +140,7 @@ jobs:
           path: workspace/repo/app/build/test-results
 
   license_checks:
-    <<: *circle_ci_android_container_config
+    executor: android
     steps:
       - *attach_workspace
       - restore_cache: *restore-gradle-cache


### PR DESCRIPTION
## Problem

We were still using CircleCI config v 2.0

## Solution

Enable https://circleci.com/docs/2.0/build-processing/ (no drawbacks affecting us)
Update config file with the new settings

The benefit of this is that

1. Simple to read (executor tells you which executor you're using, steps are now named)
2. We can have a step that will in the future represent multiple steps (for example, I did it in this PR for the restore/save of gradle caches)

I changed the restore/save of gradle caches. The reason for that is that we don't want to invalidate the wrapper cache if our dependencies change, and vice versa. Also, the wrapper checksum wasn't part of the cache key, meaning updating our gradle wrapper wouldn't have created a new cache (caches are read-only, if a cache with the same name already exists, it won't be overwritten by the new value)
