### PR TITLE
Fix crash when opening AboutActivity

### DIFF
--- a/app/src/main/java/net/squanchy/about/AboutComponent.kt
+++ b/app/src/main/java/net/squanchy/about/AboutComponent.kt
@@ -5,11 +5,13 @@ import dagger.Component
 import net.squanchy.injection.BaseActivityComponentBuilder
 import net.squanchy.injection.ActivityLifecycle
 import net.squanchy.injection.ApplicationComponent
+import net.squanchy.injection.applicationComponent
 import net.squanchy.navigation.NavigationModule
 import net.squanchy.navigation.Navigator
 
 fun aboutComponent(activity: AppCompatActivity): AboutComponent =
     DaggerAboutComponent.builder()
+        .applicationComponent(activity.applicationComponent)
         .activity(activity)
         .build()
 


### PR DESCRIPTION
## Problem

The app crashes whenever the `AboutActivity` initializes. More info in #631.

## Solution

The solution was to add the missing `applicationComponent` when building the`DaggerAboutComponent`.

### Test(s) added

No tests were added/modified.

### Screenshots

No UI modification.

### Paired with

Nobody.
