### PR TITLE
Update Kotlin to 1.3.40, fix build

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -21,8 +21,8 @@ android {
     compileSdkVersion Integer.parseInt(project.COMPILE_SDK_VERSION)
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_7
-        targetCompatibility JavaVersion.VERSION_1_7
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
     }
 
     defaultConfig {

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -2,7 +2,7 @@ ext {
     daggerVersion = '2.23.1'
     glideVersion = '4.9.0'
     workManagerVersion = '1.0.1'
-    kotlinVersion = '1.3.31'
+    kotlinVersion = '1.3.40'
     moshiVersion = '1.8.0'
 
     detektVersion = '1.0.0-RC15'


### PR DESCRIPTION
## Problem

Kotlin 1.3.40 is out and it's awesome! Also the app doesn't compile because `androidx:core:1.2.0-alpha02` has somehow introduced some Java 8 classes that need desugaring.

## Solution

Enable desugaring (it's cheap and incremental in AS 3.5/AGP 3.4.1), upgrade Kotlin, done!

### Test(s) added

Builds and runs.