### PR TITLE
Update workmanager to androidx

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,7 +1,7 @@
 ext {
     daggerVersion = '2.23.1'
     glideVersion = '4.9.0'
-    workManagerVersion = '1.0.1'
+    workManagerVersion = '2.1.0-beta02'
     kotlinVersion = '1.3.40'
     moshiVersion = '1.8.0'
 
@@ -22,8 +22,8 @@ ext {
             androidxConstraintLayout: 'androidx.constraintlayout:constraintlayout:2.0.0-beta2',
             androidxKtx             : 'androidx.core:core-ktx:1.2.0-alpha02',
             androidxMaterial        : 'com.google.android.material:material:1.1.0-alpha07',
-            androidxWorkManager     : "android.arch.work:work-runtime-ktx:$workManagerVersion",
-            androidxWorkManagerRx   : "android.arch.work:work-rxjava2:$workManagerVersion",
+            androidxWorkManager     : "androidx.work:work-runtime-ktx:$workManagerVersion",
+            androidxWorkManagerRx   : "androidx.work:work-rxjava2:$workManagerVersion",
             arrowCore               : 'io.arrow-kt:arrow-core:0.8.2',
             crashlytics             : 'com.crashlytics.sdk.android:crashlytics:2.10.1',
             dagger                  : "com.google.dagger:dagger:${daggerVersion}",


### PR DESCRIPTION
## Problem

Workmanager was still relying on the support library instead of androidx

## Solution

Update to the androidx dependency